### PR TITLE
feat(#36): add data disclaimer to footer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,34 +29,41 @@ export default function RootLayout({
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}>
         <Providers>
           {children}
-          <footer className="w-full flex justify-center gap-4 p-4 text-xs text-muted-foreground border-t border-border mt-auto">
-            <span>
-              Powered by{" "}
+          <footer className="w-full flex flex-col items-center gap-2 p-4 text-xs text-muted-foreground border-t border-border mt-auto">
+            <div className="flex flex-wrap justify-center gap-4">
+              <span>
+                Powered by{" "}
+                <a
+                  href="https://shootnscoreit.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-foreground"
+                >
+                  Shoot&apos;n Score It
+                </a>
+              </span>
+              <span aria-hidden="true">·</span>
               <a
-                href="https://shootnscoreit.com"
+                href="https://github.com/mandakan/ssi-scoreboard"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline hover:text-foreground"
               >
-                Shoot&apos;n Score It
+                GitHub
               </a>
-            </span>
-            <span aria-hidden="true">·</span>
-            <a
-              href="https://github.com/mandakan/ssi-scoreboard"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-foreground"
-            >
-              GitHub
-            </a>
-            <span aria-hidden="true">·</span>
-            <Link
-              href="/legal"
-              className="hover:text-foreground underline underline-offset-4"
-            >
-              Terms &amp; Privacy
-            </Link>
+              <span aria-hidden="true">·</span>
+              <Link
+                href="/legal"
+                className="hover:text-foreground underline underline-offset-4"
+              >
+                Terms &amp; Privacy
+              </Link>
+            </div>
+            <p className="text-center max-w-sm">
+              Match data is fetched from Shoot&apos;n Score It and displayed via
+              this app. SSI is not responsible for the privacy, security, or
+              integrity of data shown here.
+            </p>
           </footer>
         </Providers>
       </body>


### PR DESCRIPTION
## Summary

- Adds a brief data disclaimer paragraph below the footer links on every page
- Informs users that match data is fetched from Shoot'n Score It and displayed via this app
- States that SSI is not responsible for the privacy, security, or integrity of data shown here
- Satisfies SSI Developer and API Agreement §4.1 (user notification requirement)

## Test plan

- [ ] Footer disclaimer is visible on all pages (home, compare, legal)
- [ ] Footer links row wraps correctly at 390px without horizontal overflow
- [ ] `pnpm typecheck && pnpm lint && pnpm test` all pass

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)