### PR TITLE
fix(#17): mobile-first responsive layout for 390px viewports

### DIFF
--- a/app/match/[ct]/[id]/page.tsx
+++ b/app/match/[ct]/[id]/page.tsx
@@ -111,7 +111,7 @@ export default function MatchPage() {
   const match = matchQuery.data;
 
   return (
-    <div className="min-h-screen p-6 max-w-6xl mx-auto space-y-6">
+    <div className="min-h-screen p-4 sm:p-6 max-w-6xl mx-auto space-y-6">
       {/* Back link */}
       <Link
         href="/"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { Target } from "lucide-react";
 
 export default function HomePage() {
   return (
-    <main className="min-h-screen flex flex-col items-center p-6 pt-16 gap-8">
+    <main className="min-h-screen flex flex-col items-center p-4 pt-8 sm:p-6 sm:pt-16 gap-8">
       <div className="flex flex-col items-center gap-4 text-center">
         <div className="flex items-center gap-3">
           <Target className="w-8 h-8 text-primary" />

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -161,7 +161,7 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
               {competitors.map((comp) => (
                 <th
                   key={comp.id}
-                  className="py-2 px-3 text-center font-medium min-w-32"
+                  className="py-2 px-3 text-center font-medium min-w-[5.5rem] sm:min-w-32"
                   style={{ borderBottom: `3px solid ${colorMap[comp.id]}` }}
                 >
                   <div className="flex flex-col items-center gap-0.5">
@@ -193,7 +193,7 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
                 {competitors.map((comp) => {
                   const sc = stage.competitors[comp.id];
                   return (
-                    <td key={comp.id} className="py-2 px-3 text-center align-top">
+                    <td key={comp.id} className="py-2 px-2 sm:px-3 text-center align-top">
                       <StageCell
                         sc={sc}
                         maxPoints={stage.max_points}
@@ -214,7 +214,7 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
                 <div>Avg {MODE_LABELS[mode]} %</div>
               </td>
               {totals.map((t) => (
-                <td key={t.id} className="py-2 px-3 text-center">
+                <td key={t.id} className="py-2 px-2 sm:px-3 text-center">
                   <div className="flex flex-col items-center gap-0.5">
                     <span>
                       {t.points != null ? (

--- a/components/competitor-picker.tsx
+++ b/components/competitor-picker.tsx
@@ -68,7 +68,7 @@ export function CompetitorPicker({
               )}
             </Button>
           </PopoverTrigger>
-          <PopoverContent className="p-0 w-72" align="start">
+          <PopoverContent className="p-0 w-[min(18rem,calc(100vw-2rem))]" align="start">
             <Command>
               <CommandInput placeholder="Search by name, number, or club…" />
               <CommandList>

--- a/components/match-header.tsx
+++ b/components/match-header.tsx
@@ -37,7 +37,7 @@ export function MatchHeader({ match }: MatchHeaderProps) {
   return (
     <div className="space-y-3">
       <div className="flex flex-wrap items-start gap-2">
-        <h1 className="text-2xl font-bold flex-1 min-w-0">{match.name}</h1>
+        <h1 className="text-xl sm:text-2xl font-bold flex-1 min-w-0">{match.name}</h1>
         <div className="flex flex-wrap gap-1.5 shrink-0">
           {match.level && (
             <Badge variant="secondary">

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -229,3 +229,36 @@ test.describe("Scoreboard E2E", () => {
     await expect(page.getByRole("table").getByText("#116")).not.toBeVisible();
   });
 });
+
+test.describe("Mobile 390px viewport", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("comparison page has no horizontal overflow with 2 competitors", async ({ page }) => {
+    await page.route("/api/match/22/26547", (route) =>
+      route.fulfill({ json: MOCK_MATCH })
+    );
+    await page.route(/\/api\/compare/, (route) =>
+      route.fulfill({ json: MOCK_COMPARE_2 })
+    );
+
+    await page.goto("/match/22/26547?competitors=100,200");
+    await expect(page.getByText("Test IPSC Match")).toBeVisible();
+    await expect(page.getByText("Stage results")).toBeVisible();
+    await expect(page.getByRole("table")).toBeVisible();
+
+    const hasOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth
+    );
+    expect(hasOverflow).toBe(false);
+  });
+
+  test("home page has no horizontal overflow at 390px", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("textbox", { name: /match url/i })).toBeVisible();
+
+    const hasOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth
+    );
+    expect(hasOverflow).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Reduce page padding on mobile (`p-4 pt-8`) vs desktop (`p-6 pt-16`), gaining 32px of usable horizontal space (358px instead of 342px at 390px)
- Narrow competitor table columns to `min-w-[5.5rem]` on mobile (88px vs 128px desktop) so 2 competitors fit without horizontal page overflow; 3+ scroll within the card's `overflow-x-auto`
- Tighten table cell padding (`px-2` mobile, `px-3` desktop) for a tighter layout on small screens
- Scale match title to `text-xl` on mobile (`text-2xl` on desktop)
- Constrain competitor picker popover width to `min(18rem, 100vw-2rem)` to prevent overflow on very narrow viewports
- Add two Playwright E2E tests at 390×844 viewport verifying zero horizontal page overflow on both the home page and comparison page

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — zero warnings
- [x] `pnpm test` — 69 unit/component tests pass
- [x] `pnpm test:e2e` — all 11 E2E tests pass, including new mobile overflow tests
- [ ] Manual: dev server at 390px — 2-competitor table fits without page scroll; 3-competitor table scrolls within card container

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)