### PR TITLE
feat: show per-competitor stage shooting order in comparison table

### DIFF
--- a/app/api/compare/logic.ts
+++ b/app/api/compare/logic.ts
@@ -26,6 +26,8 @@ export interface RawScorecard {
   miss_count: number | null;
   no_shoots: number | null;
   procedurals: number | null;
+  // ISO datetime string from the API — used to derive per-competitor shooting order
+  scorecard_created?: string | null;
 }
 
 /**
@@ -99,6 +101,29 @@ export function computeGroupRankings(
 ): StageComparison[] {
   const selectedIds = new Set(selectedCompetitors.map((c) => c.id));
 
+  // Pre-compute per-competitor shooting order for selected competitors.
+  // Strategy: sort each competitor's scorecards by scorecard_created (ISO string, lexicographic
+  // sort works correctly). The position in that sorted list is their 1-based shooting order
+  // for each stage. This reflects actual shooting order as recorded by the RO at the stage.
+  const shootingOrderMap = new Map<number, Map<number, number>>(); // competitor_id → stage_id → order
+  const byCompetitor = new Map<number, RawScorecard[]>();
+  for (const sc of allScorecards) {
+    if (!selectedIds.has(sc.competitor_id)) continue;
+    const existing = byCompetitor.get(sc.competitor_id) ?? [];
+    existing.push(sc);
+    byCompetitor.set(sc.competitor_id, existing);
+  }
+  for (const [compId, cards] of byCompetitor) {
+    const withTimestamp = cards.filter((sc) => sc.scorecard_created);
+    if (withTimestamp.length === 0) continue;
+    const sorted = [...withTimestamp].sort((a, b) =>
+      a.scorecard_created!.localeCompare(b.scorecard_created!)
+    );
+    const orderMap = new Map<number, number>();
+    sorted.forEach((sc, i) => orderMap.set(sc.stage_id, i + 1));
+    shootingOrderMap.set(compId, orderMap);
+  }
+
   // Group ALL scorecards by stage
   const byStage = new Map<number, RawScorecard[]>();
   for (const sc of allScorecards) {
@@ -155,6 +180,8 @@ export function computeGroupRankings(
     for (const comp of selectedCompetitors) {
       const sc = allStage.find((s) => s.competitor_id === comp.id);
 
+      const shooting_order = shootingOrderMap.get(comp.id)?.get(stageId) ?? null;
+
       if (!sc || sc.dnf) {
         competitorMap[comp.id] = {
           competitor_id: comp.id,
@@ -176,6 +203,7 @@ export function computeGroupRankings(
           miss_count: null,
           no_shoots: null,
           procedurals: null,
+          shooting_order,
         };
       } else {
         const hf = effectiveHF(sc);
@@ -203,6 +231,7 @@ export function computeGroupRankings(
           miss_count: sc.miss_count,
           no_shoots: sc.no_shoots,
           procedurals: sc.procedurals,
+          shooting_order,
         };
       }
     }

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -7,6 +7,7 @@ import type { CompareResponse, CompetitorInfo } from "@/lib/types";
 // ─── Raw GraphQL response shapes ─────────────────────────────────────────────
 
 interface RawScCard {
+  created?: string | null;
   points?: number | string | null;
   hitfactor?: number | string | null;
   time?: number | string | null;
@@ -186,6 +187,7 @@ export async function GET(req: Request) {
         miss_count: parseNum(sc.miss),
         no_shoots: parseNum(sc.penalty),
         procedurals: parseNum(sc.procedural),
+        scorecard_created: sc.created ?? null,
       });
     }
   }

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -19,6 +19,16 @@ interface ComparisonTableProps {
 
 const RANK_COLORS = ["bg-yellow-400", "bg-gray-300", "bg-amber-600"];
 
+function ordinal(n: number): string {
+  const mod100 = n % 100;
+  const mod10 = n % 10;
+  if (mod100 >= 11 && mod100 <= 13) return `${n}th`;
+  if (mod10 === 1) return `${n}st`;
+  if (mod10 === 2) return `${n}nd`;
+  if (mod10 === 3) return `${n}rd`;
+  return `${n}th`;
+}
+
 function PenaltyBadge({
   miss,
   noShoots,
@@ -401,6 +411,25 @@ function rankTooltip(
   }
 }
 
+function ShootingOrderBadge({ order }: { order: number }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="text-[10px] text-muted-foreground/60 tabular-nums cursor-help leading-none"
+          aria-label={`Shot this stage ${ordinal(order)} in their rotation`}
+        >
+          {ordinal(order)}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-52 text-center text-xs">
+        This was the {ordinal(order)} stage this competitor shot — derived from
+        scorecard submission timestamps
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function StageCell({
   sc,
   maxPoints,
@@ -420,61 +449,76 @@ function StageCell({
 
   if (sc.dnf) {
     return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Badge
-            variant="secondary"
-            className="text-xs cursor-help"
-            aria-label="Stage not fired"
-            tabIndex={0}
-          >
-            DNF
-          </Badge>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="text-xs">
-          Stage not fired
-        </TooltipContent>
-      </Tooltip>
+      <div className="flex flex-col items-center gap-0.5">
+        {sc.shooting_order != null && (
+          <ShootingOrderBadge order={sc.shooting_order} />
+        )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge
+              variant="secondary"
+              className="text-xs cursor-help"
+              aria-label="Stage not fired"
+              tabIndex={0}
+            >
+              DNF
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            Stage not fired
+          </TooltipContent>
+        </Tooltip>
+      </div>
     );
   }
 
   if (sc.dq) {
     return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Badge
-            variant="destructive"
-            className="text-xs cursor-help"
-            aria-label="Disqualified"
-            tabIndex={0}
-          >
-            DQ
-          </Badge>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="text-xs">
-          Disqualified — stage scored as 0
-        </TooltipContent>
-      </Tooltip>
+      <div className="flex flex-col items-center gap-0.5">
+        {sc.shooting_order != null && (
+          <ShootingOrderBadge order={sc.shooting_order} />
+        )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge
+              variant="destructive"
+              className="text-xs cursor-help"
+              aria-label="Disqualified"
+              tabIndex={0}
+            >
+              DQ
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            Disqualified — stage scored as 0
+          </TooltipContent>
+        </Tooltip>
+      </div>
     );
   }
 
   if (sc.zeroed) {
     return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Badge
-            variant="outline"
-            className="text-xs border-orange-400 text-orange-600 cursor-help"
-            aria-label="Stage zeroed"
-            tabIndex={0}
-          >
-            0
-          </Badge>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="text-xs">
-          Stage zeroed — 0 points, ranked last
-        </TooltipContent>
-      </Tooltip>
+      <div className="flex flex-col items-center gap-0.5">
+        {sc.shooting_order != null && (
+          <ShootingOrderBadge order={sc.shooting_order} />
+        )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge
+              variant="outline"
+              className="text-xs border-orange-400 text-orange-600 cursor-help"
+              aria-label="Stage zeroed"
+              tabIndex={0}
+            >
+              0
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            Stage zeroed — 0 points, ranked last
+          </TooltipContent>
+        </Tooltip>
+      </div>
     );
   }
 
@@ -482,6 +526,10 @@ function StageCell({
 
   return (
     <div className="flex flex-col items-center gap-0.5">
+      {/* Shooting order indicator */}
+      {sc.shooting_order != null && (
+        <ShootingOrderBadge order={sc.shooting_order} />
+      )}
       {/* Primary: hit factor + rank badge */}
       <div className="flex items-center gap-1">
         {rank != null && (

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -167,6 +167,7 @@ export const SCORECARDS_QUERY = `
           }
           scorecards {
             ... on IpscScoreCardNode {
+              created
               points
               hitfactor
               time

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -84,6 +84,9 @@ export interface CompetitorSummary {
   miss_count: number | null;
   no_shoots: number | null;
   procedurals: number | null;
+  // 1-based index of this stage in the order this competitor shot it.
+  // Derived from scorecard submission timestamps (reflects actual shooting order).
+  shooting_order?: number | null;
 }
 
 export interface StageComparison {

--- a/tests/unit/compare-logic.test.ts
+++ b/tests/unit/compare-logic.test.ts
@@ -223,6 +223,96 @@ describe("computeGroupRankings — penalty fields", () => {
   });
 });
 
+describe("computeGroupRankings — shooting order", () => {
+  it("derives shooting order from scorecard_created timestamps", () => {
+    // Alice shot stage 2 first, then stage 1
+    const scorecards = [
+      makeCard(1, 1, { scorecard_created: "2026-02-22T12:00:00Z" }),
+      makeCard(1, 2, { scorecard_created: "2026-02-22T10:00:00Z" }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    // stage 2 was first (earlier timestamp) → shooting_order 1
+    const stage2 = result.find((s) => s.stage_num === 2)!;
+    expect(stage2.competitors[1].shooting_order).toBe(1);
+    // stage 1 was second → shooting_order 2
+    const stage1 = result.find((s) => s.stage_num === 1)!;
+    expect(stage1.competitors[1].shooting_order).toBe(2);
+  });
+
+  it("two competitors can have different shooting orders for the same stage", () => {
+    // Alice: stage 1 first, stage 2 second
+    // Bob:   stage 2 first, stage 1 second
+    const scorecards = [
+      makeCard(1, 1, { scorecard_created: "2026-02-22T10:00:00Z" }),
+      makeCard(1, 2, { scorecard_created: "2026-02-22T12:00:00Z" }),
+      makeCard(2, 1, { scorecard_created: "2026-02-22T12:30:00Z" }),
+      makeCard(2, 2, { scorecard_created: "2026-02-22T10:30:00Z" }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0], competitors[1]]);
+    const stage1 = result.find((s) => s.stage_num === 1)!;
+    expect(stage1.competitors[1].shooting_order).toBe(1); // Alice shot stage 1 first
+    expect(stage1.competitors[2].shooting_order).toBe(2); // Bob shot stage 1 second
+    const stage2 = result.find((s) => s.stage_num === 2)!;
+    expect(stage2.competitors[1].shooting_order).toBe(2); // Alice shot stage 2 second
+    expect(stage2.competitors[2].shooting_order).toBe(1); // Bob shot stage 2 first
+  });
+
+  it("shooting_order is null when no scorecard_created timestamps are present", () => {
+    const scorecards = [
+      makeCard(1, 1),
+      makeCard(1, 2),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    for (const stage of result) {
+      expect(stage.competitors[1].shooting_order).toBeNull();
+    }
+  });
+
+  it("shooting_order is null for stages with no timestamp even when other stages have one", () => {
+    // stage 1 has a timestamp, stage 2 does not
+    const scorecards = [
+      makeCard(1, 1, { scorecard_created: "2026-02-22T10:00:00Z" }),
+      makeCard(1, 2, { scorecard_created: null }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const stage2 = result.find((s) => s.stage_num === 2)!;
+    expect(stage2.competitors[1].shooting_order).toBeNull();
+  });
+
+  it("non-selected competitors do not affect shooting order computation", () => {
+    // comp id 99 is not selected — should be ignored
+    const nonSelected: RawScorecard = {
+      competitor_id: 99,
+      competitor_division: "hg1",
+      stage_id: 1,
+      stage_number: 1,
+      stage_name: "Stage 1",
+      max_points: 100,
+      points: 80,
+      hit_factor: 4.0,
+      time: 20,
+      dq: false,
+      zeroed: false,
+      dnf: false,
+      a_hits: null,
+      c_hits: null,
+      d_hits: null,
+      miss_count: null,
+      no_shoots: null,
+      procedurals: null,
+      scorecard_created: "2026-02-22T08:00:00Z",
+    };
+    const scorecards = [
+      nonSelected,
+      makeCard(1, 1, { scorecard_created: "2026-02-22T10:00:00Z" }),
+      makeCard(1, 2, { scorecard_created: "2026-02-22T12:00:00Z" }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const stage1 = result.find((s) => s.stage_num === 1)!;
+    expect(stage1.competitors[1].shooting_order).toBe(1);
+  });
+});
+
 describe("computeGroupRankings — overall rankings", () => {
   it("ranks competitors across all divisions by HF", () => {
     const scorecards = [


### PR DESCRIPTION
## Summary

- Adds a small ordinal indicator (`1st`, `2nd`, `3rd`…) to every cell in the comparison table, showing which position in their rotation each competitor shot that stage
- Uses scorecard submission timestamps (`created` on `IpscScoreCardNode`) as the source of truth — more reliable than squad numbers since rotation schemes vary by match director
- A tooltip on the badge explains the methodology: *"This was the Nth stage this competitor shot — derived from scorecard submission timestamps"*
- Appears on all cell states (normal, DNF, DQ, zeroed) so context is always visible
- Gracefully degrades to no indicator when timestamps are unavailable

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — zero warnings
- [x] `pnpm test` — 164 tests pass (5 new unit tests for shooting order logic)
- [ ] Verify visually on a live match: stage cells show `1st`/`2nd`/… ordinals that match the actual squad rotation
- [ ] Verify tooltip text is readable on mobile (390px)
- [ ] Verify ordinal is absent when `scorecard_created` is not present (older matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)