### PR TITLE
feat: add Powered by Shoot'n Score It footer attribution

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,6 +27,17 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}>
         <Providers>{children}</Providers>
+        <footer className="py-4 text-center text-xs text-muted-foreground">
+          Powered by{" "}
+          <a
+            href="https://shootnscoreit.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-foreground"
+          >
+            Shoot&apos;n Score It
+          </a>
+        </footer>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

- Adds a persistent footer in `app/layout.tsx` with a "Powered by Shoot'n Score It" link to https://shootnscoreit.com
- Footer appears on every page of the app
- Uses semantic HTML and existing design tokens (`text-muted-foreground`, `hover:text-foreground`)

Closes #35

## Test plan

- [ ] Visit home page — footer visible at bottom with working link
- [ ] Visit a match page — footer visible at bottom
- [ ] Link opens shootnscoreit.com in a new tab
- [ ] `pnpm typecheck && pnpm lint && pnpm test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)