### PR TITLE
feat: competition search dropdown on landing page

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { executeQuery, EVENTS_QUERY } from "@/lib/graphql";
+import type { EventSummary } from "@/lib/types";
+
+interface RawEvent {
+  id: string;
+  get_content_type_key: number;
+  name: string;
+  venue: string | null;
+  starts: string;
+  status: string;
+  region: string;
+  get_full_rule_display: string;
+  get_full_level_display: string;
+}
+
+interface RawEventsData {
+  events: RawEvent[];
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get("q") ?? "";
+
+  // Default date range: 3 months back to 3 months forward
+  const now = new Date();
+  const after = new Date(now);
+  after.setMonth(after.getMonth() - 3);
+  const before = new Date(now);
+  before.setMonth(before.getMonth() + 3);
+
+  const variables: Record<string, string> = {
+    starts_after: after.toISOString().slice(0, 10),
+    starts_before: before.toISOString().slice(0, 10),
+  };
+  if (q) variables.search = q;
+
+  let data: RawEventsData;
+  try {
+    data = await executeQuery<RawEventsData>(EVENTS_QUERY, variables);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Upstream error";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+
+  const events: EventSummary[] = data.events
+    // Only include match nodes (ct=22), not series (ct=43)
+    .filter((e) => e.get_content_type_key === 22)
+    // Sort by start date descending (upcoming/most-recent first)
+    .sort((a, b) => new Date(b.starts).getTime() - new Date(a.starts).getTime())
+    .map((e) => ({
+      id: parseInt(e.id, 10),
+      content_type: e.get_content_type_key,
+      name: e.name,
+      venue: e.venue || null,
+      date: e.starts,
+      status: e.status,
+      region: e.region,
+      discipline: e.get_full_rule_display,
+      level: e.get_full_level_display,
+    }));
+
+  return NextResponse.json(events);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import { UrlInputForm } from "@/components/url-input-form";
 import { RecentCompetitions } from "@/components/recent-competitions";
+import { EventSearch } from "@/components/event-search";
 import { Target } from "lucide-react";
 
 export default function HomePage() {
@@ -16,15 +17,25 @@ export default function HomePage() {
         </p>
       </div>
 
-      <div className="w-full max-w-2xl space-y-2">
-        <p className="text-sm font-medium">Add a match URL</p>
-        <UrlInputForm />
-        <p className="text-xs text-muted-foreground">
-          Example:{" "}
-          <code className="bg-muted px-1 py-0.5 rounded text-xs">
-            https://shootnscoreit.com/event/22/26547/
-          </code>
-        </p>
+      <div className="w-full max-w-2xl space-y-6">
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Browse competitions</p>
+          <EventSearch />
+          <p className="text-xs text-muted-foreground">
+            IPSC handgun &amp; PCC — past 3 months and upcoming
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Or paste a match URL</p>
+          <UrlInputForm />
+          <p className="text-xs text-muted-foreground">
+            Example:{" "}
+            <code className="bg-muted px-1 py-0.5 rounded text-xs">
+              https://shootnscoreit.com/event/22/26547/
+            </code>
+          </p>
+        </div>
       </div>
 
       <RecentCompetitions />

--- a/components/event-search.tsx
+++ b/components/event-search.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { ChevronsUpDown, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { useEventsQuery } from "@/lib/queries";
+import type { EventSummary } from "@/lib/types";
+
+const STATUS_LABEL: Record<string, string> = {
+  on: "Open",
+  cp: "Completed",
+  dr: "Draft",
+  cs: "Cancelled",
+  pr: "Upcoming",
+  ol: "Online",
+};
+
+function formatEventDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export function EventSearch() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(inputValue), 300);
+    return () => clearTimeout(timer);
+  }, [inputValue]);
+
+  const { data: events = [], isLoading } = useEventsQuery(debouncedQuery);
+
+  function handleSelect(event: EventSummary) {
+    setOpen(false);
+    router.push(`/match/${event.content_type}/${event.id}`);
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-label="Browse IPSC competitions"
+          className="w-full justify-between font-normal"
+        >
+          <span className="text-muted-foreground truncate">
+            Browse competitions…
+          </span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="Search by name…"
+            value={inputValue}
+            onValueChange={setInputValue}
+          />
+          <CommandList>
+            {isLoading ? (
+              <div
+                className="flex items-center justify-center py-6"
+                aria-live="polite"
+                aria-label="Loading competitions"
+              >
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              </div>
+            ) : events.length === 0 ? (
+              <CommandEmpty>No competitions found.</CommandEmpty>
+            ) : (
+              <CommandGroup>
+                {events.map((event) => (
+                  <CommandItem
+                    key={event.id}
+                    value={String(event.id)}
+                    onSelect={() => handleSelect(event)}
+                    className="flex flex-col items-start gap-0.5 py-2.5"
+                  >
+                    <span className="font-medium leading-snug">{event.name}</span>
+                    <span className="text-xs text-muted-foreground leading-snug">
+                      {formatEventDate(event.date)}
+                      {" · "}
+                      {event.discipline}
+                      {" · "}
+                      {event.level}
+                      {" · "}
+                      {event.region}
+                      {" · "}
+                      {STATUS_LABEL[event.status] ?? event.status}
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,13 +1,24 @@
 // Client-safe API helpers — these call our own Next.js Route Handlers,
 // NOT the SSI API directly (which has no CORS headers).
 
-import type { MatchResponse, CompareResponse } from "@/lib/types";
+import type { MatchResponse, CompareResponse, EventSummary } from "@/lib/types";
 
 export async function fetchMatch(ct: string, id: string): Promise<MatchResponse> {
   const res = await fetch(`/api/match/${ct}/${id}`);
   if (!res.ok) {
     const body = await res.text();
     throw new Error(`Match fetch failed (${res.status}): ${body}`);
+  }
+  return res.json();
+}
+
+export async function fetchEvents(q: string): Promise<EventSummary[]> {
+  const params = new URLSearchParams();
+  if (q) params.set("q", q);
+  const res = await fetch(`/api/events?${params}`);
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Events fetch failed (${res.status}): ${body}`);
   }
   return res.json();
 }

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -99,6 +99,27 @@ export const MATCH_QUERY = `
   }
 `;
 
+// ─── Query: list IPSC handgun events ─────────────────────────────────────────
+// Returns all publicly-visible IPSC handgun & PCC matches (firearms:"hg")
+// filtered by optional free-text search and date range.
+// Results include both IpscMatchNode (ct=22) and IpscSerieNode (ct=43) —
+// filter to ct=22 in the route handler.
+export const EVENTS_QUERY = `
+  query GetEvents($search: String, $starts_after: String, $starts_before: String) {
+    events(rule: "ip", firearms: "hg", search: $search, starts_after: $starts_after, starts_before: $starts_before) {
+      id
+      get_content_type_key
+      name
+      venue
+      starts
+      status
+      region
+      get_full_rule_display
+      get_full_level_display
+    }
+  }
+`;
+
 // ─── Query: all stage scorecards for a match ─────────────────────────────────
 // Returns raw scorecard data for every competitor on every stage.
 // `get_results` (official placement) is blocked during active matches — this

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1,8 +1,8 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { fetchMatch, fetchCompare } from "@/lib/api";
-import type { MatchResponse, CompareResponse } from "@/lib/types";
+import { fetchMatch, fetchCompare, fetchEvents } from "@/lib/api";
+import type { MatchResponse, CompareResponse, EventSummary } from "@/lib/types";
 
 export function useMatchQuery(ct: string, id: string) {
   return useQuery<MatchResponse, Error>({
@@ -10,6 +10,14 @@ export function useMatchQuery(ct: string, id: string) {
     queryFn: () => fetchMatch(ct, id),
     staleTime: 30_000, // 30 seconds
     enabled: Boolean(ct && id),
+  });
+}
+
+export function useEventsQuery(q: string) {
+  return useQuery<EventSummary[], Error>({
+    queryKey: ["events", q],
+    queryFn: () => fetchEvents(q),
+    staleTime: 60_000, // 1 minute
   });
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -97,3 +97,15 @@ export interface CompareResponse {
   stages: StageComparison[];
   competitors: CompetitorInfo[];
 }
+
+export interface EventSummary {
+  id: number;
+  content_type: number;
+  name: string;
+  venue: string | null;
+  date: string; // ISO timestamp
+  status: string; // "on" | "cp" | "dr" | "cs" | "pr" | "ol"
+  region: string;
+  discipline: string; // e.g. "IPSC Handgun & PCC"
+  level: string; // e.g. "Level II"
+}


### PR DESCRIPTION
## Summary

- Adds a searchable combobox to the home page so users can browse and jump to IPSC competitions without pasting a URL
- New `GET /api/events` route proxies the SSI `events` GraphQL query filtered to `rule:"ip"` + `firearms:"hg"` (handgun & PCC), returning only match nodes (`content_type=22`), sorted by start date descending
- Default date window is ±3 months; free-text `?q=` search is passed through to the upstream API
- `EventSearch` component uses shadcn `Popover` + `Command` with a 300 ms debounce on the input and pre-fetches results on mount so the list is ready when the user opens the dropdown
- Each result shows name, date, discipline, level, region and status

## Test plan

- [ ] Open landing page — combobox should appear above the URL paste form
- [ ] Click combobox — recent IPSC handgun competitions (±3 months) load immediately
- [ ] Type a club/match name — results filter via API after ~300 ms
- [ ] Select a result — navigates to `/match/<ct>/<id>`
- [ ] `pnpm typecheck && pnpm lint && pnpm test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)