### PR TITLE
feat: stage run classification — solid/conservative/over-push/meltdown (closes #48)

### DIFF
--- a/app/api/compare/logic.ts
+++ b/app/api/compare/logic.ts
@@ -7,6 +7,7 @@ import type {
   CompetitorInfo,
   CompetitorPenaltyStats,
   EfficiencyStats,
+  StageClassification,
 } from "@/lib/types";
 
 export interface RawScorecard {
@@ -131,6 +132,95 @@ const DIFFICULTY_LABELS: Record<1 | 2 | 3 | 4 | 5, string> = {
   4: "very hard",
   5: "brutal",
 };
+
+/**
+ * Thresholds used for per-stage run classification.
+ * Centralised here so they can be adjusted without hunting through logic code.
+ */
+export const STAGE_CLASS_THRESHOLDS = {
+  SOLID_HF_PCT: 95,           // HF% ≥ this → eligible for Solid
+  CONSERVATIVE_HF_PCT_MIN: 85, // HF% ≥ this (and < SOLID) → eligible for Conservative
+  CONSERVATIVE_A_PCT: 90,     // A% must be > this for Conservative
+  OVERPUSH_HF_PCT: 85,        // HF% < this → eligible for Over-push
+  OVERPUSH_A_PCT: 85,         // A% must be < this for Over-push
+  MELTDOWN_HF_PCT: 70,        // HF% < this → Meltdown (any penalty count)
+  MELTDOWN_MISS_NS: 2,        // miss + no-shoot ≥ this → Meltdown
+} as const;
+
+/**
+ * Classify a single stage run into one of four quality buckets.
+ *
+ * Priority (highest to lowest):
+ *   1. Meltdown — catastrophic: HF% < 70 %, ≥ 2 misses/NS, or any procedural
+ *   2. Solid    — excellent: HF% ≥ 95 %, penalty-free
+ *   3. Conservative — decent: HF% 85–95 %, penalty-free, A% > 90 %
+ *   4. Over-push — risky: HF% < 85 %, penalised, A% < 85 %
+ *   null — does not fit any bucket (edge cases, or groupPercent is unknown)
+ *
+ * @param groupPercent HF as % of the group leader on this stage (already computed)
+ * @param aHits        A-zone hits (null if not recorded)
+ * @param cHits        C/B-zone hits (null if not recorded)
+ * @param dHits        D-zone hits (null if not recorded)
+ * @param missCount    Miss count (null if not recorded)
+ * @param noShoots     No-shoot penalties (null if not recorded)
+ * @param procedurals  Procedural penalties (null if not recorded)
+ */
+export function classifyStageRun(
+  groupPercent: number | null,
+  aHits: number | null,
+  cHits: number | null,
+  dHits: number | null,
+  missCount: number | null,
+  noShoots: number | null,
+  procedurals: number | null
+): StageClassification | null {
+  if (groupPercent === null) return null;
+
+  const a = aHits ?? 0;
+  const c = cHits ?? 0;
+  const d = dHits ?? 0;
+  const miss = missCount ?? 0;
+  const ns = noShoots ?? 0;
+  const proc = procedurals ?? 0;
+  const penalized = miss > 0 || ns > 0 || proc > 0;
+
+  const totalHits = a + c + d + miss;
+  const aPct = totalHits > 0 ? (a / totalHits) * 100 : null;
+
+  // 1. Meltdown (checked first — takes priority over all other buckets)
+  if (
+    groupPercent < STAGE_CLASS_THRESHOLDS.MELTDOWN_HF_PCT ||
+    miss + ns >= STAGE_CLASS_THRESHOLDS.MELTDOWN_MISS_NS ||
+    proc > 0
+  ) {
+    return "meltdown";
+  }
+
+  // 2. Solid: fast and clean
+  if (groupPercent >= STAGE_CLASS_THRESHOLDS.SOLID_HF_PCT && !penalized) {
+    return "solid";
+  }
+
+  // 3. Conservative: decent pace, penalty-free, high accuracy
+  if (
+    groupPercent >= STAGE_CLASS_THRESHOLDS.CONSERVATIVE_HF_PCT_MIN &&
+    !penalized &&
+    (aPct === null || aPct > STAGE_CLASS_THRESHOLDS.CONSERVATIVE_A_PCT)
+  ) {
+    return "conservative";
+  }
+
+  // 4. Over-push: pushed speed, paid penalty cost, accuracy suffered
+  if (
+    groupPercent < STAGE_CLASS_THRESHOLDS.OVERPUSH_HF_PCT &&
+    penalized &&
+    (aPct === null || aPct < STAGE_CLASS_THRESHOLDS.OVERPUSH_A_PCT)
+  ) {
+    return "over-push";
+  }
+
+  return null;
+}
 
 /**
  * Map a normalised difficulty score [0, 1] to a 1–5 integer level.
@@ -303,6 +393,7 @@ export function computeGroupRankings(
           no_shoots: null,
           procedurals: null,
           shooting_order,
+          stageClassification: null,
         };
       } else {
         const hf = effectiveHF(sc);
@@ -310,6 +401,7 @@ export function computeGroupRankings(
         const divKey = sc.competitor_division ?? "__none__";
         const divInfo = divResults.get(divKey);
         const overallRank = overallRankMap.get(comp.id) ?? null;
+        const groupPercent = pct(hf, groupLeaderHF);
 
         competitorMap[comp.id] = {
           competitor_id: comp.id,
@@ -317,7 +409,7 @@ export function computeGroupRankings(
           hit_factor: hf,
           time: sc.time,
           group_rank: groupRankMap.get(comp.id) ?? null,
-          group_percent: pct(hf, groupLeaderHF),
+          group_percent: groupPercent,
           div_rank: divInfo ? (divInfo.rankMap.get(comp.id) ?? null) : null,
           div_percent: divInfo ? pct(hf, divInfo.leaderHF) : null,
           overall_rank: overallRank,
@@ -334,6 +426,15 @@ export function computeGroupRankings(
           no_shoots: sc.no_shoots,
           procedurals: sc.procedurals,
           shooting_order,
+          stageClassification: classifyStageRun(
+            groupPercent,
+            sc.a_hits,
+            sc.c_hits,
+            sc.d_hits,
+            sc.miss_count,
+            sc.no_shoots,
+            sc.procedurals
+          ),
         };
       }
     }

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -7,11 +7,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { AlertTriangle, ExternalLink } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ExternalLink, Flame, Shield, Zap } from "lucide-react";
 import { cn, formatHF, formatTime, formatPct, computePointsDelta, formatDelta } from "@/lib/utils";
 import { buildColorMap } from "@/lib/colors";
 import { HitZoneBar } from "@/components/hit-zone-bar";
-import type { CompareResponse, CompetitorSummary, PctMode, ViewMode } from "@/lib/types";
+import type { CompareResponse, CompetitorSummary, PctMode, StageClassification, ViewMode } from "@/lib/types";
 
 interface ComparisonTableProps {
   data: CompareResponse;
@@ -182,6 +182,77 @@ function PenaltyBadge({
       </TooltipTrigger>
       <TooltipContent side="top" className="text-xs">
         {tooltipText}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+const CLASSIFICATION_CONFIG: Record<
+  StageClassification,
+  { label: string; color: string; Icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean }> }
+> = {
+  solid: { label: "Solid", color: "text-emerald-500", Icon: CheckCircle2 },
+  conservative: { label: "Conservative", color: "text-yellow-500", Icon: Shield },
+  "over-push": { label: "Over-push", color: "text-orange-500", Icon: Zap },
+  meltdown: { label: "Meltdown", color: "text-red-500", Icon: Flame },
+};
+
+/**
+ * Small dot + icon badge indicating run quality classification.
+ * Uses both color and shape to satisfy WCAG color-not-sole-differentiator.
+ */
+function StageClassificationBadge({
+  classification,
+  groupPercent,
+  aPct,
+  miss,
+  noShoots,
+  procedurals,
+}: {
+  classification: StageClassification | null;
+  groupPercent: number | null;
+  aPct: number | null;
+  miss: number | null;
+  noShoots: number | null;
+  procedurals: number | null;
+}) {
+  if (!classification) return null;
+  const { label, color, Icon } = CLASSIFICATION_CONFIG[classification];
+
+  const parts: string[] = [];
+  if (groupPercent != null) parts.push(`${groupPercent.toFixed(1)}% HF`);
+  if (aPct != null) parts.push(`${aPct.toFixed(0)}% A-zone`);
+  const m = miss ?? 0;
+  const ns = noShoots ?? 0;
+  const proc = procedurals ?? 0;
+  if (m + ns + proc > 0) {
+    const pen: string[] = [];
+    if (m > 0) pen.push(`${m} miss`);
+    if (ns > 0) pen.push(`${ns} no-shoot`);
+    if (proc > 0) pen.push(`${proc} procedural`);
+    parts.push(pen.join(", "));
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={cn("inline-flex items-center gap-0.5 cursor-help leading-none", color)}
+          aria-label={`Run classification: ${label}`}
+          role="img"
+        >
+          <span
+            className="w-2 h-2 rounded-full bg-current"
+            aria-hidden={true}
+          />
+          <Icon className="w-3 h-3" aria-hidden={true} />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="text-xs space-y-0.5">
+        <div className="font-medium">{label}</div>
+        {parts.length > 0 && (
+          <div className="text-muted-foreground">{parts.join(" · ")}</div>
+        )}
       </TooltipContent>
     </Tooltip>
   );
@@ -361,10 +432,20 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
     let totalDelta = 0;
     let deltaCount = 0;
     let totalMaxPts = 0;
+    let solidCount = 0;
+    let conservativeCount = 0;
+    let overpushCount = 0;
+    let meltdownCount = 0;
 
     for (const stage of stages) {
       const sc = stage.competitors[comp.id];
       if (!sc || sc.dnf) continue;
+      switch (sc.stageClassification) {
+        case "solid": solidCount++; break;
+        case "conservative": conservativeCount++; break;
+        case "over-push": overpushCount++; break;
+        case "meltdown": meltdownCount++; break;
+      }
       hasFired = true;
       firedCount++;
       totalPts += sc.points ?? 0;
@@ -411,6 +492,10 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
       isClean: hasFired && firedCount === firedWithAllPenaltyData && totalPenaltyPts === 0,
       totalDelta: deltaCount > 0 ? totalDelta : null,
       totalMaxPts,
+      solidCount,
+      conservativeCount,
+      overpushCount,
+      meltdownCount,
     };
   });
 
@@ -446,25 +531,74 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
               <th className="text-left py-2 pr-4 font-medium text-muted-foreground">
                 Stage
               </th>
-              {competitors.map((comp) => (
-                <th
-                  key={comp.id}
-                  className="py-2 px-3 text-center font-medium min-w-[5.5rem] sm:min-w-32"
-                  style={{ borderBottom: `3px solid ${colorMap[comp.id]}` }}
-                >
-                  <div className="flex flex-col items-center gap-0.5">
-                    <span className="font-mono text-xs text-muted-foreground">
-                      #{comp.competitor_number}
-                    </span>
-                    <span>{comp.name.split(" ")[0]}</span>
-                    {comp.division && (
-                      <span className="text-xs text-muted-foreground uppercase tracking-wide">
-                        {comp.division}
+              {competitors.map((comp) => {
+                const t = totals.find((x) => x.id === comp.id);
+                const hasClassifications = t &&
+                  (t.solidCount + t.conservativeCount + t.overpushCount + t.meltdownCount) > 0;
+                const classificationSummaryLabel = t ? [
+                  t.solidCount > 0 && `${t.solidCount} solid`,
+                  t.conservativeCount > 0 && `${t.conservativeCount} conservative`,
+                  t.overpushCount > 0 && `${t.overpushCount} over-push`,
+                  t.meltdownCount > 0 && `${t.meltdownCount} meltdown`,
+                ].filter(Boolean).join(" · ") : "";
+                return (
+                  <th
+                    key={comp.id}
+                    className="py-2 px-3 text-center font-medium min-w-[5.5rem] sm:min-w-32"
+                    style={{ borderBottom: `3px solid ${colorMap[comp.id]}` }}
+                  >
+                    <div className="flex flex-col items-center gap-0.5">
+                      <span className="font-mono text-xs text-muted-foreground">
+                        #{comp.competitor_number}
                       </span>
-                    )}
-                  </div>
-                </th>
-              ))}
+                      <span>{comp.name.split(" ")[0]}</span>
+                      {comp.division && (
+                        <span className="text-xs text-muted-foreground uppercase tracking-wide">
+                          {comp.division}
+                        </span>
+                      )}
+                      {hasClassifications && t && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span
+                              className="inline-flex items-center gap-1 cursor-help"
+                              aria-label={`Run classification summary: ${classificationSummaryLabel}`}
+                            >
+                              {t.solidCount > 0 && (
+                                <span className="inline-flex items-center gap-px text-[10px] text-emerald-500">
+                                  <CheckCircle2 className="w-2.5 h-2.5" aria-hidden={true} />
+                                  {t.solidCount}
+                                </span>
+                              )}
+                              {t.conservativeCount > 0 && (
+                                <span className="inline-flex items-center gap-px text-[10px] text-yellow-500">
+                                  <Shield className="w-2.5 h-2.5" aria-hidden={true} />
+                                  {t.conservativeCount}
+                                </span>
+                              )}
+                              {t.overpushCount > 0 && (
+                                <span className="inline-flex items-center gap-px text-[10px] text-orange-500">
+                                  <Zap className="w-2.5 h-2.5" aria-hidden={true} />
+                                  {t.overpushCount}
+                                </span>
+                              )}
+                              {t.meltdownCount > 0 && (
+                                <span className="inline-flex items-center gap-px text-[10px] text-red-500">
+                                  <Flame className="w-2.5 h-2.5" aria-hidden={true} />
+                                  {t.meltdownCount}
+                                </span>
+                              )}
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" className="text-xs">
+                            {classificationSummaryLabel}
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                  </th>
+                );
+              })}
             </tr>
           </thead>
           <tbody>
@@ -897,6 +1031,22 @@ function StageCell({
         noShoots={sc.no_shoots}
         procedurals={sc.procedurals}
       />
+      {/* Run classification badge */}
+      {(() => {
+        const totalHits =
+          (sc.a_hits ?? 0) + (sc.c_hits ?? 0) + (sc.d_hits ?? 0) + (sc.miss_count ?? 0);
+        const aPct = totalHits > 0 ? ((sc.a_hits ?? 0) / totalHits) * 100 : null;
+        return (
+          <StageClassificationBadge
+            classification={sc.stageClassification}
+            groupPercent={sc.group_percent}
+            aPct={aPct}
+            miss={sc.miss_count}
+            noShoots={sc.no_shoots}
+            procedurals={sc.procedurals}
+          />
+        );
+      })()}
     </div>
   );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -94,6 +94,9 @@ export interface CompetitorSummary {
   // Formula: 1 − (overall_rank − 1) / (N − 1) where N = non-DNF field competitors.
   // null for DNF or when N = 0.
   overall_percentile: number | null;
+  // Run quality classification based on HF% vs group leader, A%, and penalty counts.
+  // null when there is insufficient data or the run is DNF.
+  stageClassification: StageClassification | null;
 }
 
 export interface StageComparison {
@@ -114,6 +117,11 @@ export interface StageComparison {
   stageDifficultyLabel: string;       // human-readable label: easy/moderate/hard/very hard/brutal
   competitors: Record<number, CompetitorSummary>; // keyed by competitor_id
 }
+
+// Run quality classification for a single stage × competitor result.
+// Computed relative to the selected group's leader HF.
+// null = not enough data to classify (e.g. missing zone data, DNF).
+export type StageClassification = "solid" | "conservative" | "over-push" | "meltdown";
 
 // Percentage context for the comparison view.
 // "group"    — HF % relative to the group leader (selected competitors only)

--- a/tests/components/comparison-chart.test.tsx
+++ b/tests/components/comparison-chart.test.tsx
@@ -31,6 +31,7 @@ const baseStageCompetitors = {
     miss_count: null,
     no_shoots: null,
     procedurals: null,
+    stageClassification: null,
   },
   2: {
     competitor_id: 2,
@@ -54,6 +55,7 @@ const baseStageCompetitors = {
     miss_count: null,
     no_shoots: null,
     procedurals: null,
+    stageClassification: null,
   },
 };
 

--- a/tests/components/comparison-table.test.tsx
+++ b/tests/components/comparison-table.test.tsx
@@ -56,6 +56,7 @@ const baseData: CompareResponse = {
           miss_count: null,
           no_shoots: null,
           procedurals: null,
+          stageClassification: null,
         },
         2: {
           competitor_id: 2,
@@ -79,6 +80,7 @@ const baseData: CompareResponse = {
           miss_count: null,
           no_shoots: null,
           procedurals: null,
+          stageClassification: null,
         },
       },
     },

--- a/tests/components/radar-chart.test.tsx
+++ b/tests/components/radar-chart.test.tsx
@@ -62,6 +62,7 @@ const baseData: CompareResponse = {
           miss_count: null,
           no_shoots: null,
           procedurals: null,
+          stageClassification: null,
         },
         2: {
           competitor_id: 2,
@@ -85,6 +86,7 @@ const baseData: CompareResponse = {
           miss_count: null,
           no_shoots: null,
           procedurals: null,
+          stageClassification: null,
         },
       },
     },

--- a/tests/components/scatter-chart.test.tsx
+++ b/tests/components/scatter-chart.test.tsx
@@ -62,6 +62,7 @@ const baseData: CompareResponse = {
           miss_count: null,
           no_shoots: null,
           procedurals: null,
+          stageClassification: null,
         },
         2: {
           competitor_id: 2,
@@ -85,6 +86,7 @@ const baseData: CompareResponse = {
           miss_count: null,
           no_shoots: null,
           procedurals: null,
+          stageClassification: null,
         },
       },
     },

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -51,9 +51,9 @@ const MOCK_COMPARE: CompareResponse = {
       stageDifficultyLevel: 3,
       stageDifficultyLabel: "hard",
       competitors: {
-        100: { competitor_id: 100, points: 72, hit_factor: 5.02, time: 14.34, group_rank: 2, group_percent: 87.6, div_rank: 1, div_percent: 100, overall_rank: 2, overall_percent: 87.6, overall_percentile: 0.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },
-        200: { competitor_id: 200, points: 76, hit_factor: 5.63, time: 13.49, group_rank: 2, group_percent: 98.3, div_rank: 1, div_percent: 100, overall_rank: 2, overall_percent: 98.3, overall_percentile: 0.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },
-        300: { competitor_id: 300, points: 76, hit_factor: 5.73, time: 13.26, group_rank: 1, group_percent: 100,  div_rank: 1, div_percent: 100, overall_rank: 1, overall_percent: 100,  overall_percentile: 1.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },
+        100: { competitor_id: 100, points: 72, hit_factor: 5.02, time: 14.34, group_rank: 2, group_percent: 87.6, div_rank: 1, div_percent: 100, overall_rank: 2, overall_percent: 87.6, overall_percentile: 0.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
+        200: { competitor_id: 200, points: 76, hit_factor: 5.63, time: 13.49, group_rank: 2, group_percent: 98.3, div_rank: 1, div_percent: 100, overall_rank: 2, overall_percent: 98.3, overall_percentile: 0.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
+        300: { competitor_id: 300, points: 76, hit_factor: 5.73, time: 13.26, group_rank: 1, group_percent: 100,  div_rank: 1, div_percent: 100, overall_rank: 1, overall_percent: 100,  overall_percentile: 1.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
       },
     },
     {
@@ -69,9 +69,9 @@ const MOCK_COMPARE: CompareResponse = {
       stageDifficultyLevel: 3,
       stageDifficultyLabel: "hard",
       competitors: {
-        100: { competitor_id: 100, points: 26, hit_factor: 1.30, time: 20.0,  group_rank: 3, group_percent: 35.8, div_rank: 2, div_percent: 35.8, overall_rank: 3, overall_percent: 35.8, overall_percentile: 0.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },
-        200: { competitor_id: 200, points: 58, hit_factor: 3.63, time: 15.98, group_rank: 1, group_percent: 100,  div_rank: 1, div_percent: 100,  overall_rank: 1, overall_percent: 100,  overall_percentile: 1.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },
-        300: { competitor_id: 300, points: 54, hit_factor: 3.16, time: 17.09, group_rank: 2, group_percent: 87.1, div_rank: 1, div_percent: 100,  overall_rank: 2, overall_percent: 87.1, overall_percentile: 0.5, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },
+        100: { competitor_id: 100, points: 26, hit_factor: 1.30, time: 20.0,  group_rank: 3, group_percent: 35.8, div_rank: 2, div_percent: 35.8, overall_rank: 3, overall_percent: 35.8, overall_percentile: 0.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
+        200: { competitor_id: 200, points: 58, hit_factor: 3.63, time: 15.98, group_rank: 1, group_percent: 100,  div_rank: 1, div_percent: 100,  overall_rank: 1, overall_percent: 100,  overall_percentile: 1.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
+        300: { competitor_id: 300, points: 54, hit_factor: 3.16, time: 17.09, group_rank: 2, group_percent: 87.1, div_rank: 1, div_percent: 100,  overall_rank: 2, overall_percent: 87.1, overall_percentile: 0.5, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
       },
     },
     {
@@ -87,9 +87,9 @@ const MOCK_COMPARE: CompareResponse = {
       stageDifficultyLevel: 3,
       stageDifficultyLabel: "hard",
       competitors: {
-        100: { competitor_id: 100, points: null, hit_factor: null, time: null, group_rank: null, group_percent: null, div_rank: null, div_percent: null, overall_rank: null, overall_percent: null, overall_percentile: null, dq: false, zeroed: false, dnf: true, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },
-        200: { competitor_id: 200, points: null, hit_factor: null, time: null, group_rank: null, group_percent: null, div_rank: null, div_percent: null, overall_rank: null, overall_percent: null, overall_percentile: null, dq: false, zeroed: false, dnf: true, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },
-        300: { competitor_id: 300, points: null, hit_factor: null, time: null, group_rank: null, group_percent: null, div_rank: null, div_percent: null, overall_rank: null, overall_percent: null, overall_percentile: null, dq: false, zeroed: false, dnf: true, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null },
+        100: { competitor_id: 100, points: null, hit_factor: null, time: null, group_rank: null, group_percent: null, div_rank: null, div_percent: null, overall_rank: null, overall_percent: null, overall_percentile: null, dq: false, zeroed: false, dnf: true, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
+        200: { competitor_id: 200, points: null, hit_factor: null, time: null, group_rank: null, group_percent: null, div_rank: null, div_percent: null, overall_rank: null, overall_percent: null, overall_percentile: null, dq: false, zeroed: false, dnf: true, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
+        300: { competitor_id: 300, points: null, hit_factor: null, time: null, group_rank: null, group_percent: null, div_rank: null, div_percent: null, overall_rank: null, overall_percent: null, overall_percentile: null, dq: false, zeroed: false, dnf: true, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
       },
     },
   ],

--- a/tests/unit/compare-logic.test.ts
+++ b/tests/unit/compare-logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeGroupRankings, computePenaltyStats, assignDifficulty, computePercentile, computeCompetitorPPS, computeFieldPPSDistribution, type RawScorecard } from "@/app/api/compare/logic";
+import { computeGroupRankings, computePenaltyStats, assignDifficulty, computePercentile, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
 import type { CompetitorInfo } from "@/lib/types";
 
 const competitors: CompetitorInfo[] = [
@@ -1025,5 +1025,212 @@ describe("computeFieldPPSDistribution", () => {
     const dist = computeFieldPPSDistribution(scorecards);
     expect(dist.fieldMedian).toBeCloseTo(8.0, 5);
     expect(dist.fieldCount).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyStageRun — per-stage run quality classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Helper: build args for classifyStageRun with sensible defaults.
+ * groupPercent defaults to 100 (group leader), fully clean A-zone run.
+ */
+function classify(overrides: {
+  groupPercent?: number | null;
+  aHits?: number | null;
+  cHits?: number | null;
+  dHits?: number | null;
+  missCount?: number | null;
+  noShoots?: number | null;
+  procedurals?: number | null;
+}) {
+  return classifyStageRun(
+    overrides.groupPercent ?? 100,
+    overrides.aHits ?? 10,
+    overrides.cHits ?? 0,
+    overrides.dHits ?? 0,
+    overrides.missCount ?? 0,
+    overrides.noShoots ?? 0,
+    overrides.procedurals ?? 0
+  );
+}
+
+describe("classifyStageRun — Solid", () => {
+  it("classifies as solid at exactly SOLID_HF_PCT with no penalties", () => {
+    expect(classify({ groupPercent: STAGE_CLASS_THRESHOLDS.SOLID_HF_PCT })).toBe("solid");
+  });
+
+  it("classifies as solid above SOLID_HF_PCT with no penalties", () => {
+    expect(classify({ groupPercent: 100 })).toBe("solid");
+  });
+
+  it("does NOT classify as solid if HF% is just below threshold", () => {
+    expect(classify({ groupPercent: STAGE_CLASS_THRESHOLDS.SOLID_HF_PCT - 0.1 })).not.toBe("solid");
+  });
+
+  it("does NOT classify as solid if there is a miss (penalty)", () => {
+    expect(classify({ groupPercent: 100, missCount: 1 })).not.toBe("solid");
+  });
+
+  it("does NOT classify as solid if there is a no-shoot", () => {
+    expect(classify({ groupPercent: 100, noShoots: 1 })).not.toBe("solid");
+  });
+});
+
+describe("classifyStageRun — Conservative", () => {
+  it("classifies as conservative at CONSERVATIVE_HF_PCT_MIN with no penalties and high A%", () => {
+    // 10 A-hits, 0 others → A% = 100 > 90
+    expect(classify({ groupPercent: STAGE_CLASS_THRESHOLDS.CONSERVATIVE_HF_PCT_MIN })).toBe("conservative");
+  });
+
+  it("classifies as conservative in the 85–95 % range when A% > 90", () => {
+    // 10 A, 0 C/D/miss → A% 100
+    expect(classify({ groupPercent: 90 })).toBe("conservative");
+  });
+
+  it("does NOT classify as conservative if A% ≤ 90 %", () => {
+    // 9 A, 1 C → A% = 9/10 = 90 — not strictly above 90
+    const result = classifyStageRun(90, 9, 1, 0, 0, 0, 0);
+    expect(result).not.toBe("conservative");
+  });
+
+  it("does NOT classify as conservative if there are penalties", () => {
+    expect(classify({ groupPercent: 90, missCount: 1 })).not.toBe("conservative");
+  });
+
+  it("does NOT classify as conservative if HF% >= SOLID_HF_PCT (Solid wins)", () => {
+    // 96 % → Solid, not Conservative
+    expect(classify({ groupPercent: 96 })).toBe("solid");
+  });
+
+  it("does NOT classify as conservative if HF% < CONSERVATIVE_HF_PCT_MIN", () => {
+    expect(classify({ groupPercent: 84, noShoots: 0, missCount: 0 })).not.toBe("conservative");
+  });
+});
+
+describe("classifyStageRun — Over-push", () => {
+  it("classifies as over-push when HF% < 85, penalised, A% < 85", () => {
+    // 5 A, 1 miss → A% = 5/6 ≈ 83 % < 85. 1 miss < MELTDOWN_MISS_NS threshold (2).
+    const result = classifyStageRun(80, 5, 0, 0, 1, 0, 0);
+    expect(result).toBe("over-push");
+  });
+
+  it("does NOT classify as over-push if no penalties", () => {
+    expect(classify({ groupPercent: 80 })).not.toBe("over-push");
+  });
+
+  it("does NOT classify as over-push if A% >= 85", () => {
+    // 9 A, 1 miss → A% = 9/10 = 90 ≥ 85
+    const result = classifyStageRun(80, 9, 0, 0, 1, 0, 0);
+    expect(result).not.toBe("over-push");
+  });
+
+  it("does NOT classify as over-push if HF% >= OVERPUSH_HF_PCT", () => {
+    // HF% exactly at threshold: classified differently
+    const result = classifyStageRun(85, 7, 0, 0, 1, 0, 0);
+    expect(result).not.toBe("over-push");
+  });
+});
+
+describe("classifyStageRun — Meltdown", () => {
+  it("classifies as meltdown when HF% < 70", () => {
+    expect(classify({ groupPercent: 69 })).toBe("meltdown");
+  });
+
+  it("classifies as meltdown at exactly HF% = 69.9 (< 70)", () => {
+    expect(classify({ groupPercent: 69.9 })).toBe("meltdown");
+  });
+
+  it("does NOT classify as meltdown at HF% = 70 with no other triggers", () => {
+    // 70 % is NOT < 70, and no other meltdown conditions → not meltdown
+    expect(classify({ groupPercent: 70 })).not.toBe("meltdown");
+  });
+
+  it("classifies as meltdown with exactly 2 miss+NS even at high HF%", () => {
+    // 2 misses → meltdown regardless of good HF%
+    expect(classify({ groupPercent: 98, missCount: 2 })).toBe("meltdown");
+  });
+
+  it("classifies as meltdown with 1 miss + 1 no-shoot (total 2)", () => {
+    expect(classify({ groupPercent: 98, missCount: 1, noShoots: 1 })).toBe("meltdown");
+  });
+
+  it("does NOT classify as meltdown with only 1 miss (below MELTDOWN_MISS_NS threshold)", () => {
+    // 1 miss alone doesn't trigger meltdown on HF% or miss count
+    // (unless HF% is already below 70 or proc > 0)
+    expect(classify({ groupPercent: 90, missCount: 1 })).not.toBe("meltdown");
+  });
+
+  it("classifies as meltdown with any procedural penalty", () => {
+    expect(classify({ groupPercent: 98, procedurals: 1 })).toBe("meltdown");
+  });
+
+  it("meltdown takes priority over other categories", () => {
+    // HF% < 70 but otherwise would look like Conservative
+    expect(classify({ groupPercent: 65, missCount: 0, noShoots: 0, procedurals: 0 })).toBe("meltdown");
+  });
+});
+
+describe("classifyStageRun — null / edge cases", () => {
+  it("returns null when groupPercent is null", () => {
+    expect(classifyStageRun(null, 10, 0, 0, 0, 0, 0)).toBeNull();
+  });
+
+  it("returns null when run does not match any bucket", () => {
+    // HF% = 88, 1 miss → not meltdown (< 2 miss, no proc), not solid (miss),
+    // not conservative (miss), not over-push (HF% ≥ 85)
+    const result = classifyStageRun(88, 9, 0, 0, 1, 0, 0);
+    expect(result).toBeNull();
+  });
+});
+
+describe("classifyStageRun — integration via computeGroupRankings", () => {
+  it("stores stageClassification on CompetitorSummary", () => {
+    // Alice is the group leader (100 %) with clean A-zone → Solid
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 5.0, a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    expect(result[0].competitors[1].stageClassification).toBe("solid");
+  });
+
+  it("DNF competitor has null stageClassification", () => {
+    const scorecards = [
+      makeCard(1, 1, { dnf: true }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    expect(result[0].competitors[1].stageClassification).toBeNull();
+  });
+
+  it("all four classifications are reachable", () => {
+    // Stage 1: Alice leads (HF 10, clean A-zone) → Solid
+    // Stage 1: Bob at 90%, clean, high A% → Conservative
+    // Stage 1: Charlie at 80%, 1 miss+no-shoot, poor A% → over-push? No...
+    //   Actually need miss/ns for Over-push AND HF < 85 AND A% < 85
+    // Let me construct them per-stage instead (one stage per classification)
+    const scorecards = [
+      // Stage 1 — Solid: Alice leads (100%), clean, all A
+      makeCard(1, 1, { hit_factor: 5.0, a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0 }),
+      // Stage 2 — Conservative: Alice at 90%, clean, high A%
+      makeCard(1, 2, { hit_factor: 4.5, a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0 }),
+      makeCard(2, 2, { hit_factor: 5.0, a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0 }),
+      // Stage 3 — Over-push: Alice at 80%, 1 miss, A% = 4/5 = 80 % < 85
+      makeCard(1, 3, { hit_factor: 4.0, a_hits: 4, c_hits: 0, d_hits: 0, miss_count: 1, no_shoots: 0, procedurals: 0 }),
+      makeCard(2, 3, { hit_factor: 5.0, a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0 }),
+      // Stage 4 — Meltdown: Alice at 60%, 0 penalties
+      makeCard(1, 4, { hit_factor: 3.0, a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0 }),
+      makeCard(2, 4, { hit_factor: 5.0, a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0], competitors[1]]);
+    const s1 = result.find((s) => s.stage_num === 1)!;
+    const s2 = result.find((s) => s.stage_num === 2)!;
+    const s3 = result.find((s) => s.stage_num === 3)!;
+    const s4 = result.find((s) => s.stage_num === 4)!;
+
+    expect(s1.competitors[1].stageClassification).toBe("solid");       // 100%, no penalties
+    expect(s2.competitors[1].stageClassification).toBe("conservative"); // 90%, no penalties, all A
+    expect(s3.competitors[1].stageClassification).toBe("over-push");    // 80%, 1 miss, 40% A
+    expect(s4.competitors[1].stageClassification).toBe("meltdown");     // 60% HF
   });
 });

--- a/tests/unit/hf-percent-utils.test.ts
+++ b/tests/unit/hf-percent-utils.test.ts
@@ -30,6 +30,7 @@ function makeStage(
       miss_count: 0,
       no_shoots: 0,
       procedurals: 0,
+      stageClassification: null,
       ...overrides,
     };
   }

--- a/tests/unit/scatter-utils.test.ts
+++ b/tests/unit/scatter-utils.test.ts
@@ -130,6 +130,7 @@ function makeStage(overrides: StageOverrides = {}): StageComparison {
         miss_count: null,
         no_shoots: null,
         procedurals: null,
+        stageClassification: null,
       },
     },
   };
@@ -237,6 +238,7 @@ describe("buildScatterData", () => {
           miss_count: null,
           no_shoots: null,
           procedurals: null,
+          stageClassification: null,
         },
         2: {
           competitor_id: 2,
@@ -260,6 +262,7 @@ describe("buildScatterData", () => {
           miss_count: null,
           no_shoots: null,
           procedurals: null,
+          stageClassification: null,
         },
       },
     };


### PR DESCRIPTION
## Summary

- Adds per-stage run quality classification (Solid / Conservative / Over-push / Meltdown) computed inside `computeGroupRankings()` and displayed as a colored dot + shaped icon badge in each stage cell
- Compact icon+count summary row in each competitor's header chip shows the match-level pattern at a glance (e.g. ✓4 🛡3 ⚡2 🔥1) with a tooltip spelling out full labels
- All thresholds centralised in `STAGE_CLASS_THRESHOLDS` for easy adjustment

## Classification logic (priority order)

| Label | Criteria |
|---|---|
| **Meltdown** | HF% < 70 % **or** ≥ 2 miss/NS **or** any procedural — checked first |
| **Solid** | HF% ≥ 95 %, penalty-free |
| **Conservative** | HF% 85–95 %, penalty-free, A% > 90 % |
| **Over-push** | HF% < 85 %, penalised, A% < 85 % |
| *(null)* | Edge cases that don't fit any bucket |

## WCAG compliance

Color is paired with a distinct icon shape for each classification (CheckCircle2 / Shield / Zap / Flame), satisfying the color-not-sole-differentiator requirement.

## Test plan

- [x] 25 new unit tests — all four buckets reachable, priority rules, null edge cases, end-to-end via `computeGroupRankings`
- [x] Existing test fixtures updated with `stageClassification: null`
- [x] `pnpm typecheck && pnpm test` — 297/297 pass, zero errors/warnings
- [x] `pnpm lint` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)