### PR TITLE
feat: HF% vs stage winner line chart per stage (closes #45)

### DIFF
--- a/app/match/[ct]/[id]/page.tsx
+++ b/app/match/[ct]/[id]/page.tsx
@@ -13,6 +13,7 @@ import { ShareButton } from "@/components/share-button";
 import { CompetitorPicker } from "@/components/competitor-picker";
 import { ComparisonTable } from "@/components/comparison-table";
 import { ComparisonChart } from "@/components/comparison-chart";
+import { HfPercentChart } from "@/components/hf-percent-chart";
 import { SpeedAccuracyChart } from "@/components/scatter-chart";
 import { StageBalanceChart } from "@/components/radar-chart";
 import { useMatchQuery, useCompareQuery } from "@/lib/queries";
@@ -236,6 +237,15 @@ export default function MatchPage() {
               <div className="rounded-lg border p-4 space-y-3">
                 <h2 className="font-semibold">Hit factor by stage</h2>
                 <ComparisonChart data={compareQuery.data} />
+              </div>
+
+              <div className="rounded-lg border p-4 space-y-3">
+                <h2 className="font-semibold">HF% vs stage winner</h2>
+                <p className="text-xs text-muted-foreground">
+                  Hit factor as a percentage of the stage winner per stage. Select
+                  a competitor as reference to see gaps relative to them.
+                </p>
+                <HfPercentChart data={compareQuery.data} />
               </div>
 
               <div className="rounded-lg border p-4 space-y-3">

--- a/components/hf-percent-chart.tsx
+++ b/components/hf-percent-chart.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ReferenceArea,
+  ResponsiveContainer,
+} from "recharts";
+import { buildColorMap } from "@/lib/colors";
+import type { CompareResponse } from "@/lib/types";
+import { computeHfPct, type RefMode } from "@/lib/hf-percent-utils";
+
+interface HfPercentChartProps {
+  data: CompareResponse;
+}
+
+export function HfPercentChart({ data }: HfPercentChartProps) {
+  const { stages, competitors } = data;
+  const colorMap = buildColorMap(competitors.map((c) => c.id));
+  const [hiddenIds, setHiddenIds] = useState<Set<number>>(new Set());
+  const [refMode, setRefMode] = useState<RefMode>("stage_winner");
+
+  const chartData = stages.map((stage) => {
+    const row: Record<string, string | number | null> = {
+      name: `S${stage.stage_num}`,
+    };
+    for (const comp of competitors) {
+      row[`hfpct_${comp.id}`] = computeHfPct(stage, comp.id, refMode);
+    }
+    return row;
+  });
+
+  const formatLabel = (id: number) => {
+    const comp = competitors.find((c) => c.id === id);
+    return comp ? `#${comp.competitor_number} ${comp.name.split(" ")[0]}` : String(id);
+  };
+
+  const toggleSeries = (id: number) => {
+    setHiddenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div>
+      {/* Reference mode selector */}
+      <div role="group" aria-label="Reference competitor" className="flex flex-wrap gap-2 pb-3">
+        <span className="self-center text-xs text-muted-foreground">vs:</span>
+        <button
+          type="button"
+          onClick={() => setRefMode("stage_winner")}
+          aria-pressed={refMode === "stage_winner"}
+          className="rounded-full border px-3 text-sm transition-opacity"
+          style={{
+            borderColor:
+              refMode === "stage_winner" ? "var(--muted-foreground)55" : "transparent",
+            backgroundColor:
+              refMode === "stage_winner" ? "var(--muted-foreground)18" : undefined,
+            opacity: refMode === "stage_winner" ? undefined : 0.5,
+          }}
+        >
+          Stage winner
+        </button>
+        {competitors.map((comp) => {
+          const active = refMode === comp.id;
+          const color = colorMap[comp.id];
+          return (
+            <button
+              key={comp.id}
+              type="button"
+              onClick={() => setRefMode(comp.id)}
+              aria-pressed={active}
+              className="flex items-center gap-2 rounded-full border px-3 text-sm transition-opacity"
+              style={{
+                borderColor: active ? color + "55" : "transparent",
+                backgroundColor: active ? color + "18" : undefined,
+                opacity: active ? undefined : 0.5,
+              }}
+            >
+              <span
+                className="inline-block h-2.5 w-2.5 flex-none rounded-full"
+                style={{ backgroundColor: color }}
+                aria-hidden="true"
+              />
+              {formatLabel(comp.id)}
+            </button>
+          );
+        })}
+      </div>
+
+      <ResponsiveContainer width="100%" height={320}>
+        <LineChart
+          data={chartData}
+          margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+        >
+          {/* Colored performance bands — rendered first to sit below grid and lines */}
+          <ReferenceArea y1={0} y2={85} fill="#ef4444" fillOpacity={0.07} />
+          <ReferenceArea y1={85} y2={95} fill="#f59e0b" fillOpacity={0.07} />
+          <ReferenceArea y1={95} y2={300} fill="#22c55e" fillOpacity={0.07} />
+
+          <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+          <XAxis
+            dataKey="name"
+            tick={{ fontSize: 12 }}
+            className="fill-muted-foreground"
+          />
+          <YAxis
+            tick={{ fontSize: 12 }}
+            className="fill-muted-foreground"
+            domain={[0, (dataMax: number) => Math.max(115, Math.ceil(dataMax / 5) * 5 + 5)]}
+            tickFormatter={(v: number) => `${v}%`}
+            label={{
+              value: "HF%",
+              angle: -90,
+              position: "insideLeft",
+              offset: 10,
+              style: { fontSize: 11, fill: "var(--muted-foreground)" },
+            }}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: "var(--popover)",
+              color: "var(--popover-foreground)",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              fontSize: 12,
+              boxShadow: "0 4px 16px rgba(0,0,0,0.14), 0 1px 4px rgba(0,0,0,0.08)",
+            }}
+            labelStyle={{ color: "var(--popover-foreground)", fontWeight: 600 }}
+            itemStyle={{ color: "var(--popover-foreground)" }}
+            cursor={{ stroke: "var(--muted-foreground)", opacity: 0.2 }}
+            formatter={(value: number | undefined, name: string | undefined) => {
+              const id = parseInt((name ?? "").replace("hfpct_", ""), 10);
+              return [
+                typeof value === "number" ? `${value.toFixed(1)}%` : "—",
+                formatLabel(id),
+              ];
+            }}
+          />
+          <ReferenceLine
+            y={100}
+            stroke="var(--muted-foreground)"
+            strokeDasharray="4 2"
+            strokeWidth={1.5}
+            label={{
+              value: "100%",
+              position: "right",
+              style: { fontSize: 10, fill: "var(--muted-foreground)" },
+            }}
+          />
+          {competitors.map((comp) => {
+            if (hiddenIds.has(comp.id)) return null;
+            return (
+              <Line
+                key={comp.id}
+                type="monotone"
+                dataKey={`hfpct_${comp.id}`}
+                stroke={colorMap[comp.id]}
+                strokeWidth={2}
+                dot={{ r: 3, fill: colorMap[comp.id] }}
+                activeDot={{ r: 5 }}
+                name={`hfpct_${comp.id}`}
+                connectNulls={false}
+              />
+            );
+          })}
+        </LineChart>
+      </ResponsiveContainer>
+
+      {/* Band legend */}
+      <div
+        className="flex flex-wrap justify-center gap-x-4 gap-y-1 pt-1 text-xs"
+        aria-label="Performance bands"
+      >
+        <span style={{ color: "#22c55e" }}>
+          <span aria-hidden="true">■</span> &gt;95% solid
+        </span>
+        <span style={{ color: "#f59e0b" }}>
+          <span aria-hidden="true">■</span> 85–95% mediocre
+        </span>
+        <span style={{ color: "#ef4444" }}>
+          <span aria-hidden="true">■</span> &lt;85% leak
+        </span>
+      </div>
+
+      {/* Series visibility legend */}
+      <div
+        role="group"
+        aria-label="Chart series visibility"
+        className="flex flex-wrap justify-center gap-2 pt-2"
+      >
+        {competitors.map((comp) => {
+          const hidden = hiddenIds.has(comp.id);
+          const label = formatLabel(comp.id);
+          const color = colorMap[comp.id];
+          return (
+            <button
+              key={comp.id}
+              type="button"
+              onClick={() => toggleSeries(comp.id)}
+              aria-pressed={!hidden}
+              className="flex items-center gap-2 rounded-full border px-3 text-sm transition-opacity"
+              style={{
+                borderColor: hidden ? "transparent" : color + "55",
+                backgroundColor: hidden ? undefined : color + "18",
+                opacity: hidden ? 0.4 : undefined,
+              }}
+            >
+              <span
+                className="inline-block h-3 w-3 flex-none rounded-full"
+                style={{ backgroundColor: color }}
+                aria-hidden="true"
+              />
+              <span className={hidden ? "line-through" : ""}>{label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/lib/hf-percent-utils.ts
+++ b/lib/hf-percent-utils.ts
@@ -1,0 +1,44 @@
+import type { StageComparison } from "@/lib/types";
+
+/**
+ * Reference for the HF% line chart.
+ * - "stage_winner": relative to the full-field stage winner (= overall_percent)
+ * - number: relative to a specific competitor's HF on that stage (by competitor_id)
+ */
+export type RefMode = "stage_winner" | number;
+
+/**
+ * Compute HF% for a competitor on a stage relative to a reference.
+ *
+ *   HF% = (competitor_hf / reference_hf) × 100
+ *
+ * For "stage_winner" mode, this returns overall_percent which is already computed
+ * relative to the full-field stage winner.
+ *
+ * Returns null when:
+ *   - Competitor has no scorecard or is DNF on this stage
+ *   - Competitor's effective HF is null
+ *   - Reference HF is null or zero (prevents division by zero)
+ *   - Reference competitor is DNF on this stage
+ */
+export function computeHfPct(
+  stage: StageComparison,
+  compId: number,
+  refMode: RefMode
+): number | null {
+  const sc = stage.competitors[compId];
+  if (!sc || sc.dnf) return null;
+
+  if (refMode === "stage_winner") {
+    // overall_percent = (competitor_hf / overall_leader_hf) × 100
+    return sc.overall_percent;
+  }
+
+  // Specific competitor reference
+  const refSc = stage.competitors[refMode];
+  // refSc.hit_factor is 0 for DQ/zeroed — !0 === true, guards division-by-zero
+  if (!refSc || refSc.dnf || !refSc.hit_factor) return null;
+  const hf = sc.hit_factor;
+  if (hf == null) return null;
+  return (hf / refSc.hit_factor) * 100;
+}

--- a/tests/unit/hf-percent-utils.test.ts
+++ b/tests/unit/hf-percent-utils.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { computeHfPct } from "@/lib/hf-percent-utils";
+import type { StageComparison, CompetitorSummary } from "@/lib/types";
+
+function makeStage(
+  competitorData: Record<number, Partial<CompetitorSummary>>
+): StageComparison {
+  const competitors: Record<number, CompetitorSummary> = {};
+  for (const [rawId, overrides] of Object.entries(competitorData)) {
+    const id = Number(rawId);
+    competitors[id] = {
+      competitor_id: id,
+      hit_factor: 4.0,
+      points: 80,
+      time: 20,
+      group_rank: 1,
+      group_percent: 100,
+      div_rank: 1,
+      div_percent: 100,
+      overall_rank: 1,
+      overall_percent: 100,
+      overall_percentile: 1.0,
+      dq: false,
+      zeroed: false,
+      dnf: false,
+      incomplete: false,
+      a_hits: 8,
+      c_hits: 0,
+      d_hits: 0,
+      miss_count: 0,
+      no_shoots: 0,
+      procedurals: 0,
+      ...overrides,
+    };
+  }
+  return {
+    stage_id: 1,
+    stage_name: "Stage 1",
+    stage_num: 1,
+    max_points: 100,
+    group_leader_hf: 5.0,
+    group_leader_points: 100,
+    overall_leader_hf: 5.0,
+    field_median_hf: 4.0,
+    field_competitor_count: 2,
+    stageDifficultyLevel: 3,
+    stageDifficultyLabel: "hard",
+    competitors,
+  };
+}
+
+describe("computeHfPct — stage_winner mode", () => {
+  it("returns overall_percent for a normal competitor", () => {
+    const stage = makeStage({ 1: { hit_factor: 5.0, overall_percent: 100 } });
+    expect(computeHfPct(stage, 1, "stage_winner")).toBe(100);
+  });
+
+  it("returns overall_percent when competitor is below the winner", () => {
+    const stage = makeStage({ 1: { hit_factor: 4.0, overall_percent: 80 } });
+    expect(computeHfPct(stage, 1, "stage_winner")).toBe(80);
+  });
+
+  it("returns null for a DNF competitor", () => {
+    const stage = makeStage({ 1: { dnf: true, overall_percent: null } });
+    expect(computeHfPct(stage, 1, "stage_winner")).toBeNull();
+  });
+
+  it("returns null when the competitor is not in the stage", () => {
+    const stage = makeStage({ 2: { hit_factor: 4.0, overall_percent: 80 } });
+    expect(computeHfPct(stage, 1, "stage_winner")).toBeNull();
+  });
+
+  it("returns null when overall_percent is null (no HF computed yet)", () => {
+    const stage = makeStage({ 1: { hit_factor: null, overall_percent: null } });
+    expect(computeHfPct(stage, 1, "stage_winner")).toBeNull();
+  });
+});
+
+describe("computeHfPct — specific competitor reference mode", () => {
+  it("returns 100 when competitor is the reference itself", () => {
+    const stage = makeStage({ 1: { hit_factor: 5.0 } });
+    expect(computeHfPct(stage, 1, 1)).toBe(100);
+  });
+
+  it("returns correct ratio when competitor is below the reference", () => {
+    // 4.0 / 5.0 * 100 = 80
+    const stage = makeStage({
+      1: { hit_factor: 4.0 },
+      2: { hit_factor: 5.0 },
+    });
+    expect(computeHfPct(stage, 1, 2)).toBeCloseTo(80, 5);
+  });
+
+  it("returns > 100 when competitor is above the reference", () => {
+    // 6.0 / 5.0 * 100 = 120
+    const stage = makeStage({
+      1: { hit_factor: 6.0 },
+      2: { hit_factor: 5.0 },
+    });
+    expect(computeHfPct(stage, 1, 2)).toBeCloseTo(120, 5);
+  });
+
+  it("returns null when the subject competitor is DNF", () => {
+    const stage = makeStage({
+      1: { dnf: true },
+      2: { hit_factor: 5.0 },
+    });
+    expect(computeHfPct(stage, 1, 2)).toBeNull();
+  });
+
+  it("returns null when the reference competitor is DNF", () => {
+    const stage = makeStage({
+      1: { hit_factor: 4.0 },
+      2: { dnf: true },
+    });
+    expect(computeHfPct(stage, 1, 2)).toBeNull();
+  });
+
+  it("returns null when the reference competitor has HF=0 (DQ/zeroed)", () => {
+    const stage = makeStage({
+      1: { hit_factor: 4.0 },
+      2: { hit_factor: 0, zeroed: true },
+    });
+    expect(computeHfPct(stage, 1, 2)).toBeNull();
+  });
+
+  it("returns null when the subject competitor's HF is null", () => {
+    const stage = makeStage({
+      1: { hit_factor: null },
+      2: { hit_factor: 5.0 },
+    });
+    expect(computeHfPct(stage, 1, 2)).toBeNull();
+  });
+
+  it("returns null when the reference competitor is not in the stage", () => {
+    const stage = makeStage({ 1: { hit_factor: 4.0 } });
+    // Competitor 99 does not exist in the stage
+    expect(computeHfPct(stage, 1, 99)).toBeNull();
+  });
+
+  it("computes ratio correctly with non-round numbers", () => {
+    // 3.5 / 5.6 * 100 ≈ 62.5
+    const stage = makeStage({
+      1: { hit_factor: 3.5 },
+      2: { hit_factor: 5.6 },
+    });
+    expect(computeHfPct(stage, 1, 2)).toBeCloseTo((3.5 / 5.6) * 100, 5);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `HfPercentChart` — a Recharts `LineChart` showing each competitor's HF as a percentage of the stage winner across all stages
- Colored `ReferenceArea` performance bands: >95% green (solid), 85–95% amber (mediocre), <85% red (leak)
- `ReferenceLine` at 100% marks the stage win threshold
- Reference toggle: switch between "Stage winner" (full-field) and any selected competitor as the 100% baseline — competitor-relative mode answers "how far was I from X on each stage?"
- Series visibility toggle legend (matches existing chart patterns)
- Extract `computeHfPct()` to `lib/hf-percent-utils.ts` with 14 unit tests

## Test plan

- [ ] `pnpm typecheck && pnpm test` pass (16 test files, 269 tests)
- [ ] Chart renders at 390px width with no overflow
- [ ] Colored bands and 100% reference line are visible
- [ ] Toggling reference between "Stage winner" and a competitor updates all lines immediately
- [ ] Hiding a competitor via the series legend removes their line
- [ ] DNF stages appear as line breaks (not connected)
- [ ] Dark mode: all colors render correctly (CSS vars, no `hsl()` wrappers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)