### PR TITLE
feat(#24): share button with native share sheet and clipboard fallback

### DIFF
--- a/app/match/[ct]/[id]/page.tsx
+++ b/app/match/[ct]/[id]/page.tsx
@@ -8,6 +8,7 @@ const EMPTY_IDS: number[] = [];
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { MatchHeader } from "@/components/match-header";
+import { ShareButton } from "@/components/share-button";
 import { CompetitorPicker } from "@/components/competitor-picker";
 import { ComparisonTable } from "@/components/comparison-table";
 import { ComparisonChart } from "@/components/comparison-chart";
@@ -117,14 +118,17 @@ export default function MatchPage() {
 
   return (
     <div className="min-h-screen p-4 sm:p-6 max-w-6xl mx-auto space-y-6">
-      {/* Back link */}
-      <Link
-        href="/"
-        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-      >
-        <ArrowLeft className="w-3.5 h-3.5" />
-        All matches
-      </Link>
+      {/* Back link + share */}
+      <div className="flex items-center justify-between">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="w-3.5 h-3.5" />
+          All matches
+        </Link>
+        <ShareButton title={match.name} />
+      </div>
 
       {/* Match header */}
       <MatchHeader match={match} />

--- a/components/share-button.tsx
+++ b/components/share-button.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { Share2, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface ShareButtonProps {
+  title?: string;
+}
+
+export function ShareButton({ title }: ShareButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function copyToClipboard(url: string) {
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  async function handleShare() {
+    const url = window.location.href;
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ url, title });
+      } catch (err) {
+        if ((err as { name?: unknown }).name === "AbortError") return;
+        await copyToClipboard(url);
+      }
+    } else {
+      await copyToClipboard(url);
+    }
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={handleShare}
+      aria-label={copied ? "Link copied" : "Share comparison link"}
+    >
+      {copied ? (
+        <Check className="w-4 h-4" />
+      ) : (
+        <Share2 className="w-4 h-4" />
+      )}
+      {copied ? "Copied" : "Share"}
+    </Button>
+  );
+}

--- a/tests/components/share-button.test.tsx
+++ b/tests/components/share-button.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { ShareButton } from "@/components/share-button";
+
+// Only fake setTimeout so waitFor (which uses setInterval internally) still works.
+const fakeTimers = () => vi.useFakeTimers({ toFake: ["setTimeout"] });
+
+describe("ShareButton", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "location", {
+      value: { href: "https://example.com/match/22/42?competitors=1,2" },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("renders with Share label and correct aria-label", () => {
+    Object.defineProperty(navigator, "share", {
+      value: undefined,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+
+    render(<ShareButton title="Test Match" />);
+
+    const btn = screen.getByRole("button", { name: "Share comparison link" });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveTextContent("Share");
+  });
+
+  it("uses clipboard when navigator.share is unavailable and shows Copied", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "share", {
+      value: undefined,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    fakeTimers();
+
+    render(<ShareButton title="Test Match" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Share comparison link" }));
+    });
+
+    expect(writeText).toHaveBeenCalledWith(
+      "https://example.com/match/22/42?competitors=1,2"
+    );
+
+    expect(screen.getByRole("button", { name: "Link copied" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Link copied" })).toHaveTextContent("Copied");
+  });
+
+  it("resets to Share after 2 seconds", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "share", {
+      value: undefined,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    fakeTimers();
+
+    render(<ShareButton />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Share comparison link" }));
+    });
+
+    expect(screen.getByRole("button", { name: "Link copied" })).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Share comparison link" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Share comparison link" })
+    ).toHaveTextContent("Share");
+  });
+
+  it("uses navigator.share when available", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "share", {
+      value: share,
+      configurable: true,
+    });
+    fakeTimers();
+
+    render(<ShareButton title="Test Match" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Share comparison link" }));
+    });
+
+    expect(share).toHaveBeenCalledWith({
+      url: "https://example.com/match/22/42?competitors=1,2",
+      title: "Test Match",
+    });
+  });
+
+  it("silently ignores AbortError from native share sheet", async () => {
+    const abortError = new DOMException("Share cancelled", "AbortError");
+    const share = vi.fn().mockRejectedValue(abortError);
+    Object.defineProperty(navigator, "share", {
+      value: share,
+      configurable: true,
+    });
+    fakeTimers();
+
+    render(<ShareButton title="Test Match" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Share comparison link" }));
+    });
+
+    expect(share).toHaveBeenCalled();
+
+    // Button should NOT switch to "Copied" — abort was silently ignored
+    expect(
+      screen.queryByRole("button", { name: "Link copied" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to clipboard when navigator.share throws a non-AbortError", async () => {
+    const networkError = new Error("Network error");
+    const share = vi.fn().mockRejectedValue(networkError);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "share", {
+      value: share,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    fakeTimers();
+
+    render(<ShareButton title="Test Match" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Share comparison link" }));
+    });
+
+    expect(writeText).toHaveBeenCalledWith(
+      "https://example.com/match/22/42?competitors=1,2"
+    );
+    expect(screen.getByRole("button", { name: "Link copied" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `ShareButton` component to the match page toolbar (`← All matches` on the left, `Share` on the right)
- Uses `navigator.share()` on mobile to open the OS share sheet; falls back to `navigator.clipboard.writeText()` on desktop or when the Web Share API is unavailable
- Button label/icon transitions Share→Copied for 2 s then resets; `aria-label` also updates for screen reader announcements
- AbortError from user-cancelled native share is silently ignored

## Test plan
- [ ] All unit + component tests pass (`pnpm test` — 125 tests, 0 failures)
- [ ] No lint warnings (`pnpm lint`)
- [ ] No TypeScript errors (`pnpm typecheck`)
- [ ] All e2e tests pass (`pnpm test:e2e`)
- [ ] Manual: on mobile, tap Share → OS share sheet opens
- [ ] Manual: on desktop, click Share → URL copied, button shows "Copied" for 2 s then resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)