### PR TITLE
feat: interactive chart legends, stage numbers on dots, fix tooltip rendering

### DIFF
--- a/components/comparison-chart.tsx
+++ b/components/comparison-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   BarChart,
   Bar,
@@ -7,7 +8,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
   // ReferenceLine, // future: benchmark overlay — overall_leader_hf (see GitHub issue #1)
 } from "recharts";
@@ -22,6 +22,7 @@ interface ComparisonChartProps {
 export function ComparisonChart({ data }: ComparisonChartProps) {
   const { stages, competitors } = data;
   const colorMap = buildColorMap(competitors.map((c) => c.id));
+  const [hiddenIds, setHiddenIds] = useState<Set<number>>(new Set());
 
   const chartData = stages.map((stage) => {
     const row: Record<string, string | number> = {
@@ -46,70 +47,113 @@ export function ComparisonChart({ data }: ComparisonChartProps) {
     return comp ? `#${comp.competitor_number} ${comp.name.split(" ")[0]}` : String(id);
   };
 
+  const toggleSeries = (id: number) => {
+    setHiddenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
   return (
-    <ResponsiveContainer width="100%" height={320}>
-      <BarChart
-        data={chartData}
-        margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+    <div>
+      <ResponsiveContainer width="100%" height={320}>
+        <BarChart
+          data={chartData}
+          margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+          <XAxis
+            dataKey="name"
+            tick={{ fontSize: 12 }}
+            className="fill-muted-foreground"
+          />
+          <YAxis
+            tick={{ fontSize: 12 }}
+            className="fill-muted-foreground"
+            allowDecimals
+            tickFormatter={(v: number) => v.toFixed(1)}
+            label={{
+              value: "Hit Factor",
+              angle: -90,
+              position: "insideLeft",
+              offset: 10,
+              style: { fontSize: 11, fill: "var(--muted-foreground)" },
+            }}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: "var(--popover)",
+              color: "var(--popover-foreground)",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              fontSize: 12,
+              boxShadow: "0 4px 16px rgba(0,0,0,0.14), 0 1px 4px rgba(0,0,0,0.08)",
+            }}
+            labelStyle={{ color: "var(--popover-foreground)", fontWeight: 600 }}
+            itemStyle={{ color: "var(--popover-foreground)" }}
+            cursor={{ fill: "var(--muted-foreground)", opacity: 0.08 }}
+            formatter={(value: number | undefined, name: string | undefined) => {
+              const id = parseInt((name ?? "").split("_").pop() ?? "0", 10);
+              return [
+                typeof value === "number" ? value.toFixed(4) : "—",
+                formatLabel(id),
+              ];
+            }}
+          />
+          {/* future benchmark overlay hook — do not remove:
+          {showBenchmark && stages[0] && (
+            <ReferenceLine y={stages[0].overall_leader_hf ?? 0} stroke="gray" strokeDasharray="4 2" label="Field leader" />
+          )}
+          */}
+          {competitors.map((comp) => {
+            if (hiddenIds.has(comp.id)) return null;
+            const key = `${comp.competitor_number}_${comp.id}`;
+            return (
+              <Bar
+                key={comp.id}
+                dataKey={key}
+                fill={colorMap[comp.id]}
+                name={key}
+                radius={[3, 3, 0, 0]}
+              />
+            );
+          })}
+        </BarChart>
+      </ResponsiveContainer>
+      <div
+        role="group"
+        aria-label="Toggle competitors"
+        className="flex flex-wrap justify-center gap-2 pt-2"
       >
-        <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-        <XAxis
-          dataKey="name"
-          tick={{ fontSize: 12 }}
-          className="fill-muted-foreground"
-        />
-        <YAxis
-          tick={{ fontSize: 12 }}
-          className="fill-muted-foreground"
-          allowDecimals
-          tickFormatter={(v: number) => v.toFixed(1)}
-          label={{
-            value: "Hit Factor",
-            angle: -90,
-            position: "insideLeft",
-            offset: 10,
-            style: { fontSize: 11, fill: "hsl(var(--muted-foreground))" },
-          }}
-        />
-        <Tooltip
-          contentStyle={{
-            backgroundColor: "hsl(var(--popover))",
-            border: "1px solid hsl(var(--border))",
-            borderRadius: 6,
-            fontSize: 12,
-          }}
-          formatter={(value: number | undefined, name: string | undefined) => {
-            const id = parseInt((name ?? "").split("_").pop() ?? "0", 10);
-            return [
-              typeof value === "number" ? value.toFixed(4) : "—",
-              formatLabel(id),
-            ];
-          }}
-        />
-        <Legend
-          formatter={(value: string) => {
-            const id = parseInt(value.split("_").pop() ?? "0", 10);
-            return formatLabel(id);
-          }}
-        />
-        {/* future benchmark overlay hook — do not remove:
-        {showBenchmark && stages[0] && (
-          <ReferenceLine y={stages[0].overall_leader_hf ?? 0} stroke="gray" strokeDasharray="4 2" label="Field leader" />
-        )}
-        */}
         {competitors.map((comp) => {
-          const key = `${comp.competitor_number}_${comp.id}`;
+          const hidden = hiddenIds.has(comp.id);
+          const label = formatLabel(comp.id);
+          const color = colorMap[comp.id];
           return (
-            <Bar
+            <button
               key={comp.id}
-              dataKey={key}
-              fill={colorMap[comp.id]}
-              name={key}
-              radius={[3, 3, 0, 0]}
-            />
+              type="button"
+              onClick={() => toggleSeries(comp.id)}
+              aria-pressed={!hidden}
+              className="flex items-center gap-2 rounded-full border px-3 text-sm transition-opacity"
+              style={{
+                borderColor: hidden ? "transparent" : color + "55",
+                backgroundColor: hidden ? undefined : color + "18",
+                opacity: hidden ? 0.4 : undefined,
+              }}
+            >
+              <span
+                className="inline-block h-3 w-3 flex-none rounded-full"
+                style={{ backgroundColor: color }}
+                aria-hidden="true"
+              />
+              <span className={hidden ? "line-through" : ""}>{label}</span>
+            </button>
           );
         })}
-      </BarChart>
-    </ResponsiveContainer>
+      </div>
+    </div>
   );
 }

--- a/components/scatter-chart.tsx
+++ b/components/scatter-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   ScatterChart,
   Scatter,
@@ -7,7 +8,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
   usePlotArea,
   useXAxisDomain,
@@ -16,7 +16,7 @@ import {
 import { buildColorMap } from "@/lib/colors";
 import { computeIsoHfLines, buildScatterData } from "@/lib/scatter-utils";
 import type { ScatterPoint } from "@/lib/scatter-utils";
-import type { CompareResponse } from "@/lib/types";
+import type { CompareResponse, CompetitorInfo } from "@/lib/types";
 
 // --------------------------------------------------------------------------
 // Custom tooltip
@@ -39,17 +39,19 @@ function CustomTooltip({
   return (
     <div
       style={{
-        backgroundColor: "hsl(var(--popover))",
-        border: "1px solid hsl(var(--border))",
+        backgroundColor: "var(--popover)",
+        color: "var(--popover-foreground)",
+        border: "1px solid var(--border)",
         borderRadius: 6,
         padding: "8px 10px",
         fontSize: 12,
         lineHeight: 1.6,
+        boxShadow: "0 4px 16px rgba(0,0,0,0.14), 0 1px 4px rgba(0,0,0,0.08)",
       }}
     >
       <p style={{ fontWeight: 600, marginBottom: 2 }}>{pt.competitorName}</p>
-      <p style={{ color: "hsl(var(--muted-foreground))", marginBottom: 6 }}>
-        Stage {pt.stageNum}: {pt.stageName}
+      <p style={{ color: "var(--muted-foreground)", marginBottom: 6 }}>
+        {pt.stageName}
       </p>
       <div
         style={{
@@ -58,14 +60,55 @@ function CustomTooltip({
           columnGap: 12,
         }}
       >
-        <span style={{ color: "hsl(var(--muted-foreground))" }}>Time</span>
+        <span style={{ color: "var(--muted-foreground)" }}>Time</span>
         <span>{pt.time.toFixed(2)} s</span>
-        <span style={{ color: "hsl(var(--muted-foreground))" }}>Points</span>
+        <span style={{ color: "var(--muted-foreground)" }}>Points</span>
         <span>{pt.points}</span>
-        <span style={{ color: "hsl(var(--muted-foreground))" }}>HF</span>
+        <span style={{ color: "var(--muted-foreground)" }}>HF</span>
         <span>{pt.hitFactor.toFixed(4)}</span>
       </div>
     </div>
+  );
+}
+
+// --------------------------------------------------------------------------
+// Custom dot: competitor color fill + stage number label inside
+// --------------------------------------------------------------------------
+
+interface DotProps {
+  cx?: number;
+  cy?: number;
+  fill?: string;
+  payload?: ScatterPoint;
+}
+
+function StageNumberDot({ cx, cy, fill, payload }: DotProps) {
+  if (cx === undefined || cy === undefined || !payload) return null;
+  return (
+    <g>
+      {/* Enlarged transparent touch/click hit area */}
+      <circle cx={cx} cy={cy} r={18} fill="transparent" />
+      <circle
+        cx={cx}
+        cy={cy}
+        r={9}
+        fill={fill}
+        stroke="white"
+        strokeWidth={1.5}
+        opacity={0.9}
+      />
+      <text
+        x={cx}
+        y={cy + 3.5}
+        textAnchor="middle"
+        fontSize={8}
+        fill="white"
+        fontWeight="bold"
+        className="pointer-events-none select-none"
+      >
+        {payload.stageNum}
+      </text>
+    </g>
   );
 }
 
@@ -112,8 +155,8 @@ function IsoHfLinesOverlay({
         const px2 = toPixelX(x2);
         const py2 = toPixelY(y2);
         // Label sits just beyond the line end; nudge inside bounds if near edge
-        const labelX = px2 <= plotArea.x + plotArea.width - 20 ? px2 + 4 : px2 - 24;
-        const labelY = py2 >= plotArea.y + 12 ? py2 - 4 : py2 + 12;
+        const labelX = px2 <= plotArea.x + plotArea.width - 20 ? px2 + 4 : px2 - 28;
+        const labelY = py2 >= plotArea.y + 14 ? py2 - 4 : py2 + 14;
 
         return (
           <g key={hf}>
@@ -123,19 +166,20 @@ function IsoHfLinesOverlay({
               x2={px2}
               y2={py2}
               style={{
-                stroke: "hsl(var(--muted-foreground))",
-                strokeDasharray: "4 3",
-                strokeWidth: 1,
-                opacity: 0.4,
+                stroke: "var(--muted-foreground)",
+                strokeDasharray: "5 3",
+                strokeWidth: 1.5,
+                opacity: 0.55,
               }}
             />
             <text
               x={labelX}
               y={labelY}
               style={{
-                fontSize: 9,
-                fill: "hsl(var(--muted-foreground))",
-                opacity: 0.65,
+                fontSize: 10,
+                fill: "var(--muted-foreground)",
+                opacity: 0.8,
+                fontWeight: 500,
               }}
             >
               HF {hf}
@@ -144,6 +188,59 @@ function IsoHfLinesOverlay({
         );
       })}
     </g>
+  );
+}
+
+// --------------------------------------------------------------------------
+// Interactive accessible legend
+// --------------------------------------------------------------------------
+
+interface LegendItem {
+  id: number;
+  label: string;
+  color: string;
+}
+
+function ToggleLegend({
+  items,
+  hiddenIds,
+  onToggle,
+}: {
+  items: LegendItem[];
+  hiddenIds: Set<number>;
+  onToggle: (id: number) => void;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="Toggle competitors"
+      className="flex flex-wrap justify-center gap-2 pt-2"
+    >
+      {items.map(({ id, label, color }) => {
+        const hidden = hiddenIds.has(id);
+        return (
+          <button
+            key={id}
+            type="button"
+            onClick={() => onToggle(id)}
+            aria-pressed={!hidden}
+            className="flex items-center gap-2 rounded-full border px-3 text-sm transition-opacity"
+            style={{
+              borderColor: hidden ? "transparent" : color + "55",
+              backgroundColor: hidden ? undefined : color + "18",
+              opacity: hidden ? 0.4 : undefined,
+            }}
+          >
+            <span
+              className="inline-block h-3 w-3 flex-none rounded-full"
+              style={{ backgroundColor: color }}
+              aria-hidden="true"
+            />
+            <span className={hidden ? "line-through" : ""}>{label}</span>
+          </button>
+        );
+      })}
+    </div>
   );
 }
 
@@ -159,6 +256,7 @@ export function SpeedAccuracyChart({ data }: SpeedAccuracyChartProps) {
   const { stages, competitors } = data;
   const colorMap = buildColorMap(competitors.map((c) => c.id));
   const dataByCompetitor = buildScatterData(stages, competitors);
+  const [hiddenIds, setHiddenIds] = useState<Set<number>>(new Set());
 
   const hasData = competitors.some(
     (c) => (dataByCompetitor[c.id]?.length ?? 0) > 0,
@@ -172,62 +270,89 @@ export function SpeedAccuracyChart({ data }: SpeedAccuracyChartProps) {
     );
   }
 
-  const formatLabel = (id: number) => {
-    const comp = competitors.find((c) => c.id === id);
-    return comp
-      ? `#${comp.competitor_number} ${comp.name.split(" ")[0]}`
-      : String(id);
+  const formatLabel = (comp: CompetitorInfo) =>
+    `#${comp.competitor_number} ${comp.name.split(" ")[0]}`;
+
+  const toggleSeries = (id: number) => {
+    setHiddenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
   };
 
+  const legendItems: LegendItem[] = competitors.map((comp) => ({
+    id: comp.id,
+    label: formatLabel(comp),
+    color: colorMap[comp.id],
+  }));
+
   return (
-    <ResponsiveContainer width="100%" height={360}>
-      <ScatterChart margin={{ top: 16, right: 28, left: 0, bottom: 20 }}>
-        <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-        <XAxis
-          type="number"
-          dataKey="time"
-          name="Time"
-          domain={[0, "auto"]}
-          tick={{ fontSize: 12 }}
-          className="fill-muted-foreground"
-          label={{
-            value: "Time (s)",
-            position: "insideBottom",
-            offset: -10,
-            style: { fontSize: 11, fill: "hsl(var(--muted-foreground))" },
-          }}
-        />
-        <YAxis
-          type="number"
-          dataKey="points"
-          name="Points"
-          domain={[0, "auto"]}
-          tick={{ fontSize: 12 }}
-          className="fill-muted-foreground"
-          label={{
-            value: "Points",
-            angle: -90,
-            position: "insideLeft",
-            offset: 10,
-            style: { fontSize: 11, fill: "hsl(var(--muted-foreground))" },
-          }}
-        />
-        <Tooltip
-          content={<CustomTooltip />}
-          cursor={{ strokeDasharray: "3 3" }}
-        />
-        <Legend />
-        {/* Iso-HF reference lines — rendered inside chart SVG via Recharts 3 direct children */}
-        <IsoHfLinesOverlay />
-        {competitors.map((comp) => (
-          <Scatter
-            key={comp.id}
-            name={formatLabel(comp.id)}
-            data={dataByCompetitor[comp.id]}
-            fill={colorMap[comp.id]}
+    <div>
+      <ResponsiveContainer width="100%" height={360}>
+        <ScatterChart margin={{ top: 16, right: 28, left: 0, bottom: 20 }}>
+          <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+          <XAxis
+            type="number"
+            dataKey="time"
+            name="Time"
+            domain={[0, "auto"]}
+            tick={{ fontSize: 12 }}
+            className="fill-muted-foreground"
+            label={{
+              value: "Time (s)",
+              position: "insideBottom",
+              offset: -10,
+              style: { fontSize: 11, fill: "var(--muted-foreground)" },
+            }}
           />
-        ))}
-      </ScatterChart>
-    </ResponsiveContainer>
+          <YAxis
+            type="number"
+            dataKey="points"
+            name="Points"
+            domain={[0, "auto"]}
+            tick={{ fontSize: 12 }}
+            className="fill-muted-foreground"
+            label={{
+              value: "Points",
+              angle: -90,
+              position: "insideLeft",
+              offset: 10,
+              style: { fontSize: 11, fill: "var(--muted-foreground)" },
+            }}
+          />
+          <Tooltip
+            content={<CustomTooltip />}
+            cursor={{ strokeDasharray: "3 3" }}
+          />
+          {/* Iso-HF reference lines — rendered inside chart SVG via Recharts 3 direct children */}
+          <IsoHfLinesOverlay />
+          {competitors.map((comp) =>
+            hiddenIds.has(comp.id) ? null : (
+              <Scatter
+                key={comp.id}
+                name={formatLabel(comp)}
+                data={dataByCompetitor[comp.id]}
+                fill={colorMap[comp.id]}
+                shape={(props) => (
+                  <StageNumberDot
+                    cx={(props as DotProps).cx}
+                    cy={(props as DotProps).cy}
+                    fill={colorMap[comp.id]}
+                    payload={(props as DotProps).payload}
+                  />
+                )}
+              />
+            ),
+          )}
+        </ScatterChart>
+      </ResponsiveContainer>
+      <ToggleLegend
+        items={legendItems}
+        hiddenIds={hiddenIds}
+        onToggle={toggleSeries}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Interactive legends**: replaced Recharts' static `<Legend>` with accessible external toggle buttons (`role="group"`, `aria-pressed`) on both the scatter and bar charts — click any competitor to hide/show their series
- **Stage numbers on scatter dots**: each dot now shows its stage number inside, so both competitor (color) and stage (number) are readable at a glance without hovering (WCAG 1.4.1 — color not sole differentiator)
- **Visible iso-HF reference lines**: bumped `strokeWidth` 1→1.5 and `opacity` 0.4→0.55 so the diagonal HF lines are actually visible
- **Fixed transparent tooltips**: root cause was `hsl(var(--popover))` — CSS variables in this project store complete `oklch()` values, so wrapping them in `hsl()` produced invalid CSS that browsers silently discard (→ transparent background); replaced all `hsl(var(--...))` inline styles with `var(--...)` throughout both chart files
- **Tooltip polish**: added `box-shadow` for elevation, `itemStyle`/`labelStyle` on bar chart to neutralise Recharts' per-series colored text, softened cursor overlay opacity

## Test plan

- [ ] Hover scatter dots — tooltip is opaque, shows competitor name + stage name + time/points/HF
- [ ] Hover bar chart columns — tooltip is opaque, all text in neutral foreground color
- [ ] Click legend buttons on both charts — series hides (button goes faint + strikethrough), click again to restore
- [ ] Scatter dots show stage number inside the circle
- [ ] Iso-HF diagonal reference lines visible on scatter chart
- [ ] All checks pass: `pnpm typecheck && pnpm test && pnpm lint`
- [ ] Verify at 390px mobile width — legend wraps, touch targets ≥44px

🤖 Generated with [Claude Code](https://claude.com/claude-code)