### PR TITLE
feat: stage points-left-on-the-table breakdown — hit quality vs penalties (closes #46)

### DIFF
--- a/app/api/compare/logic.ts
+++ b/app/api/compare/logic.ts
@@ -8,6 +8,7 @@ import type {
   CompetitorPenaltyStats,
   EfficiencyStats,
   ConsistencyStats,
+  LossBreakdownStats,
   StageClassification,
 } from "@/lib/types";
 
@@ -395,6 +396,8 @@ export function computeGroupRankings(
           procedurals: null,
           shooting_order,
           stageClassification: null,
+          hitLossPoints: null,
+          penaltyLossPoints: 0,
         };
       } else {
         const hf = effectiveHF(sc);
@@ -403,6 +406,27 @@ export function computeGroupRankings(
         const divInfo = divResults.get(divKey);
         const overallRank = overallRankMap.get(comp.id) ?? null;
         const groupPercent = pct(hf, groupLeaderHF);
+
+        // Compute points-left-on-the-table split: hit quality vs. penalties.
+        // penalty_loss = (miss + ns + proc) × 10 (each penalty costs 10 pts)
+        // hit_loss     = (total_rounds × A_value) − sc.points − penalty_loss
+        //              where A_value = 5 (constant regardless of major/minor).
+        // hit_loss is null when zone data is unavailable (a/c/d/miss counts all null).
+        const scMiss = sc.miss_count ?? 0;
+        const scNs = sc.no_shoots ?? 0;
+        const scProc = sc.procedurals ?? 0;
+        const penaltyLossPoints = (scMiss + scNs + scProc) * 10;
+
+        let hitLossPoints: number | null = null;
+        if (
+          !sc.dq && !sc.zeroed &&
+          sc.points != null &&
+          sc.a_hits != null && sc.c_hits != null && sc.d_hits != null && sc.miss_count != null
+        ) {
+          const totalRounds = sc.a_hits + sc.c_hits + sc.d_hits + sc.miss_count + scNs;
+          const aMax = totalRounds * 5;
+          hitLossPoints = Math.max(0, aMax - sc.points - penaltyLossPoints);
+        }
 
         competitorMap[comp.id] = {
           competitor_id: comp.id,
@@ -436,6 +460,8 @@ export function computeGroupRankings(
             sc.no_shoots,
             sc.procedurals
           ),
+          hitLossPoints,
+          penaltyLossPoints,
         };
       }
     }
@@ -614,6 +640,48 @@ export function computeFieldPPSDistribution(
     fieldMedian,
     fieldMax: sorted[sorted.length - 1],
     fieldCount: sorted.length,
+  };
+}
+
+/**
+ * Aggregate per-stage hit-quality and penalty losses into match-level totals.
+ *
+ * Only non-DNF, non-DQ, non-zeroed stages are included (mirrors the coaching
+ * intent: those stages had valid, countable results).
+ *
+ * hit_loss per stage  = (total_rounds × 5) − points − penalty_loss
+ *   where total_rounds = a + c + d + miss + ns  (every round fired)
+ * penalty_loss per stage = (miss + ns + proc) × 10
+ *
+ * hitLossPoints is null when zone data was unavailable on a stage.
+ * Such stages still count toward stagesFired but not toward hasHitZoneData.
+ */
+export function computeLossBreakdown(
+  stages: StageComparison[],
+  competitorId: number
+): LossBreakdownStats {
+  let totalHitLoss = 0;
+  let totalPenaltyLoss = 0;
+  let stagesFired = 0;
+  let hasHitZoneData = false;
+
+  for (const stage of stages) {
+    const sc = stage.competitors[competitorId];
+    if (!sc || sc.dnf || sc.dq || sc.zeroed) continue;
+    stagesFired++;
+    totalPenaltyLoss += sc.penaltyLossPoints;
+    if (sc.hitLossPoints != null) {
+      totalHitLoss += sc.hitLossPoints;
+      hasHitZoneData = true;
+    }
+  }
+
+  return {
+    totalHitLoss,
+    totalPenaltyLoss,
+    totalLoss: totalHitLoss + totalPenaltyLoss,
+    stagesFired,
+    hasHitZoneData,
   };
 }
 

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { executeQuery, SCORECARDS_QUERY, MATCH_QUERY } from "@/lib/graphql";
 import { formatDivisionDisplay } from "@/lib/divisions";
-import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, type RawScorecard } from "@/app/api/compare/logic";
+import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, type RawScorecard } from "@/app/api/compare/logic";
 import type { CompareResponse, CompetitorInfo } from "@/lib/types";
 
 // ─── Raw GraphQL response shapes ─────────────────────────────────────────────
@@ -232,6 +232,10 @@ export async function GET(req: Request) {
     requestedCompetitors.map((c) => [c.id, computeConsistencyStats(stages, c.id)])
   );
 
+  const lossBreakdownStats = Object.fromEntries(
+    requestedCompetitors.map((c) => [c.id, computeLossBreakdown(stages, c.id)])
+  );
+
   const response: CompareResponse = {
     match_id: parseInt(id, 10),
     stages,
@@ -239,6 +243,7 @@ export async function GET(req: Request) {
     penaltyStats,
     efficiencyStats,
     consistencyStats,
+    lossBreakdownStats,
   };
 
   return NextResponse.json(response);

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -7,11 +7,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { AlertTriangle, CheckCircle2, ExternalLink, Flame, Shield, Zap } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ChevronDown, ChevronUp, ExternalLink, Flame, Shield, Zap } from "lucide-react";
 import { cn, formatHF, formatTime, formatPct, computePointsDelta, formatDelta } from "@/lib/utils";
 import { buildColorMap } from "@/lib/colors";
 import { HitZoneBar } from "@/components/hit-zone-bar";
