### PR TITLE
feat(#9): penalty damage indicator with clean-match badge

### DIFF
--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -18,6 +18,45 @@ interface ComparisonTableProps {
 
 const RANK_COLORS = ["bg-yellow-400", "bg-gray-300", "bg-amber-600"];
 
+function PenaltyBadge({
+  miss,
+  noShoots,
+  procedurals,
+}: {
+  miss: number | null;
+  noShoots: number | null;
+  procedurals: number | null;
+}) {
+  const m = miss ?? 0;
+  const ns = noShoots ?? 0;
+  const p = procedurals ?? 0;
+  const total = (m + ns + p) * 10;
+
+  if (total === 0) return null;
+
+  const parts: string[] = [];
+  if (m > 0) parts.push(`${m} miss (\u2212${m * 10})`);
+  if (ns > 0) parts.push(`${ns} no-shoot (\u2212${ns * 10})`);
+  if (p > 0) parts.push(`${p} procedural (\u2212${p * 10})`);
+  const tooltipText = `${parts.join(" + ")} = \u2212${total} pts`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="text-xs font-medium text-red-600 dark:text-red-400 tabular-nums cursor-help"
+          aria-label={`Penalties: ${tooltipText}`}
+        >
+          {`\u2212${total}pts`}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="text-xs">
+        {tooltipText}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function RankBadge({
   rank,
   tooltip,
@@ -118,21 +157,25 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
   const [mode, setMode] = useState<PctMode>("group");
   const colorMap = buildColorMap(competitors.map((c) => c.id));
 
-  // Compute totals per competitor: total raw points, average %, and zone/penalty sums
+  // Compute totals per competitor: total raw points, average %, zone/penalty sums, and clean match status
   const totals = competitors.map((comp) => {
     let totalPts = 0;
     let pctSum = 0;
     let pctCount = 0;
     let hasFired = false;
+    let firedCount = 0;
     let aTotal = 0, cTotal = 0, dTotal = 0, mTotal = 0;
     let nsTotal = 0, pTotal = 0;
     let hasZoneData = false;
     let hasPenaltyData = false;
+    let totalPenaltyPts = 0;
+    let firedWithAllPenaltyData = 0;
 
     for (const stage of stages) {
       const sc = stage.competitors[comp.id];
       if (!sc || sc.dnf) continue;
       hasFired = true;
+      firedCount++;
       totalPts += sc.points ?? 0;
       const { pct } = modeValues(sc, mode);
       if (pct != null) {
@@ -151,6 +194,10 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
         nsTotal += sc.no_shoots ?? 0;
         pTotal += sc.procedurals ?? 0;
       }
+      if (sc.miss_count !== null && sc.no_shoots !== null && sc.procedurals !== null) {
+        firedWithAllPenaltyData++;
+        totalPenaltyPts += (sc.miss_count + sc.no_shoots + sc.procedurals) * 10;
+      }
     }
 
     return {
@@ -163,6 +210,8 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
       misses: hasZoneData ? mTotal : null,
       noShoots: hasPenaltyData ? nsTotal : null,
       procedurals: hasPenaltyData ? pTotal : null,
+      totalPenaltyPts,
+      isClean: hasFired && firedCount === firedWithAllPenaltyData && totalPenaltyPts === 0,
     };
   });
 
@@ -257,6 +306,26 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
                       noShoots={t.noShoots}
                       procedurals={t.procedurals}
                     />
+                    {t.totalPenaltyPts > 0 && (
+                      <span className="text-xs font-medium text-red-600 dark:text-red-400 tabular-nums">
+                        {`\u2212${t.totalPenaltyPts}pts`}
+                      </span>
+                    )}
+                    {t.isClean && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span
+                            className="text-xs text-green-600 dark:text-green-400 font-medium cursor-help"
+                            aria-label="Clean match: no penalties across all fired stages"
+                          >
+                            ✓ Clean
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="top" className="text-xs">
+                          No penalties across all fired stages
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
                   </div>
                 </td>
               ))}
@@ -364,6 +433,12 @@ function StageCell({
         cHits={sc.c_hits}
         dHits={sc.d_hits}
         misses={sc.miss_count}
+        noShoots={sc.no_shoots}
+        procedurals={sc.procedurals}
+      />
+      {/* Penalty badge */}
+      <PenaltyBadge
+        miss={sc.miss_count}
         noShoots={sc.no_shoots}
         procedurals={sc.procedurals}
       />

--- a/tests/components/comparison-table.test.tsx
+++ b/tests/components/comparison-table.test.tsx
@@ -142,3 +142,76 @@ describe("ComparisonTable", () => {
     expect(screen.getByText("Overall")).toBeInTheDocument();
   });
 });
+
+describe("ComparisonTable — penalty badge", () => {
+  function makeDataWithPenalties(
+    penaltiesComp1: { miss_count: number; no_shoots: number; procedurals: number },
+    penaltiesComp2: { miss_count: number; no_shoots: number; procedurals: number }
+  ): CompareResponse {
+    return {
+      ...baseData,
+      stages: [
+        {
+          ...baseData.stages[0],
+          competitors: {
+            1: { ...baseData.stages[0].competitors[1], ...penaltiesComp1 },
+            2: { ...baseData.stages[0].competitors[2], ...penaltiesComp2 },
+          },
+        },
+      ],
+    };
+  }
+
+  it("hides penalty badge when all penalties are explicitly zero", () => {
+    const data = makeDataWithPenalties(
+      { miss_count: 0, no_shoots: 0, procedurals: 0 },
+      { miss_count: 0, no_shoots: 0, procedurals: 0 }
+    );
+    renderWithProviders(<ComparisonTable data={data} />);
+    expect(screen.queryByText(/\u2212\d+pts/)).not.toBeInTheDocument();
+  });
+
+  it("shows penalty badge with correct total when miss penalties exist", () => {
+    // 2 misses + 1 no-shoot = 30 pts penalty
+    const data = makeDataWithPenalties(
+      { miss_count: 2, no_shoots: 1, procedurals: 0 },
+      { miss_count: 0, no_shoots: 0, procedurals: 0 }
+    );
+    renderWithProviders(<ComparisonTable data={data} />);
+    expect(screen.getAllByText("\u221230pts").length).toBeGreaterThan(0);
+  });
+
+  it("shows penalty badge for procedurals only", () => {
+    const data = makeDataWithPenalties(
+      { miss_count: 0, no_shoots: 0, procedurals: 2 },
+      { miss_count: 0, no_shoots: 0, procedurals: 0 }
+    );
+    renderWithProviders(<ComparisonTable data={data} />);
+    expect(screen.getAllByText("\u221220pts").length).toBeGreaterThan(0);
+  });
+
+  it("shows clean match indicator in totals row when all stages have zero penalties", () => {
+    const data = makeDataWithPenalties(
+      { miss_count: 0, no_shoots: 0, procedurals: 0 },
+      { miss_count: 0, no_shoots: 0, procedurals: 0 }
+    );
+    renderWithProviders(<ComparisonTable data={data} />);
+    expect(screen.getAllByText("✓ Clean").length).toBeGreaterThan(0);
+  });
+
+  it("hides clean match indicator when penalties exist", () => {
+    const data = makeDataWithPenalties(
+      { miss_count: 1, no_shoots: 0, procedurals: 0 },
+      { miss_count: 0, no_shoots: 0, procedurals: 0 }
+    );
+    renderWithProviders(<ComparisonTable data={data} />);
+    // Only competitor 2 (all zeros) should be clean
+    expect(screen.getAllByText("✓ Clean").length).toBe(1);
+  });
+
+  it("does not show clean match indicator when penalty data is null (unknown)", () => {
+    // baseData has all nulls — no penalty data available, so we can't confirm clean
+    renderWithProviders(<ComparisonTable data={baseData} />);
+    expect(screen.queryByText("✓ Clean")).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/compare-logic.test.ts
+++ b/tests/unit/compare-logic.test.ts
@@ -188,6 +188,41 @@ describe("computeGroupRankings — division rankings", () => {
   });
 });
 
+describe("computeGroupRankings — penalty fields", () => {
+  it("passes miss_count, no_shoots, and procedurals through to CompetitorSummary", () => {
+    const scorecards = [
+      makeCard(1, 1, { miss_count: 2, no_shoots: 1, procedurals: 1 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const sc = result[0].competitors[1];
+    expect(sc.miss_count).toBe(2);
+    expect(sc.no_shoots).toBe(1);
+    expect(sc.procedurals).toBe(1);
+  });
+
+  it("preserves zero penalty fields for a clean stage", () => {
+    const scorecards = [
+      makeCard(1, 1, { miss_count: 0, no_shoots: 0, procedurals: 0 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const sc = result[0].competitors[1];
+    expect(sc.miss_count).toBe(0);
+    expect(sc.no_shoots).toBe(0);
+    expect(sc.procedurals).toBe(0);
+  });
+
+  it("sets all penalty fields to null for a DNF stage", () => {
+    const scorecards = [
+      makeCard(1, 1, { dnf: true, miss_count: 2, no_shoots: 0, procedurals: 1 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const sc = result[0].competitors[1];
+    expect(sc.miss_count).toBeNull();
+    expect(sc.no_shoots).toBeNull();
+    expect(sc.procedurals).toBeNull();
+  });
+});
+
 describe("computeGroupRankings — overall rankings", () => {
   it("ranks competitors across all divisions by HF", () => {
     const scorecards = [


### PR DESCRIPTION
Closes #9

## Summary

- Red `−Xpts` badge on each stage cell where total penalty > 0 (miss + no-shoot + procedural, each worth 10 pts)
- Tooltip breakdown: `2 miss (−20) + 1 no-shoot (−10) = −30 pts` — keyboard/screen-reader accessible via `aria-label`
- Badge hidden when penalty = 0 (both explicit zeros and null/no-data)
- Totals row: accumulated penalty points per competitor, plus a `✓ Clean` indicator when all fired stages have confirmed zero penalties
- Clean match indicator is intentionally withheld when any penalty field is null (unknown data)

## No data-layer changes

`miss`, `no_shoots`, and `procedurals` were already fetched by `SCORECARDS_QUERY` (added for issue #6) and flowed through `computeGroupRankings` → `CompetitorSummary`. Only UI and tests were needed.

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — zero warnings
- [x] `pnpm test` — 93 tests pass (3 new unit tests for penalty field pass-through, 6 new component tests for badge/clean-match logic)
- [ ] Manual: verify badge appears on a live match with known penalties
- [ ] Manual: verify `✓ Clean` appears for a competitor with zero penalties across all stages
- [ ] Manual: verify no horizontal overflow at 390px with penalty badges visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)