### PR TITLE
feat(#11): stage difficulty context via full-field median HF

### DIFF
--- a/app/api/compare/logic.ts
+++ b/app/api/compare/logic.ts
@@ -83,6 +83,29 @@ function pct(hf: number | null, leaderHF: number | null): number | null {
 }
 
 /**
+ * Compute the median HF for a set of scorecards.
+ * Excludes DNF, DQ, and zeroed scorecards, and entries with null hit_factor.
+ * Returns the median and the count of valid competitors included.
+ */
+function medianHF(scorecards: RawScorecard[]): { median: number | null; count: number } {
+  const valid = scorecards
+    .filter((sc) => !sc.dnf && !sc.dq && !sc.zeroed)
+    .map((sc) => sc.hit_factor)
+    .filter((hf): hf is number => hf != null);
+
+  if (valid.length === 0) return { median: null, count: 0 };
+
+  const sorted = [...valid].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const median =
+    sorted.length % 2 === 0
+      ? (sorted[mid - 1] + sorted[mid]) / 2
+      : sorted[mid];
+
+  return { median, count: valid.length };
+}
+
+/**
  * Given ALL scorecards for a match and the selected competitors, compute:
  *   - Group rankings (rank/% within selected competitors)
  *   - Division rankings (rank/% within each competitor's own division, full field)
@@ -151,6 +174,10 @@ export function computeGroupRankings(
     // Overall rankings — all competitors across all divisions
     const { rankMap: overallRankMap, leaderHF: overallLeaderHF } =
       rankByHF(allStage);
+
+    // Full-field median HF (excluding DNF/DQ/zeroed)
+    const { median: fieldMedianHF, count: fieldCompetitorCount } =
+      medianHF(allStage);
 
     // Division rankings — group by division string, rank within each
     const byDivision = new Map<string, RawScorecard[]>();
@@ -244,6 +271,8 @@ export function computeGroupRankings(
       group_leader_hf: groupLeaderHF,
       group_leader_points: groupLeaderPoints,
       overall_leader_hf: overallLeaderHF,
+      field_median_hf: fieldMedianHF,
+      field_competitor_count: fieldCompetitorCount,
       competitors: competitorMap,
     };
 

--- a/components/comparison-chart.tsx
+++ b/components/comparison-chart.tsx
@@ -24,13 +24,16 @@ export function ComparisonChart({ data, showBenchmark = false }: ComparisonChart
   const colorMap = buildColorMap(competitors.map((c) => c.id));
   const [hiddenIds, setHiddenIds] = useState<Set<number>>(new Set());
   const [benchmarkVisible, setBenchmarkVisible] = useState(showBenchmark);
+  const [medianVisible, setMedianVisible] = useState(false);
 
   const hasBenchmark = stages.some((s) => s.overall_leader_hf != null);
+  const hasMedian = stages.some((s) => s.field_median_hf != null);
 
   const chartData = stages.map((stage) => {
     const row: Record<string, string | number | null> = {
       name: `S${stage.stage_num}`,
       overall_leader_hf: stage.overall_leader_hf,
+      field_median_hf: stage.field_median_hf,
     };
     for (const comp of competitors) {
       const sc = stage.competitors[comp.id];
@@ -102,6 +105,9 @@ export function ComparisonChart({ data, showBenchmark = false }: ComparisonChart
               if (name === "overall_leader_hf") {
                 return [typeof value === "number" ? value.toFixed(4) : "—", "Field leader"];
               }
+              if (name === "field_median_hf") {
+                return [typeof value === "number" ? value.toFixed(4) : "—", "Field median"];
+              }
               const id = parseInt((name ?? "").split("_").pop() ?? "0", 10);
               return [
                 typeof value === "number" ? value.toFixed(4) : "—",
@@ -119,6 +125,19 @@ export function ComparisonChart({ data, showBenchmark = false }: ComparisonChart
               activeDot={false}
               legendType="none"
               name="overall_leader_hf"
+              connectNulls={false}
+            />
+          )}
+          {medianVisible && hasMedian && (
+            <Line
+              dataKey="field_median_hf"
+              stroke="var(--muted-foreground)"
+              strokeDasharray="1 3"
+              strokeWidth={1.5}
+              dot={false}
+              activeDot={false}
+              legendType="none"
+              name="field_median_hf"
               connectNulls={false}
             />
           )}
@@ -160,6 +179,26 @@ export function ComparisonChart({ data, showBenchmark = false }: ComparisonChart
               aria-hidden="true"
             />
             <span className={benchmarkVisible ? "" : "line-through"}>Field leader</span>
+          </button>
+        )}
+        {hasMedian && (
+          <button
+            type="button"
+            onClick={() => setMedianVisible((v) => !v)}
+            aria-pressed={medianVisible}
+            className="flex items-center gap-2 rounded-full border px-3 text-sm transition-opacity"
+            style={{
+              borderColor: medianVisible ? "var(--muted-foreground)55" : "transparent",
+              backgroundColor: medianVisible ? "var(--muted-foreground)18" : undefined,
+              opacity: medianVisible ? undefined : 0.4,
+            }}
+          >
+            <span
+              className="inline-block w-4"
+              style={{ borderTop: "2px dotted var(--muted-foreground)" }}
+              aria-hidden="true"
+            />
+            <span className={medianVisible ? "" : "line-through"}>Field median</span>
           </button>
         )}
         {competitors.map((comp) => {

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -316,6 +316,23 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
                         ].filter(Boolean).join(" · ")}
                       </span>
                     )}
+                    {/* Field median annotation */}
+                    {stage.field_median_hf != null && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span
+                            className="text-xs text-muted-foreground/60 tabular-nums cursor-help"
+                            aria-label={`Field median hit factor: ${formatHF(stage.field_median_hf)} across ${stage.field_competitor_count} competitors`}
+                          >
+                            {`med: ${formatHF(stage.field_median_hf)}`}
+                            <span className="opacity-60">{` (${stage.field_competitor_count})`}</span>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="top" className="max-w-52 text-center text-xs">
+                          {`Field median hit factor: ${formatHF(stage.field_median_hf)} across ${stage.field_competitor_count} competitors (excludes DNF/DQ/zeroed)`}
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
                   </div>
                 </td>
                 {competitors.map((comp) => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -101,6 +101,8 @@ export interface StageComparison {
   group_leader_hf: number | null;     // best HF in selected group
   group_leader_points: number | null; // best raw pts in selected group — benchmark overlay hook, do not remove
   overall_leader_hf: number | null;   // best HF across full field — benchmark overlay hook
+  field_median_hf: number | null;     // median HF across the full field (excludes DNF/DQ/zeroed)
+  field_competitor_count: number;     // count of valid field competitors contributing to the median
   competitors: Record<number, CompetitorSummary>; // keyed by competitor_id
 }
 

--- a/tests/components/comparison-chart.test.tsx
+++ b/tests/components/comparison-chart.test.tsx
@@ -65,6 +65,8 @@ const baseData: CompareResponse = {
       group_leader_hf: 5.63,
       group_leader_points: 76,
       overall_leader_hf: 6.1,
+      field_median_hf: 4.0,
+      field_competitor_count: 50,
       competitors: baseStageCompetitors,
     },
   ],

--- a/tests/components/comparison-table.test.tsx
+++ b/tests/components/comparison-table.test.tsx
@@ -24,6 +24,8 @@ const baseData: CompareResponse = {
       group_leader_hf: 5.63,
       group_leader_points: 76,
       overall_leader_hf: 5.63,
+      field_median_hf: 4.0,
+      field_competitor_count: 50,
       competitors: {
         1: {
           competitor_id: 1,
@@ -183,6 +185,8 @@ describe("ComparisonTable", () => {
           group_leader_hf: 4.0,
           group_leader_points: 58,
           overall_leader_hf: 4.0,
+          field_median_hf: 4.0,
+          field_competitor_count: 50,
           competitors: {
             1: { ...baseData.stages[0].competitors[1], dq: false },
             2: baseData.stages[0].competitors[2],

--- a/tests/components/radar-chart.test.tsx
+++ b/tests/components/radar-chart.test.tsx
@@ -30,6 +30,8 @@ const baseData: CompareResponse = {
       group_leader_hf: 5.63,
       group_leader_points: 76,
       overall_leader_hf: 5.63,
+      field_median_hf: 4.0,
+      field_competitor_count: 50,
       competitors: {
         1: {
           competitor_id: 1,

--- a/tests/components/scatter-chart.test.tsx
+++ b/tests/components/scatter-chart.test.tsx
@@ -30,6 +30,8 @@ const baseData: CompareResponse = {
       group_leader_hf: 5.63,
       group_leader_points: 76,
       overall_leader_hf: 5.63,
+      field_median_hf: 4.0,
+      field_competitor_count: 50,
       competitors: {
         1: {
           competitor_id: 1,

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -39,6 +39,8 @@ const MOCK_COMPARE: CompareResponse = {
       group_leader_hf: 5.73,
       group_leader_points: 76,
       overall_leader_hf: 5.73,
+      field_median_hf: 4.0,
+      field_competitor_count: 50,
       competitors: {
         100: { competitor_id: 100, points: 72, hit_factor: 5.02, time: 14.34, group_rank: 2, group_percent: 87.6, div_rank: 1, div_percent: 100, overall_rank: 2, overall_percent: 87.6, dq: false, zeroed: false, dnf: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },
         200: { competitor_id: 200, points: 76, hit_factor: 5.63, time: 13.49, group_rank: 2, group_percent: 98.3, div_rank: 1, div_percent: 100, overall_rank: 2, overall_percent: 98.3, dq: false, zeroed: false, dnf: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },
@@ -53,6 +55,8 @@ const MOCK_COMPARE: CompareResponse = {
       group_leader_hf: 3.63,
       group_leader_points: 58,
       overall_leader_hf: 3.63,
+      field_median_hf: 4.0,
+      field_competitor_count: 50,
       competitors: {
         100: { competitor_id: 100, points: 26, hit_factor: 1.30, time: 20.0,  group_rank: 3, group_percent: 35.8, div_rank: 2, div_percent: 35.8, overall_rank: 3, overall_percent: 35.8, dq: false, zeroed: false, dnf: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },
         200: { competitor_id: 200, points: 58, hit_factor: 3.63, time: 15.98, group_rank: 1, group_percent: 100,  div_rank: 1, div_percent: 100,  overall_rank: 1, overall_percent: 100,  dq: false, zeroed: false, dnf: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },
@@ -67,6 +71,8 @@ const MOCK_COMPARE: CompareResponse = {
       group_leader_hf: null,
       group_leader_points: null,
       overall_leader_hf: null,
+      field_median_hf: null,
+      field_competitor_count: 0,
       competitors: {
         100: { competitor_id: 100, points: null, hit_factor: null, time: null, group_rank: null, group_percent: null, div_rank: null, div_percent: null, overall_rank: null, overall_percent: null, dq: false, zeroed: false, dnf: true, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },
         200: { competitor_id: 200, points: null, hit_factor: null, time: null, group_rank: null, group_percent: null, div_rank: null, div_percent: null, overall_rank: null, overall_percent: null, dq: false, zeroed: false, dnf: true, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },

--- a/tests/unit/compare-logic.test.ts
+++ b/tests/unit/compare-logic.test.ts
@@ -313,6 +313,142 @@ describe("computeGroupRankings — shooting order", () => {
   });
 });
 
+describe("computeGroupRankings — field median HF", () => {
+  it("computes median for an odd number of competitors", () => {
+    // sorted: [3.0, 4.0, 5.0] → median = 4.0
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 5.0 }),
+      makeCard(2, 1, { hit_factor: 3.0 }),
+      makeCard(3, 1, { hit_factor: 4.0 }),
+    ];
+    const result = computeGroupRankings(scorecards, competitors);
+    expect(result[0].field_median_hf).toBe(4.0);
+    expect(result[0].field_competitor_count).toBe(3);
+  });
+
+  it("computes median for an even number of competitors", () => {
+    // sorted: [3.0, 5.0] → median = (3.0 + 5.0) / 2 = 4.0
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 5.0 }),
+      makeCard(2, 1, { hit_factor: 3.0 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0], competitors[1]]);
+    expect(result[0].field_median_hf).toBe(4.0);
+    expect(result[0].field_competitor_count).toBe(2);
+  });
+
+  it("excludes DNF competitors from the median", () => {
+    // sorted valid: [3.0, 5.0] → median = 4.0; DNF is excluded
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 5.0 }),
+      makeCard(2, 1, { hit_factor: 3.0 }),
+      makeCard(3, 1, { dnf: true, hit_factor: null }),
+    ];
+    const result = computeGroupRankings(scorecards, competitors);
+    expect(result[0].field_median_hf).toBe(4.0);
+    expect(result[0].field_competitor_count).toBe(2);
+  });
+
+  it("excludes DQ competitors from the median", () => {
+    // DQ competitor has reported HF=6.0 but is excluded from median
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 5.0 }),
+      makeCard(2, 1, { hit_factor: 3.0 }),
+      makeCard(3, 1, { dq: true, hit_factor: 6.0 }),
+    ];
+    const result = computeGroupRankings(scorecards, competitors);
+    expect(result[0].field_median_hf).toBe(4.0);
+    expect(result[0].field_competitor_count).toBe(2);
+  });
+
+  it("excludes zeroed competitors from the median", () => {
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 5.0 }),
+      makeCard(2, 1, { hit_factor: 3.0 }),
+      makeCard(3, 1, { zeroed: true, hit_factor: 4.5 }),
+    ];
+    const result = computeGroupRankings(scorecards, competitors);
+    expect(result[0].field_median_hf).toBe(4.0);
+    expect(result[0].field_competitor_count).toBe(2);
+  });
+
+  it("returns null median and count 0 when all competitors have DNF", () => {
+    const scorecards = [
+      makeCard(1, 1, { dnf: true }),
+      makeCard(2, 1, { dnf: true }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0], competitors[1]]);
+    expect(result[0].field_median_hf).toBeNull();
+    expect(result[0].field_competitor_count).toBe(0);
+  });
+
+  it("returns correct median and count for a single competitor", () => {
+    const scorecards = [makeCard(1, 1, { hit_factor: 4.5 })];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    expect(result[0].field_median_hf).toBe(4.5);
+    expect(result[0].field_competitor_count).toBe(1);
+  });
+
+  it("includes non-selected competitors in the full-field median", () => {
+    // Non-selected competitor (id=99) contributes to median
+    // sorted valid: [3.0, 5.0, 8.0] → median = 5.0
+    const nonSelected: RawScorecard = {
+      competitor_id: 99,
+      competitor_division: "hg1",
+      stage_id: 1,
+      stage_number: 1,
+      stage_name: "Stage 1",
+      max_points: 100,
+      points: 100,
+      hit_factor: 8.0,
+      time: 12.5,
+      dq: false,
+      zeroed: false,
+      dnf: false,
+      a_hits: 12,
+      c_hits: 0,
+      d_hits: 0,
+      miss_count: 0,
+      no_shoots: 0,
+      procedurals: 0,
+    };
+    const scorecards = [
+      nonSelected,
+      makeCard(1, 1, { hit_factor: 5.0 }),
+      makeCard(2, 1, { hit_factor: 3.0 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0], competitors[1]]);
+    expect(result[0].field_median_hf).toBe(5.0);
+    expect(result[0].field_competitor_count).toBe(3);
+  });
+
+  it("excludes null hit_factor entries from the median", () => {
+    // hit_factor=null means API hasn't computed it yet
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 5.0 }),
+      makeCard(2, 1, { hit_factor: null }),
+      makeCard(3, 1, { hit_factor: 3.0 }),
+    ];
+    const result = computeGroupRankings(scorecards, competitors);
+    expect(result[0].field_median_hf).toBe(4.0);
+    expect(result[0].field_competitor_count).toBe(2);
+  });
+
+  it("computes median per stage independently", () => {
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 2.0 }),
+      makeCard(2, 1, { hit_factor: 4.0 }),
+      makeCard(1, 2, { hit_factor: 6.0, stage_number: 2 }),
+      makeCard(2, 2, { hit_factor: 8.0, stage_number: 2 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0], competitors[1]]);
+    const stage1 = result.find((s) => s.stage_num === 1)!;
+    const stage2 = result.find((s) => s.stage_num === 2)!;
+    expect(stage1.field_median_hf).toBe(3.0);
+    expect(stage2.field_median_hf).toBe(7.0);
+  });
+});
+
 describe("computeGroupRankings — overall rankings", () => {
   it("ranks competitors across all divisions by HF", () => {
     const scorecards = [

--- a/tests/unit/scatter-utils.test.ts
+++ b/tests/unit/scatter-utils.test.ts
@@ -102,6 +102,8 @@ function makeStage(overrides: StageOverrides = {}): StageComparison {
     group_leader_hf: 5.0,
     group_leader_points: 80,
     overall_leader_hf: 5.0,
+    field_median_hf: 4.0,
+    field_competitor_count: 50,
     competitors: {
       1: {
         competitor_id: 1,
@@ -204,6 +206,8 @@ describe("buildScatterData", () => {
       group_leader_hf: 6.0,
       group_leader_points: 100,
       overall_leader_hf: 6.0,
+      field_median_hf: 4.0,
+      field_competitor_count: 50,
       competitors: {
         1: {
           competitor_id: 1,


### PR DESCRIPTION
Closes #11

## Summary

- Computes `field_median_hf` and `field_competitor_count` per stage in `computeGroupRankings()` using a new `medianHF()` helper that excludes DNF/DQ/zeroed scorecards
- Adds both fields to the `StageComparison` type
- Bar chart gains a toggleable dotted reference line ("Field median"), visually distinct from the existing dashed "Field leader" line
- Comparison table shows a subtle `med: X.XX (N)` annotation in the stage column, with a tooltip explaining the exclusions

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — zero warnings
- [x] `pnpm test` — 177 tests pass, including 10 new unit tests for `medianHF()` covering: odd count, even count, DNF exclusion, DQ exclusion, zeroed exclusion, all-DNF edge case, single competitor, non-selected competitors included in full-field count, null HF exclusion, per-stage independence
- [ ] Visually verify median line toggles correctly on the bar chart
- [ ] Visually verify `med: X.XX (N)` appears in the stage column of the comparison table

🤖 Generated with [Claude Code](https://claude.com/claude-code)