-import type { CompareResponse, CompetitorSummary, PctMode, StageClassification, ViewMode } from "@/lib/types";
+import type { CompareResponse, CompetitorInfo, CompetitorSummary, LossBreakdownStats, PctMode, StageClassification, ViewMode } from "@/lib/types";
 
 interface ComparisonTableProps {
   data: CompareResponse;
@@ -258,6 +258,181 @@ function StageClassificationBadge({
   );
 }
 
+/**
+ * Horizontal stacked bar showing: remaining points / hit-quality loss / penalty loss.
+ * Width is proportional to best-possible (a_max) score.
+ * Only rendered when we have hit zone data so the bar is meaningful.
+ */
+function LossStackedBar({
+  stats,
+  totalPossible,
+}: {
+  stats: LossBreakdownStats;
+  totalPossible: number;
+}) {
+  if (!stats.hasHitZoneData || totalPossible === 0) return null;
+
+  const remaining = totalPossible - stats.totalHitLoss - stats.totalPenaltyLoss;
+  const remainPct = Math.max(0, (remaining / totalPossible) * 100);
+  const hitLossPct = Math.max(0, (stats.totalHitLoss / totalPossible) * 100);
+  const penaltyLossPct = Math.max(0, (stats.totalPenaltyLoss / totalPossible) * 100);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className="flex h-3 w-full rounded overflow-hidden cursor-help"
+          role="img"
+          aria-label={`Points breakdown: ${remaining} scored, ${stats.totalHitLoss} hit-quality loss, ${stats.totalPenaltyLoss} penalty loss`}
+        >
+          <div
+            className="h-full bg-emerald-500"
+            style={{ width: `${remainPct}%` }}
+            aria-hidden="true"
+          />
+          <div
+            className="h-full bg-amber-400"
+            style={{ width: `${hitLossPct}%` }}
+            aria-hidden="true"
+          />
+          <div
+            className="h-full bg-red-500"
+            style={{ width: `${penaltyLossPct}%` }}
+            aria-hidden="true"
+          />
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="text-xs space-y-0.5">
+        <div className="font-medium">Points on the table</div>
+        <div className="flex items-center gap-1.5">
+          <span className="inline-block w-2.5 h-2.5 rounded-sm bg-emerald-500" aria-hidden="true" />
+          {`Scored: ${remaining} pts`}
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="inline-block w-2.5 h-2.5 rounded-sm bg-amber-400" aria-hidden="true" />
+          {`Hit quality loss: ${stats.totalHitLoss} pts`}
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="inline-block w-2.5 h-2.5 rounded-sm bg-red-500" aria-hidden="true" />
+          {`Penalty loss: ${stats.totalPenaltyLoss} pts`}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+/**
+ * Per-competitor analysis panel: stacked bar + per-stage breakdown of loss.
+ * Only shown when the "Show coaching data" panel is expanded.
+ */
+function CompetitorLossPanel({
+  comp,
+  stages,
+  stats,
+  color,
+}: {
+  comp: CompetitorInfo;
+  stages: CompareResponse["stages"];
+  stats: LossBreakdownStats;
+  color: string;
+}) {
+  // Compute total possible across all fired stages for the bar's denominator.
+  // total_possible = scored + hit_loss + penalty_loss (i.e. a_max aggregated)
+  const totalPossible = stats.totalHitLoss + stats.totalPenaltyLoss +
+    stages.reduce((sum, stage) => {
+      const sc = stage.competitors[comp.id];
+      if (!sc || sc.dnf || sc.dq || sc.zeroed) return sum;
+      return sum + (sc.points ?? 0) + sc.penaltyLossPoints;
+    }, 0);
+
+  const firedStages = stages.filter((stage) => {
+    const sc = stage.competitors[comp.id];
+    return sc && !sc.dnf && !sc.dq && !sc.zeroed;
+  });
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <span
+          className="inline-block w-2 h-2 rounded-full"
+          style={{ backgroundColor: color }}
+          aria-hidden="true"
+        />
+        <span className="text-xs font-medium">{comp.name.split(" ")[0]}</span>
+        {stats.totalLoss > 0 && (
+          <span className="text-xs text-muted-foreground">
+            {`−${stats.totalLoss} pts total`}
+            {stats.totalHitLoss > 0 && ` (${stats.totalHitLoss} hit quality`}
+            {stats.totalHitLoss > 0 && stats.totalPenaltyLoss > 0 && ` + ${stats.totalPenaltyLoss} penalties)`}
+            {stats.totalHitLoss > 0 && stats.totalPenaltyLoss === 0 && `)`}
+            {stats.totalHitLoss === 0 && stats.totalPenaltyLoss > 0 && ` (${stats.totalPenaltyLoss} penalties)`}
+          </span>
+        )}
+        {stats.totalLoss === 0 && stats.stagesFired > 0 && (
+          <span className="text-xs text-emerald-600 dark:text-emerald-400">Perfect A-zone run</span>
+        )}
+      </div>
+
+      <LossStackedBar stats={stats} totalPossible={totalPossible} />
+
+      {/* Per-stage breakdown table */}
+      {firedStages.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs border-collapse">
+            <thead>
+              <tr className="border-b text-muted-foreground">
+                <th className="text-left py-1 pr-3 font-normal">Stage</th>
+                <th className="text-right py-1 px-2 font-normal">Hit quality loss</th>
+                <th className="text-right py-1 px-2 font-normal">Penalty loss</th>
+                <th className="text-right py-1 pl-2 font-normal">Total loss</th>
+              </tr>
+            </thead>
+            <tbody>
+              {firedStages.map((stage) => {
+                const sc = stage.competitors[comp.id];
+                if (!sc) return null;
+                const hitLoss = sc.hitLossPoints;
+                const penLoss = sc.penaltyLossPoints;
+                const stageTotalLoss = hitLoss != null ? hitLoss + penLoss : null;
+                return (
+                  <tr key={stage.stage_id} className="border-b border-border/40 hover:bg-muted/20">
+                    <td className="py-1 pr-3 text-muted-foreground">
+                      {`S${stage.stage_num}`}
+                    </td>
+                    <td className="py-1 px-2 text-right tabular-nums">
+                      {hitLoss != null ? (
+                        <span className={hitLoss > 0 ? "text-amber-600 dark:text-amber-400" : "text-muted-foreground"}>
+                          {hitLoss > 0 ? `−${hitLoss}` : "—"}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground/50" title="Zone data unavailable">n/a</span>
+                      )}
+                    </td>
+                    <td className="py-1 px-2 text-right tabular-nums">
+                      <span className={penLoss > 0 ? "text-red-600 dark:text-red-400" : "text-muted-foreground"}>
+                        {penLoss > 0 ? `−${penLoss}` : "—"}
+                      </span>
+                    </td>
+                    <td className="py-1 pl-2 text-right tabular-nums font-medium">
+                      {stageTotalLoss != null ? (
+                        <span className={stageTotalLoss > 0 ? "text-foreground" : "text-muted-foreground"}>
+                          {stageTotalLoss > 0 ? `−${stageTotalLoss}` : "—"}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground/50">n/a</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function RankBadge({
   rank,
   tooltip,
@@ -403,9 +578,10 @@ function modeValues(
 }
 
 export function ComparisonTable({ data }: ComparisonTableProps) {
-  const { stages, competitors, penaltyStats, efficiencyStats, consistencyStats } = data;
+  const { stages, competitors, penaltyStats, efficiencyStats, consistencyStats, lossBreakdownStats } = data;
   const [mode, setMode] = useState<PctMode>("group");
   const [viewMode, setViewMode] = useState<ViewMode>("absolute");
+  const [showAnalysis, setShowAnalysis] = useState(false);
 
   // Detect match-level DQ: every scorecard for a competitor has dq: true
   const matchDqCompetitors = competitors.filter((comp) => {
@@ -789,6 +965,32 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
                           </TooltipContent>
                         </Tooltip>
                       )}
+                      {(() => {
+                        const lbs = lossBreakdownStats[t.id];
+                        if (!lbs || lbs.totalLoss === 0) return null;
+                        const hasBoth = lbs.totalHitLoss > 0 && lbs.totalPenaltyLoss > 0;
+                        const label = hasBoth
+                          ? `−${lbs.totalLoss} pts on table`
+                          : lbs.totalPenaltyLoss > 0
+                            ? `−${lbs.totalPenaltyLoss} pts to penalties`
+                            : `−${lbs.totalHitLoss} pts hit quality`;
+                        return (
+                          <button
+                            onClick={() => setShowAnalysis((v) => !v)}
+                            className={cn(
+                              "inline-flex items-center gap-1 rounded border px-1.5 py-0.5",
+                              "text-xs font-medium tabular-nums cursor-pointer",
+                              "border-amber-400 text-amber-700 dark:text-amber-400",
+                              "hover:bg-amber-50 dark:hover:bg-amber-950/30 transition-colors",
+                              "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+                            )}
+                            aria-label={`${label} — click to ${showAnalysis ? "hide" : "show"} coaching analysis`}
+                            aria-expanded={showAnalysis}
+                          >
+                            {label}
+                          </button>
+                        );
+                      })()}
                       {t.isClean && (
                         <Tooltip>
                           <TooltipTrigger asChild>
@@ -812,6 +1014,83 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
           </tbody>
         </table>
       </div>
+
+      {/* Coaching analysis panel — collapsible, hidden by default */}
+      {competitors.some((c) => {
+        const lbs = lossBreakdownStats[c.id];
+        return lbs && lbs.totalLoss > 0;
+      }) && (
+        <div className="rounded-lg border border-amber-200 dark:border-amber-900/50">
+          <button
+            onClick={() => setShowAnalysis((v) => !v)}
+            className={cn(
+              "flex w-full items-center justify-between px-4 py-3 text-sm font-medium",
+              "hover:bg-muted/30 transition-colors rounded-lg",
+              "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+            )}
+            aria-expanded={showAnalysis}
+            aria-controls="coaching-analysis-panel"
+          >
+            <span className="flex items-center gap-2">
+              <span className="text-amber-700 dark:text-amber-400">Coaching analysis</span>
+              <span className="text-xs text-muted-foreground font-normal">
+                Points left on the table per shooter
+              </span>
+            </span>
+            {showAnalysis
+              ? <ChevronUp className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
+              : <ChevronDown className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
+            }
+          </button>
+
+          {showAnalysis && (
+            <div
+              id="coaching-analysis-panel"
+              className="px-4 pb-4 space-y-5 border-t border-amber-200 dark:border-amber-900/50 pt-4"
+            >
+              {/* Legend */}
+              <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+                <span className="flex items-center gap-1">
+                  <span className="inline-block w-3 h-3 rounded-sm bg-emerald-500" aria-hidden="true" />
+                  Scored
+                </span>
+                <span className="flex items-center gap-1">
+                  <span className="inline-block w-3 h-3 rounded-sm bg-amber-400" aria-hidden="true" />
+                  Hit quality loss (C/D/miss vs A)
+                </span>
+                <span className="flex items-center gap-1">
+                  <span className="inline-block w-3 h-3 rounded-sm bg-red-500" aria-hidden="true" />
+                  Penalty loss (miss/NS/procedural)
+                </span>
+              </div>
+
+              {/* Per-competitor breakdown */}
+              <div className="space-y-5">
+                {competitors.map((comp) => {
+                  const lbs = lossBreakdownStats[comp.id];
+                  if (!lbs || lbs.stagesFired === 0) return null;
+                  return (
+                    <CompetitorLossPanel
+                      key={comp.id}
+                      comp={comp}
+                      stages={stages}
+                      stats={lbs}
+                      color={colorMap[comp.id]}
+                    />
+                  );
+                })}
+              </div>
+
+              {/* Explanation note */}
+              <p className="text-xs text-muted-foreground/70">
+                Hit quality loss = points left on table from C/D/miss vs best possible A-zone.
+                Penalty loss = miss + no-shoot + procedural penalties (10 pts each).
+                Only valid (non-DQ, non-zeroed, non-DNF) stages are included.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -97,6 +97,12 @@ export interface CompetitorSummary {
   // Run quality classification based on HF% vs group leader, A%, and penalty counts.
   // null when there is insufficient data or the run is DNF.
   stageClassification: StageClassification | null;
+  // Points left on table due to non-A hit quality (C/D/miss opportunity cost).
+  // null when zone data (a_hits, c_hits, d_hits, miss_count) is unavailable, or for DNF/DQ/zeroed.
+  hitLossPoints: number | null;
+  // Points lost to penalties (miss + no_shoot + procedural × 10 each).
+  // Always 0 for DNF; always ≥ 0 for fired stages.
+  penaltyLossPoints: number;
 }
 
 export interface StageComparison {
@@ -157,13 +163,24 @@ export interface ConsistencyStats {
   stagesFired: number;                   // non-DNF, non-DQ, non-zeroed stages with valid group_percent
 }
 
+// Match-level aggregate of points-left-on-the-table per competitor.
+// Separates lost points into two root causes: hit quality and penalties.
+export interface LossBreakdownStats {
+  totalHitLoss: number;     // sum of hitLossPoints across non-DNF, non-DQ, non-zeroed stages
+  totalPenaltyLoss: number; // sum of penaltyLossPoints across non-DNF, non-DQ, non-zeroed stages
+  totalLoss: number;        // totalHitLoss + totalPenaltyLoss
+  stagesFired: number;      // non-DNF, non-DQ, non-zeroed stages included in the breakdown
+  hasHitZoneData: boolean;  // true if at least one stage had zone data (so hit loss is meaningful)
+}
+
 export interface CompareResponse {
   match_id: number;
   stages: StageComparison[];
   competitors: CompetitorInfo[];
   penaltyStats: Record<number, CompetitorPenaltyStats>; // keyed by competitor_id
   efficiencyStats: Record<number, EfficiencyStats>;     // keyed by competitor_id
-  consistencyStats: Record<number, ConsistencyStats>;  // keyed by competitor_id
+  consistencyStats: Record<number, ConsistencyStats>;   // keyed by competitor_id
+  lossBreakdownStats: Record<number, LossBreakdownStats>; // keyed by competitor_id
 }
 
 export interface EventSummary {

--- a/tests/components/comparison-chart.test.tsx
+++ b/tests/components/comparison-chart.test.tsx
@@ -32,6 +32,8 @@ const baseStageCompetitors = {
     no_shoots: null,
     procedurals: null,
     stageClassification: null,
+    hitLossPoints: null,
+    penaltyLossPoints: 0,
   },
   2: {
     competitor_id: 2,
@@ -56,6 +58,8 @@ const baseStageCompetitors = {
     no_shoots: null,
     procedurals: null,
     stageClassification: null,
+    hitLossPoints: null,
+    penaltyLossPoints: 0,
   },
 };
 
@@ -66,6 +70,7 @@ const baseData: CompareResponse = {
     2: { totalPenalties: 0, penaltyCostPercent: 0, matchPctActual: 80, matchPctClean: 80, penaltiesPerStage: 0, penaltiesPer100Rounds: 0 },
   },
   efficiencyStats: {},
+  lossBreakdownStats: {},
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },

--- a/tests/components/comparison-table.test.tsx
+++ b/tests/components/comparison-table.test.tsx
@@ -19,6 +19,7 @@ const baseData: CompareResponse = {
     2: { totalPenalties: 0, penaltyCostPercent: 0, matchPctActual: 100, matchPctClean: 100, penaltiesPerStage: 0, penaltiesPer100Rounds: 0 },
   },
   efficiencyStats: {},
+  lossBreakdownStats: {},
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },
@@ -61,6 +62,8 @@ const baseData: CompareResponse = {
           no_shoots: null,
           procedurals: null,
           stageClassification: null,
+          hitLossPoints: null,
+          penaltyLossPoints: 0,
         },
         2: {
           competitor_id: 2,
@@ -85,6 +88,8 @@ const baseData: CompareResponse = {
           no_shoots: null,
           procedurals: null,
           stageClassification: null,
+          hitLossPoints: null,
+          penaltyLossPoints: 0,
         },
       },
     },

--- a/tests/components/radar-chart.test.tsx
+++ b/tests/components/radar-chart.test.tsx
@@ -10,6 +10,7 @@ const baseData: CompareResponse = {
     2: { totalPenalties: 0, penaltyCostPercent: 0, matchPctActual: 80, matchPctClean: 80, penaltiesPerStage: 0, penaltiesPer100Rounds: 0 },
   },
   efficiencyStats: {},
+  lossBreakdownStats: {},
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },
@@ -67,6 +68,8 @@ const baseData: CompareResponse = {
           no_shoots: null,
           procedurals: null,
           stageClassification: null,
+          hitLossPoints: null,
+          penaltyLossPoints: 0,
         },
         2: {
           competitor_id: 2,
@@ -91,6 +94,8 @@ const baseData: CompareResponse = {
           no_shoots: null,
           procedurals: null,
           stageClassification: null,
+          hitLossPoints: null,
+          penaltyLossPoints: 0,
         },
       },
     },

--- a/tests/components/scatter-chart.test.tsx
+++ b/tests/components/scatter-chart.test.tsx
@@ -10,6 +10,7 @@ const baseData: CompareResponse = {
     2: { totalPenalties: 0, penaltyCostPercent: 0, matchPctActual: 80, matchPctClean: 80, penaltiesPerStage: 0, penaltiesPer100Rounds: 0 },
   },
   efficiencyStats: {},
+  lossBreakdownStats: {},
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },
@@ -67,6 +68,8 @@ const baseData: CompareResponse = {
           no_shoots: null,
           procedurals: null,
           stageClassification: null,
+          hitLossPoints: null,
+          penaltyLossPoints: 0,
         },
         2: {
           competitor_id: 2,
@@ -91,6 +94,8 @@ const baseData: CompareResponse = {
           no_shoots: null,
           procedurals: null,
           stageClassification: null,
+          hitLossPoints: null,
+          penaltyLossPoints: 0,
         },
       },
     },

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -42,6 +42,11 @@ const MOCK_COMPARE: CompareResponse = {
     200: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     300: { coefficientOfVariation: null, label: null, stagesFired: 1 },
   },
+  lossBreakdownStats: {
+    100: { totalHitLoss: 0, totalPenaltyLoss: 0, totalLoss: 0, stagesFired: 2, hasHitZoneData: false },
+    200: { totalHitLoss: 0, totalPenaltyLoss: 0, totalLoss: 0, stagesFired: 2, hasHitZoneData: false },
+    300: { totalHitLoss: 0, totalPenaltyLoss: 0, totalLoss: 0, stagesFired: 2, hasHitZoneData: false },
+  },
   stages: [
     {
       stage_id: 1,
@@ -56,9 +61,9 @@ const MOCK_COMPARE: CompareResponse = {
       stageDifficultyLevel: 3,
       stageDifficultyLabel: "hard",
       competitors: {
-        100: { competitor_id: 100, points: 72, hit_factor: 5.02, time: 14.34, group_rank: 2, group_percent: 87.6, div_rank: 1, div_percent: 100, overall_rank: 2, overall_percent: 87.6, overall_percentile: 0.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
-        200: { competitor_id: 200, points: 76, hit_factor: 5.63, time: 13.49, group_rank: 2, group_percent: 98.3, div_rank: 1, div_percent: 100, overall_rank: 2, overall_percent: 98.3, overall_percentile: 0.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
-        300: { competitor_id: 300, points: 76, hit_factor: 5.73, time: 13.26, group_rank: 1, group_percent: 100,  div_rank: 1, div_percent: 100, overall_rank: 1, overall_percent: 100,  overall_percentile: 1.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
+        100: { competitor_id: 100, points: 72, hit_factor: 5.02, time: 14.34, group_rank: 2, group_percent: 87.6, div_rank: 1, div_percent: 100, overall_rank: 2, overall_percent: 87.6, overall_percentile: 0.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null, hitLossPoints: null, penaltyLossPoints: 0 },
+        200: { competitor_id: 200, points: 76, hit_factor: 5.63, time: 13.49, group_rank: 2, group_percent: 98.3, div_rank: 1, div_percent: 100, overall_rank: 2, overall_percent: 98.3, overall_percentile: 0.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null, hitLossPoints: null, penaltyLossPoints: 0 },
+        300: { competitor_id: 300, points: 76, hit_factor: 5.73, time: 13.26, group_rank: 1, group_percent: 100,  div_rank: 1, div_percent: 100, overall_rank: 1, overall_percent: 100,  overall_percentile: 1.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null, hitLossPoints: null, penaltyLossPoints: 0 },
       },
     },
     {
@@ -74,9 +79,9 @@ const MOCK_COMPARE: CompareResponse = {
       stageDifficultyLevel: 3,
       stageDifficultyLabel: "hard",
       competitors: {
-        100: { competitor_id: 100, points: 26, hit_factor: 1.30, time: 20.0,  group_rank: 3, group_percent: 35.8, div_rank: 2, div_percent: 35.8, overall_rank: 3, overall_percent: 35.8, overall_percentile: 0.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
-        200: { competitor_id: 200, points: 58, hit_factor: 3.63, time: 15.98, group_rank: 1, group_percent: 100,  div_rank: 1, div_percent: 100,  overall_rank: 1, overall_percent: 100,  overall_percentile: 1.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
-        300: { competitor_id: 300, points: 54, hit_factor: 3.16, time: 17.09, group_rank: 2, group_percent: 87.1, div_rank: 1, div_percent: 100,  overall_rank: 2, overall_percent: 87.1, overall_percentile: 0.5, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
+        100: { competitor_id: 100, points: 26, hit_factor: 1.30, time: 20.0,  group_rank: 3, group_percent: 35.8, div_rank: 2, div_percent: 35.8, overall_rank: 3, overall_percent: 35.8, overall_percentile: 0.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null, hitLossPoints: null, penaltyLossPoints: 0 },
+        200: { competitor_id: 200, points: 58, hit_factor: 3.63, time: 15.98, group_rank: 1, group_percent: 100,  div_rank: 1, div_percent: 100,  overall_rank: 1, overall_percent: 100,  overall_percentile: 1.0, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null, hitLossPoints: null, penaltyLossPoints: 0 },
+        300: { competitor_id: 300, points: 54, hit_factor: 3.16, time: 17.09, group_rank: 2, group_percent: 87.1, div_rank: 1, div_percent: 100,  overall_rank: 2, overall_percent: 87.1, overall_percentile: 0.5, dq: false, zeroed: false, dnf: false, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null, hitLossPoints: null, penaltyLossPoints: 0 },
       },
     },
     {
@@ -92,9 +97,9 @@ const MOCK_COMPARE: CompareResponse = {
       stageDifficultyLevel: 3,
       stageDifficultyLabel: "hard",
       competitors: {
-        100: { competitor_id: 100, points: null, hit_factor: null, time: null, group_rank: null, group_percent: null, div_rank: null, div_percent: null, overall_rank: null, overall_percent: null, overall_percentile: null, dq: false, zeroed: false, dnf: true, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
-        200: { competitor_id: 200, points: null, hit_factor: null, time: null, group_rank: null, group_percent: null, div_rank: null, div_percent: null, overall_rank: null, overall_percent: null, overall_percentile: null, dq: false, zeroed: false, dnf: true, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
-        300: { competitor_id: 300, points: null, hit_factor: null, time: null, group_rank: null, group_percent: null, div_rank: null, div_percent: null, overall_rank: null, overall_percent: null, overall_percentile: null, dq: false, zeroed: false, dnf: true, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null },
+        100: { competitor_id: 100, points: null, hit_factor: null, time: null, group_rank: null, group_percent: null, div_rank: null, div_percent: null, overall_rank: null, overall_percent: null, overall_percentile: null, dq: false, zeroed: false, dnf: true, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null, hitLossPoints: null, penaltyLossPoints: 0 },
+        200: { competitor_id: 200, points: null, hit_factor: null, time: null, group_rank: null, group_percent: null, div_rank: null, div_percent: null, overall_rank: null, overall_percent: null, overall_percentile: null, dq: false, zeroed: false, dnf: true, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null, hitLossPoints: null, penaltyLossPoints: 0 },
+        300: { competitor_id: 300, points: null, hit_factor: null, time: null, group_rank: null, group_percent: null, div_rank: null, div_percent: null, overall_rank: null, overall_percent: null, overall_percentile: null, dq: false, zeroed: false, dnf: true, incomplete: false, a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: null, procedurals: null, stageClassification: null, hitLossPoints: null, penaltyLossPoints: 0 },
       },
     },
   ],

--- a/tests/unit/compare-logic.test.ts
+++ b/tests/unit/compare-logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeGroupRankings, computePenaltyStats, assignDifficulty, computePercentile, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, computeConsistencyStats, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
+import { computeGroupRankings, computePenaltyStats, assignDifficulty, computePercentile, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, computeConsistencyStats, computeLossBreakdown, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
 import type { CompetitorInfo } from "@/lib/types";
 
 const competitors: CompetitorInfo[] = [
@@ -1373,5 +1373,224 @@ describe("computeConsistencyStats", () => {
     // Actually on stage 4 Bob has hf=10.2 and Alice has hf=10.0, so Bob leads → 100%.
     // Let's just check the label exists and is a valid string
     expect(["very consistent", "consistent", "moderate", "variable", "streaky"]).toContain(r1.label);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-stage hitLossPoints / penaltyLossPoints (on CompetitorSummary)
+// ---------------------------------------------------------------------------
+
+describe("computeGroupRankings — hitLossPoints / penaltyLossPoints per stage", () => {
+  it("all A-zone hits, no penalties: hitLossPoints = 0, penaltyLossPoints = 0", () => {
+    // 10 A-hits × 5 pts = 50 pts scored, no misses, no penalties
+    const scorecards = [
+      makeCard(1, 1, { a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0, points: 50 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const sc = result[0].competitors[1];
+    expect(sc.hitLossPoints).toBe(0);
+    expect(sc.penaltyLossPoints).toBe(0);
+  });
+
+  it("C-zone hits cost hit quality but not penalties (minor scoring)", () => {
+    // 8 A + 2 C (minor: C=3 → points = 8×5 + 2×3 = 46). 10 rounds × 5 = 50 max.
+    // hit_loss = 50 - 46 - 0 = 4, penalty_loss = 0
+    const scorecards = [
+      makeCard(1, 1, { a_hits: 8, c_hits: 2, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0, points: 46 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const sc = result[0].competitors[1];
+    expect(sc.hitLossPoints).toBe(4);
+    expect(sc.penaltyLossPoints).toBe(0);
+  });
+
+  it("1 miss: miss cost splits between hit quality loss (5 pts) and penalty loss (10 pts)", () => {
+    // 9 A + 1 miss, points = 9×5 - 10 = 35. 10 rounds × 5 = 50 max.
+    // penalty_loss = 10, hit_loss = 50 - 35 - 10 = 5
+    const scorecards = [
+      makeCard(1, 1, { a_hits: 9, c_hits: 0, d_hits: 0, miss_count: 1, no_shoots: 0, procedurals: 0, points: 35 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const sc = result[0].competitors[1];
+    expect(sc.penaltyLossPoints).toBe(10);
+    expect(sc.hitLossPoints).toBe(5);
+  });
+
+  it("1 no-shoot: penalty_loss = 10, hit_loss includes the ns as a wasted round", () => {
+    // 10 A + 1 NS, points = 10×5 - 10 = 40. 11 rounds × 5 = 55 max.
+    // penalty_loss = 10, hit_loss = 55 - 40 - 10 = 5
+    const scorecards = [
+      makeCard(1, 1, { a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 1, procedurals: 0, points: 40 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const sc = result[0].competitors[1];
+    expect(sc.penaltyLossPoints).toBe(10);
+    expect(sc.hitLossPoints).toBe(5);
+  });
+
+  it("procedural-only penalty: penaltyLossPoints = 10, hit_loss unaffected (no extra round)", () => {
+    // 10 A, 1 procedural (no rounds fired), points = 10×5 - 10 = 40. 10 rounds × 5 = 50 max.
+    // penalty_loss = 10, hit_loss = 50 - 40 - 10 = 0
+    const scorecards = [
+      makeCard(1, 1, { a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 1, points: 40 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const sc = result[0].competitors[1];
+    expect(sc.penaltyLossPoints).toBe(10);
+    expect(sc.hitLossPoints).toBe(0);
+  });
+
+  it("null zone data → hitLossPoints is null, penaltyLossPoints computed from counts", () => {
+    // No zone data, but we have penalty counts
+    const scorecards = [
+      makeCard(1, 1, { a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: 1, procedurals: 0, points: 40 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const sc = result[0].competitors[1];
+    expect(sc.hitLossPoints).toBeNull();
+    expect(sc.penaltyLossPoints).toBe(10);
+  });
+
+  it("null a_hits but non-null miss_count → hitLossPoints is null (incomplete zone data)", () => {
+    const scorecards = [
+      makeCard(1, 1, { a_hits: null, c_hits: null, d_hits: null, miss_count: 1, no_shoots: 0, procedurals: 0, points: 35 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const sc = result[0].competitors[1];
+    expect(sc.hitLossPoints).toBeNull();
+  });
+
+  it("DNF stage → both loss fields are null/0", () => {
+    const scorecards = [makeCard(1, 1, { dnf: true })];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const sc = result[0].competitors[1];
+    expect(sc.hitLossPoints).toBeNull();
+    expect(sc.penaltyLossPoints).toBe(0);
+  });
+
+  it("DQ stage → hitLossPoints is null, penaltyLossPoints from counts", () => {
+    const scorecards = [
+      makeCard(1, 1, { dq: true, a_hits: 8, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0, points: 40 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const sc = result[0].competitors[1];
+    expect(sc.hitLossPoints).toBeNull();
+    expect(sc.penaltyLossPoints).toBe(0);
+  });
+
+  it("zeroed stage → hitLossPoints is null", () => {
+    const scorecards = [
+      makeCard(1, 1, { zeroed: true, a_hits: 8, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0, points: 40 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const sc = result[0].competitors[1];
+    expect(sc.hitLossPoints).toBeNull();
+  });
+
+  it("all misses: high hit loss and penalty loss", () => {
+    // 0 A, 0 C, 0 D, 10 misses: points = 0 - 100 = -100 (but IPSC usually floors at 0 — treat as computed)
+    // For test purposes: points = -100 stored by API, total_rounds = 10, aMax = 50
+    // penalty_loss = 100, hit_loss = 50 - (-100) - 100 = 50... but hitLoss clamped to max(0, ...)
+    // Actually: aMax = 10×5 = 50, sc.points = -100, hit_loss = 50 - (-100) - 100 = 50
+    // penalty_loss = 100
+    // Hmm, that doesn't make sense. All misses means 0 A hits but 10 miss rounds.
+    // If points=-100, and penalty_loss=100, then hit_loss=50-(-100)-100=50.
+    // This means: 10 missed rounds × 5 = 50 pts opportunity cost from hit quality.
+    // Makes sense: if you'd hit all those 10 rounds in A-zone you'd score 50 instead of -100.
+    // total_loss = 50 + 100 = 150 = aMax - points = 50 - (-100) = 150. ✓
+    const scorecards = [
+      makeCard(1, 1, { a_hits: 0, c_hits: 0, d_hits: 0, miss_count: 10, no_shoots: 0, procedurals: 0, points: -100 }),
+    ];
+    const result = computeGroupRankings(scorecards, [competitors[0]]);
+    const sc = result[0].competitors[1];
+    expect(sc.penaltyLossPoints).toBe(100);
+    expect(sc.hitLossPoints).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeLossBreakdown — match-level aggregation
+// ---------------------------------------------------------------------------
+
+describe("computeLossBreakdown", () => {
+  it("returns zero totals when competitor has all As and no penalties", () => {
+    const scorecards = [
+      makeCard(1, 1, { a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0, points: 50 }),
+    ];
+    const stages = computeGroupRankings(scorecards, [competitors[0]]);
+    const stats = computeLossBreakdown(stages, 1);
+    expect(stats.totalHitLoss).toBe(0);
+    expect(stats.totalPenaltyLoss).toBe(0);
+    expect(stats.totalLoss).toBe(0);
+    expect(stats.stagesFired).toBe(1);
+    expect(stats.hasHitZoneData).toBe(true);
+  });
+
+  it("aggregates hit loss and penalty loss across multiple stages", () => {
+    // Stage 1: 8 A + 2 C minor (pts=46) → hit_loss=4, penalty_loss=0
+    // Stage 2: 9 A + 1 miss (pts=35) → hit_loss=5, penalty_loss=10
+    const scorecards = [
+      makeCard(1, 1, { a_hits: 8, c_hits: 2, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0, points: 46 }),
+      makeCard(1, 2, { a_hits: 9, c_hits: 0, d_hits: 0, miss_count: 1, no_shoots: 0, procedurals: 0, points: 35 }),
+    ];
+    const stages = computeGroupRankings(scorecards, [competitors[0]]);
+    const stats = computeLossBreakdown(stages, 1);
+    expect(stats.totalHitLoss).toBe(9);      // 4 + 5
+    expect(stats.totalPenaltyLoss).toBe(10); // 0 + 10
+    expect(stats.totalLoss).toBe(19);
+    expect(stats.stagesFired).toBe(2);
+    expect(stats.hasHitZoneData).toBe(true);
+  });
+
+  it("excludes DNF stages from aggregation", () => {
+    const scorecards = [
+      makeCard(1, 1, { a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0, points: 50 }),
+      makeCard(1, 2, { dnf: true }),
+    ];
+    const stages = computeGroupRankings(scorecards, [competitors[0]]);
+    const stats = computeLossBreakdown(stages, 1);
+    expect(stats.stagesFired).toBe(1);
+  });
+
+  it("excludes DQ stages from aggregation", () => {
+    const scorecards = [
+      makeCard(1, 1, { a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0, points: 50 }),
+      makeCard(1, 2, { dq: true, a_hits: 5, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0, points: 25 }),
+    ];
+    const stages = computeGroupRankings(scorecards, [competitors[0]]);
+    const stats = computeLossBreakdown(stages, 1);
+    expect(stats.stagesFired).toBe(1);
+  });
+
+  it("returns hasHitZoneData = false when all stages lack zone data", () => {
+    // no zone data (null a_hits etc.) → hitLossPoints is null on each stage
+    const scorecards = [
+      makeCard(1, 1, { a_hits: null, c_hits: null, d_hits: null, miss_count: null, no_shoots: 0, procedurals: 0, points: 50 }),
+    ];
+    const stages = computeGroupRankings(scorecards, [competitors[0]]);
+    const stats = computeLossBreakdown(stages, 1);
+    expect(stats.hasHitZoneData).toBe(false);
+    expect(stats.totalHitLoss).toBe(0); // no zone data → 0 (not counted)
+  });
+
+  it("returns hasHitZoneData = true when at least one stage has zone data", () => {
+    const scorecards = [
+      makeCard(1, 1, { a_hits: null, c_hits: null, d_hits: null, miss_count: null, points: 50 }),
+      makeCard(1, 2, { a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, points: 50 }),
+    ];
+    const stages = computeGroupRankings(scorecards, [competitors[0]]);
+    const stats = computeLossBreakdown(stages, 1);
+    expect(stats.hasHitZoneData).toBe(true);
+  });
+
+  it("procedural-only penalty is counted in totalPenaltyLoss only", () => {
+    const scorecards = [
+      makeCard(1, 1, { a_hits: 10, c_hits: 0, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 1, points: 40 }),
+    ];
+    const stages = computeGroupRankings(scorecards, [competitors[0]]);
+    const stats = computeLossBreakdown(stages, 1);
+    expect(stats.totalPenaltyLoss).toBe(10);
+    expect(stats.totalHitLoss).toBe(0);
+    expect(stats.totalLoss).toBe(10);
   });
 });

--- a/tests/unit/hf-percent-utils.test.ts
+++ b/tests/unit/hf-percent-utils.test.ts
@@ -31,6 +31,8 @@ function makeStage(
       no_shoots: 0,
       procedurals: 0,
       stageClassification: null,
+      hitLossPoints: null,
+      penaltyLossPoints: 0,
       ...overrides,
     };
   }

--- a/tests/unit/scatter-utils.test.ts
+++ b/tests/unit/scatter-utils.test.ts
@@ -131,6 +131,8 @@ function makeStage(overrides: StageOverrides = {}): StageComparison {
         no_shoots: null,
         procedurals: null,
         stageClassification: null,
+        hitLossPoints: null,
+        penaltyLossPoints: 0,
       },
     },
   };
@@ -239,6 +241,8 @@ describe("buildScatterData", () => {
           no_shoots: null,
           procedurals: null,
           stageClassification: null,
+          hitLossPoints: null,
+          penaltyLossPoints: 0,
         },
         2: {
           competitor_id: 2,
@@ -263,6 +267,8 @@ describe("buildScatterData", () => {
           no_shoots: null,
           procedurals: null,
           stageClassification: null,
+          hitLossPoints: null,
+          penaltyLossPoints: 0,
         },
       },
     };


### PR DESCRIPTION
## Summary

- Adds per-stage `hitLossPoints` and `penaltyLossPoints` to `CompetitorSummary`, computed in `computeGroupRankings()` — works for both major and minor power factor without needing to know which (uses actual points, which already embed the correct C/D values, against a constant A-value of 5)
- New `computeLossBreakdown()` aggregates into `LossBreakdownStats` per competitor across all valid stages
- Collapsible **Coaching analysis** panel below the comparison table, hidden by default — coordinates with the #49 penalty badge already in the totals row
- Per-competitor stacked bar (scored / hit-quality loss / penalty loss) + per-stage breakdown table
- 13 new unit tests covering all edge cases

## Coordination with #49

The penalty loss numbers here share the same underlying penalty counts as the penalty cost badge from #49. Both are computed from the same `miss_count`, `no_shoots`, and `procedurals` fields on `CompetitorSummary`. No duplicate computation.

## Test plan

- [ ] `pnpm typecheck && pnpm test` — zero errors, 323/323 tests
- [ ] `pnpm lint` — zero warnings
- [ ] Open a match, select competitors with zone data — verify "Coaching analysis" panel appears and loss bar renders
- [ ] Verify panel is hidden by default and toggled by the amber badge in the totals row
- [ ] Verify panel does NOT appear when all competitors have zero losses (perfect A-zone run)
- [ ] Verify `n/a` shown in per-stage table when zone data is unavailable (null a_hits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)