### PR TITLE
feat: add delta heatmap view to comparison table (issue #7)

### DIFF
--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -8,10 +8,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { AlertTriangle, ExternalLink } from "lucide-react";
-import { cn, formatHF, formatTime, formatPct } from "@/lib/utils";
+import { cn, formatHF, formatTime, formatPct, computePointsDelta, formatDelta } from "@/lib/utils";
 import { buildColorMap } from "@/lib/colors";
 import { HitZoneBar } from "@/components/hit-zone-bar";
-import type { CompareResponse, CompetitorSummary, PctMode } from "@/lib/types";
+import type { CompareResponse, CompetitorSummary, PctMode, ViewMode } from "@/lib/types";
 
 interface ComparisonTableProps {
   data: CompareResponse;
@@ -198,6 +198,55 @@ function ModeToggle({
   );
 }
 
+function ViewModeToggle({
+  viewMode,
+  onChange,
+}: {
+  viewMode: ViewMode;
+  onChange: (m: ViewMode) => void;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="Table view mode"
+      className="inline-flex rounded-md border text-xs"
+    >
+      {(["absolute", "delta"] as ViewMode[]).map((m, i, arr) => (
+        <button
+          key={m}
+          onClick={() => onChange(m)}
+          aria-pressed={viewMode === m}
+          className={cn(
+            "px-2.5 py-1 transition-colors capitalize",
+            i === 0 ? "rounded-l-md" : "",
+            i === arr.length - 1 ? "rounded-r-md" : "",
+            "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+            viewMode === m
+              ? "bg-foreground text-background font-medium"
+              : "text-muted-foreground hover:bg-muted"
+          )}
+        >
+          {m === "absolute" ? "Absolute" : "Delta"}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Returns Tailwind bg classes for the delta heatmap cell based on the
+ * magnitude of the gap relative to stage max_points.
+ * Green = at/near leader; red = far behind.
+ */
+function deltaColorClasses(delta: number, maxPoints: number): string {
+  if (delta >= 0) return "bg-emerald-100 dark:bg-emerald-900/50";
+  const ratio = Math.abs(delta) / Math.max(maxPoints, 1);
+  if (ratio <= 0.15) return "bg-lime-100 dark:bg-lime-900/50";
+  if (ratio <= 0.30) return "bg-amber-100 dark:bg-amber-900/50";
+  if (ratio <= 0.50) return "bg-orange-100 dark:bg-orange-900/50";
+  return "bg-red-100 dark:bg-red-900/50";
+}
+
 /** Pick the rank and percent values for a given mode. */
 function modeValues(
   sc: CompetitorSummary,
@@ -216,6 +265,7 @@ function modeValues(
 export function ComparisonTable({ data }: ComparisonTableProps) {
   const { stages, competitors } = data;
   const [mode, setMode] = useState<PctMode>("group");
+  const [viewMode, setViewMode] = useState<ViewMode>("absolute");
 
   // Detect match-level DQ: every scorecard for a competitor has dq: true
   const matchDqCompetitors = competitors.filter((comp) => {
@@ -239,6 +289,9 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
     let hasPenaltyData = false;
     let totalPenaltyPts = 0;
     let firedWithAllPenaltyData = 0;
+    let totalDelta = 0;
+    let deltaCount = 0;
+    let totalMaxPts = 0;
 
     for (const stage of stages) {
       const sc = stage.competitors[comp.id];
@@ -267,6 +320,12 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
         firedWithAllPenaltyData++;
         totalPenaltyPts += (sc.miss_count + sc.no_shoots + sc.procedurals) * 10;
       }
+      const d = computePointsDelta(sc.points, stage.group_leader_points);
+      if (d != null) {
+        totalDelta += d;
+        deltaCount++;
+        totalMaxPts += stage.max_points;
+      }
     }
 
     return {
@@ -281,6 +340,8 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
       procedurals: hasPenaltyData ? pTotal : null,
       totalPenaltyPts,
       isClean: hasFired && firedCount === firedWithAllPenaltyData && totalPenaltyPts === 0,
+      totalDelta: deltaCount > 0 ? totalDelta : null,
+      totalMaxPts,
     };
   });
 
@@ -298,10 +359,15 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
         </div>
       ))}
 
-      {/* Mode toggle */}
-      <div className="flex items-center gap-2">
-        <span className="text-xs text-muted-foreground">% relative to:</span>
-        <ModeToggle mode={mode} onChange={setMode} />
+      {/* View mode toggle (Absolute / Delta) */}
+      <div className="flex flex-wrap items-center gap-3">
+        <ViewModeToggle viewMode={viewMode} onChange={setViewMode} />
+        {viewMode === "absolute" && (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">% relative to:</span>
+            <ModeToggle mode={mode} onChange={setMode} />
+          </div>
+        )}
       </div>
 
       <div className="overflow-x-auto">
@@ -400,6 +466,8 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
                         sc={sc}
                         maxPoints={stage.max_points}
                         mode={mode}
+                        viewMode={viewMode}
+                        groupLeaderPoints={stage.group_leader_points}
                         groupSize={competitors.length}
                         divisionName={comp.division}
                       />
@@ -412,51 +480,75 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
             {/* Totals row */}
             <tr className="border-t-2 font-semibold bg-muted/20">
               <td className="py-2 pr-4 text-xs text-muted-foreground font-normal">
-                <div>Total pts</div>
-                <div>Avg {MODE_LABELS[mode]} %</div>
+                {viewMode === "delta" ? (
+                  <div>Total deficit</div>
+                ) : (
+                  <>
+                    <div>Total pts</div>
+                    <div>Avg {MODE_LABELS[mode]} %</div>
+                  </>
+                )}
               </td>
               {totals.map((t) => (
                 <td key={t.id} className="py-2 px-2 sm:px-3 text-center">
-                  <div className="flex flex-col items-center gap-0.5">
-                    <span>
-                      {t.points != null ? (
-                        t.points.toFixed(0)
-                      ) : (
-                        <span className="text-muted-foreground font-normal">—</span>
+                  {viewMode === "delta" ? (
+                    <div
+                      className={cn(
+                        "inline-flex flex-col items-center justify-center gap-0.5 py-1 px-2 rounded",
+                        t.totalDelta != null
+                          ? deltaColorClasses(t.totalDelta, t.totalMaxPts)
+                          : ""
                       )}
-                    </span>
-                    <span className="text-xs text-muted-foreground font-normal">
-                      {t.avgPct != null ? formatPct(t.avgPct) : "—"}
-                    </span>
-                    <HitZoneBar
-                      aHits={t.aHits}
-                      cHits={t.cHits}
-                      dHits={t.dHits}
-                      misses={t.misses}
-                      noShoots={t.noShoots}
-                      procedurals={t.procedurals}
-                    />
-                    {t.totalPenaltyPts > 0 && (
-                      <span className="text-xs font-medium text-red-600 dark:text-red-400 tabular-nums">
-                        {`\u2212${t.totalPenaltyPts}pts`}
+                    >
+                      <span className={cn(
+                        "font-semibold tabular-nums",
+                        t.totalDelta === 0 ? "text-muted-foreground" : "text-foreground"
+                      )}>
+                        {t.totalDelta != null ? formatDelta(t.totalDelta) : "—"}
                       </span>
-                    )}
-                    {t.isClean && (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <span
-                            className="text-xs text-green-600 dark:text-green-400 font-medium cursor-help"
-                            aria-label="Clean match: no penalties across all fired stages"
-                          >
-                            ✓ Clean
-                          </span>
-                        </TooltipTrigger>
-                        <TooltipContent side="top" className="text-xs">
-                          No penalties across all fired stages
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                  </div>
+                    </div>
+                  ) : (
+                    <div className="flex flex-col items-center gap-0.5">
+                      <span>
+                        {t.points != null ? (
+                          t.points.toFixed(0)
+                        ) : (
+                          <span className="text-muted-foreground font-normal">—</span>
+                        )}
+                      </span>
+                      <span className="text-xs text-muted-foreground font-normal">
+                        {t.avgPct != null ? formatPct(t.avgPct) : "—"}
+                      </span>
+                      <HitZoneBar
+                        aHits={t.aHits}
+                        cHits={t.cHits}
+                        dHits={t.dHits}
+                        misses={t.misses}
+                        noShoots={t.noShoots}
+                        procedurals={t.procedurals}
+                      />
+                      {t.totalPenaltyPts > 0 && (
+                        <span className="text-xs font-medium text-red-600 dark:text-red-400 tabular-nums">
+                          {`\u2212${t.totalPenaltyPts}pts`}
+                        </span>
+                      )}
+                      {t.isClean && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span
+                              className="text-xs text-green-600 dark:text-green-400 font-medium cursor-help"
+                              aria-label="Clean match: no penalties across all fired stages"
+                            >
+                              ✓ Clean
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="top" className="text-xs">
+                            No penalties across all fired stages
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                  )}
                 </td>
               ))}
             </tr>
@@ -508,12 +600,16 @@ function StageCell({
   sc,
   maxPoints,
   mode,
+  viewMode,
+  groupLeaderPoints,
   groupSize,
   divisionName,
 }: {
   sc: CompetitorSummary | undefined;
   maxPoints: number;
   mode: PctMode;
+  viewMode: ViewMode;
+  groupLeaderPoints: number | null;
   groupSize: number;
   divisionName: string | null;
 }) {
@@ -592,6 +688,31 @@ function StageCell({
             Stage zeroed — 0 points, ranked last
           </TooltipContent>
         </Tooltip>
+      </div>
+    );
+  }
+
+  // Delta mode: show gap to group leader with color-coded background
+  if (viewMode === "delta") {
+    const delta = computePointsDelta(sc.points, groupLeaderPoints);
+    return (
+      <div
+        className={cn(
+          "inline-flex flex-col items-center justify-center gap-0.5 py-1 px-2 rounded w-full",
+          delta != null ? deltaColorClasses(delta, maxPoints) : ""
+        )}
+      >
+        {sc.shooting_order != null && (
+          <ShootingOrderBadge order={sc.shooting_order} />
+        )}
+        <span
+          className={cn(
+            "font-semibold tabular-nums text-sm",
+            delta === 0 ? "text-muted-foreground" : "text-foreground"
+          )}
+        >
+          {delta != null ? formatDelta(delta) : "—"}
+        </span>
       </div>
     );
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -121,6 +121,11 @@ export interface StageComparison {
 // "overall"  — HF % relative to the overall stage winner (full field, all divisions)
 export type PctMode = "group" | "division" | "overall";
 
+// View mode for the comparison table.
+// "absolute" — shows raw hit factor, points, and percentage
+// "delta"    — shows gap to the group leader per stage (±X.X pts)
+export type ViewMode = "absolute" | "delta";
+
 export interface CompareResponse {
   match_id: number;
   stages: StageComparison[];

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -44,3 +44,27 @@ export function formatPct(pct: number | null | undefined): string {
   if (pct == null) return "—";
   return `${pct.toFixed(1)}%`;
 }
+
+/**
+ * Compute the points delta for a competitor vs the group leader on a stage.
+ *   - returns null when either value is unavailable (e.g. DNF)
+ *   - returns 0 when the competitor IS the leader (tie counts as zero gap)
+ *   - returns a negative number for competitors behind the leader
+ */
+export function computePointsDelta(
+  points: number | null,
+  groupLeaderPoints: number | null
+): number | null {
+  if (points == null || groupLeaderPoints == null) return null;
+  return points - groupLeaderPoints;
+}
+
+/**
+ * Format a points delta as "±0.0 pts" (leader/tie), "+X.X pts" (ahead),
+ * or "−X.X pts" (behind).  Uses the real minus sign (U+2212) for negative values.
+ */
+export function formatDelta(delta: number): string {
+  if (delta === 0) return "\u00b10.0 pts";
+  if (delta > 0) return `+${delta.toFixed(1)} pts`;
+  return `\u2212${Math.abs(delta).toFixed(1)} pts`;
+}

--- a/tests/components/comparison-table.test.tsx
+++ b/tests/components/comparison-table.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ComparisonTable } from "@/components/comparison-table";
 import type { CompareResponse } from "@/lib/types";
@@ -350,5 +350,138 @@ describe("ComparisonTable — incomplete scorecard indicator", () => {
     expect(
       screen.queryByLabelText("Incomplete scorecard (rule 9.7.6.2)")
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("ComparisonTable — delta view mode", () => {
+  it("renders Absolute and Delta toggle buttons", () => {
+    renderWithProviders(<ComparisonTable data={baseData} />);
+    expect(screen.getByRole("button", { name: "Absolute" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delta" })).toBeInTheDocument();
+  });
+
+  it("Absolute toggle is pressed by default", () => {
+    renderWithProviders(<ComparisonTable data={baseData} />);
+    expect(screen.getByRole("button", { name: "Absolute" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Delta" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("switches to delta mode when Delta button is clicked", () => {
+    renderWithProviders(<ComparisonTable data={baseData} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delta" }));
+    expect(screen.getByRole("button", { name: "Delta" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Absolute" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("shows delta value (leader has ±0.0 pts) in delta mode", () => {
+    // Bob is the group leader (group_leader_points = 76, Bob.points = 76 → delta = 0)
+    renderWithProviders(<ComparisonTable data={baseData} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delta" }));
+    expect(screen.getAllByText("±0.0 pts").length).toBeGreaterThan(0);
+  });
+
+  it("shows negative delta for the non-leader competitor in delta mode", () => {
+    // Alice: points=72, leader=76 → delta = -4 → "−4.0 pts"
+    renderWithProviders(<ComparisonTable data={baseData} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delta" }));
+    expect(screen.getAllByText("\u22124.0 pts").length).toBeGreaterThan(0);
+  });
+
+  it("shows em-dash in delta mode for a competitor with no scorecard", () => {
+    const data: CompareResponse = {
+      ...baseData,
+      stages: [
+        {
+          ...baseData.stages[0],
+          competitors: {
+            // competitor 2 only — no scorecard for competitor 1
+            2: baseData.stages[0].competitors[2],
+          },
+        },
+      ],
+    };
+    renderWithProviders(<ComparisonTable data={data} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delta" }));
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+
+  it("still shows DNF badge in delta mode", () => {
+    const data: CompareResponse = {
+      ...baseData,
+      stages: [
+        {
+          ...baseData.stages[0],
+          competitors: {
+            1: { ...baseData.stages[0].competitors[1], dnf: true, hit_factor: null, points: null },
+            2: baseData.stages[0].competitors[2],
+          },
+        },
+      ],
+    };
+    renderWithProviders(<ComparisonTable data={data} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delta" }));
+    expect(screen.getByText("DNF")).toBeInTheDocument();
+  });
+
+  it("still shows DQ badge in delta mode", () => {
+    const data: CompareResponse = {
+      ...baseData,
+      stages: [
+        {
+          ...baseData.stages[0],
+          competitors: {
+            1: { ...baseData.stages[0].competitors[1], dq: true },
+            2: baseData.stages[0].competitors[2],
+          },
+        },
+      ],
+    };
+    renderWithProviders(<ComparisonTable data={data} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delta" }));
+    expect(screen.getByText("DQ")).toBeInTheDocument();
+  });
+
+  it("totals row shows 'Total deficit' label in delta mode", () => {
+    renderWithProviders(<ComparisonTable data={baseData} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delta" }));
+    expect(screen.getByText("Total deficit")).toBeInTheDocument();
+  });
+
+  it("totals row shows cumulative deficit for the non-leader in delta mode", () => {
+    // Alice: -4 pts across the 1 stage → total deficit = "−4.0 pts"
+    renderWithProviders(<ComparisonTable data={baseData} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delta" }));
+    // Leader shows ±0.0 pts, non-leader shows −4.0 pts (appears at least once each)
+    expect(screen.getAllByText("±0.0 pts").length).toBeGreaterThanOrEqual(2); // per-stage + totals for leader
+    expect(screen.getAllByText("\u22124.0 pts").length).toBeGreaterThanOrEqual(2); // per-stage + totals for non-leader
+  });
+
+  it("hides % reference toggle in delta mode", () => {
+    renderWithProviders(<ComparisonTable data={baseData} />);
+    // % toggle visible in absolute mode
+    expect(screen.getByText("% relative to:")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Delta" }));
+    // % toggle hidden in delta mode
+    expect(screen.queryByText("% relative to:")).not.toBeInTheDocument();
+  });
+
+  it("tie case: two competitors with equal points both show ±0.0 pts in delta mode", () => {
+    const tieData: CompareResponse = {
+      ...baseData,
+      stages: [
+        {
+          ...baseData.stages[0],
+          group_leader_points: 76,
+          competitors: {
+            1: { ...baseData.stages[0].competitors[1], points: 76 },
+            2: { ...baseData.stages[0].competitors[2], points: 76 },
+          },
+        },
+      ],
+    };
+    renderWithProviders(<ComparisonTable data={tieData} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delta" }));
+    // Both competitors show ±0.0 pts (per-stage); totals row also shows ±0.0 pts
+    expect(screen.getAllByText("±0.0 pts").length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseMatchUrl, formatHF, formatTime, formatPct } from "@/lib/utils";
+import { parseMatchUrl, formatHF, formatTime, formatPct, computePointsDelta, formatDelta } from "@/lib/utils";
 
 describe("parseMatchUrl", () => {
   it("parses a valid shootnscoreit.com URL", () => {
@@ -70,5 +70,58 @@ describe("formatPct", () => {
 
   it("returns em-dash for null", () => {
     expect(formatPct(null)).toBe("—");
+  });
+});
+
+describe("computePointsDelta", () => {
+  it("returns 0 for a tie (competitor equals group leader)", () => {
+    expect(computePointsDelta(76, 76)).toBe(0);
+  });
+
+  it("returns negative delta when competitor is behind the leader", () => {
+    expect(computePointsDelta(72, 76)).toBe(-4);
+  });
+
+  it("returns positive delta when competitor somehow exceeds leader (rounding edge)", () => {
+    // group_leader_points may lag if computed from a subset; positive delta is valid
+    expect(computePointsDelta(80, 76)).toBe(4);
+  });
+
+  it("returns null when competitor points are null (DNF)", () => {
+    expect(computePointsDelta(null, 76)).toBeNull();
+  });
+
+  it("returns null when group_leader_points are null (no valid scorecards on stage)", () => {
+    expect(computePointsDelta(72, null)).toBeNull();
+  });
+
+  it("returns null when both values are null", () => {
+    expect(computePointsDelta(null, null)).toBeNull();
+  });
+
+  it("handles zero points (zeroed/DQ competitor vs leader)", () => {
+    expect(computePointsDelta(0, 76)).toBe(-76);
+  });
+});
+
+describe("formatDelta", () => {
+  it("formats zero as '±0.0 pts'", () => {
+    expect(formatDelta(0)).toBe("±0.0 pts");
+  });
+
+  it("formats a negative delta with real minus sign", () => {
+    expect(formatDelta(-4.2)).toBe("\u22124.2 pts");
+  });
+
+  it("formats a positive delta with '+' prefix", () => {
+    expect(formatDelta(3.5)).toBe("+3.5 pts");
+  });
+
+  it("rounds to 1 decimal place", () => {
+    expect(formatDelta(-12.567)).toBe("\u221212.6 pts");
+  });
+
+  it("formats a large negative delta correctly", () => {
+    expect(formatDelta(-100)).toBe("\u2212100.0 pts");
   });
 });


### PR DESCRIPTION
Add an Absolute | Delta toggle above the comparison table. In delta
mode each cell shows the gap to the group leader on that stage
(±0.0 pts / −X.X pts) with a green→red WCAG-AA-safe background
gradient keyed to the magnitude of the gap (normalised by max_points).

- `lib/types.ts`: add `ViewMode = "absolute" | "delta"` type
- `lib/utils.ts`: add pure `computePointsDelta` and `formatDelta` helpers
- `components/comparison-table.tsx`:
  - `ViewModeToggle` component (keyboard-accessible, aria-pressed)
  - `deltaColorClasses` helper (5 colour bands, light + dark variants)
  - `StageCell` renders delta value with coloured background in delta mode
  - DQ / zeroed / DNF cells preserve their badges in both modes
  - Totals row shows cumulative deficit and "Total deficit" label
  - % reference toggle hidden in delta mode (not applicable)
- Unit tests: `computePointsDelta` (tie=0, DNF=null, zero points)
  and `formatDelta` edge cases in `tests/unit/utils.test.ts`
- Component tests: toggle behaviour, delta values, badge preservation,
  totals row, tie case in `tests/components/comparison-table.test.tsx`

Closes #7

https://claude.ai/code/session_014tCN63Xh8ZXW3ZMfYLMrGC