### PR TITLE
feat: "one stage away" what-if analysis (closes #50)

### DIFF
--- a/app/api/compare/logic.ts
+++ b/app/api/compare/logic.ts
@@ -10,6 +10,8 @@ import type {
   ConsistencyStats,
   LossBreakdownStats,
   StageClassification,
+  SimResult,
+  WhatIfResult,
 } from "@/lib/types";
 
 export interface RawScorecard {
@@ -730,4 +732,159 @@ export function computeConsistencyStats(
   const cv = stdDev / mean;
 
   return { coefficientOfVariation: cv, label: ciLabel(cv), stagesFired };
+}
+
+/**
+ * Rank competitors by avg match % descending, handling ties (shared rank,
+ * next rank skips). Returns a Map<competitor_id, rank>.
+ */
+function rankByMatchPct(pctMap: Map<number, number>): Map<number, number> {
+  const sorted = [...pctMap.entries()].sort((a, b) => b[1] - a[1]);
+  const rankMap = new Map<number, number>();
+  let currentRank = 1;
+  for (let i = 0; i < sorted.length; i++) {
+    if (i > 0 && sorted[i][1] < sorted[i - 1][1]) currentRank = i + 1;
+    rankMap.set(sorted[i][0], currentRank);
+  }
+  return rankMap;
+}
+
+/**
+ * Simulate replacing each competitor's worst stage with two alternative
+ * performances and recompute match % and rank within the compared group.
+ *
+ * Scenarios:
+ *   1. Median replacement  — replace worst stage with the competitor's own
+ *      median group % across all other (non-worst) stages.
+ *   2. Second-worst replacement — replace worst stage with the competitor's
+ *      second-worst stage (conservative lower bound).
+ *
+ * Ranking is computed by substituting only the one competitor's simulated
+ * match % while all other competitors keep their actual match %.
+ *
+ * Returns null for competitors with fewer than 2 valid stages (not enough
+ * data to identify a "worst" vs a "rest").
+ *
+ * Valid stages: non-DNF, non-DQ, non-zeroed, with a non-null group_percent.
+ */
+export function simulateWithoutWorstStage(
+  stages: StageComparison[],
+  competitors: CompetitorInfo[]
+): Record<number, WhatIfResult | null> {
+  // Precompute each competitor's actual avg match % and total points.
+  const actualPcts = new Map<number, number>();
+  const actualTotalPoints = new Map<number, number>();
+
+  for (const comp of competitors) {
+    let pctSum = 0;
+    let pctCount = 0;
+    let totalPts = 0;
+    for (const stage of stages) {
+      const sc = stage.competitors[comp.id];
+      if (!sc) continue;
+      if (!sc.dnf) totalPts += sc.points ?? 0;
+      if (!sc.dnf && !sc.dq && !sc.zeroed && sc.group_percent != null) {
+        pctSum += sc.group_percent;
+        pctCount++;
+      }
+    }
+    actualPcts.set(comp.id, pctCount > 0 ? pctSum / pctCount : 0);
+    actualTotalPoints.set(comp.id, totalPts);
+  }
+
+  const actualRankMap = rankByMatchPct(actualPcts);
+
+  const result: Record<number, WhatIfResult | null> = {};
+
+  for (const comp of competitors) {
+    // Gather valid stages for this competitor.
+    const validStages: Array<{
+      stageNum: number;
+      groupPct: number;
+      actualPoints: number;
+      groupLeaderPoints: number | null;
+    }> = [];
+
+    for (const stage of stages) {
+      const sc = stage.competitors[comp.id];
+      if (!sc || sc.dnf || sc.dq || sc.zeroed || sc.group_percent == null) continue;
+      validStages.push({
+        stageNum: stage.stage_num,
+        groupPct: sc.group_percent,
+        actualPoints: sc.points ?? 0,
+        groupLeaderPoints: stage.group_leader_points,
+      });
+    }
+
+    if (validStages.length < 2) {
+      result[comp.id] = null;
+      continue;
+    }
+
+    // Sort ascending by group_percent (worst first); use stage_num as tiebreaker.
+    const sorted = [...validStages].sort(
+      (a, b) => a.groupPct - b.groupPct || a.stageNum - b.stageNum
+    );
+
+    const worstStage = sorted[0];
+    const remaining = sorted.slice(1); // all stages except the worst
+
+    // Median of remaining stages (sorted ascending already).
+    const remPcts = remaining.map((s) => s.groupPct); // already sorted ascending
+    const mid = Math.floor(remPcts.length / 2);
+    const medianPct =
+      remPcts.length % 2 === 0
+        ? (remPcts[mid - 1] + remPcts[mid]) / 2
+        : remPcts[mid];
+
+    // Second-worst = lowest of remaining (first in ascending sort).
+    const secondWorstPct = remaining[0].groupPct;
+
+    const actualMatchPct = actualPcts.get(comp.id) ?? 0;
+    const totalPts = actualTotalPoints.get(comp.id) ?? 0;
+    const pctSum = actualMatchPct * validStages.length;
+
+    function simulate(replacementPct: number): SimResult {
+      const simMatchPct =
+        (pctSum - worstStage.groupPct + replacementPct) / validStages.length;
+
+      // Estimate simulated points on the replaced stage via proportional scaling.
+      let simWorstPoints: number;
+      if (worstStage.groupLeaderPoints != null && worstStage.groupLeaderPoints > 0) {
+        simWorstPoints = (replacementPct / 100) * worstStage.groupLeaderPoints;
+      } else if (worstStage.groupPct > 0) {
+        simWorstPoints =
+          (replacementPct / worstStage.groupPct) * worstStage.actualPoints;
+      } else {
+        simWorstPoints = worstStage.actualPoints;
+      }
+
+      const simTotalPoints = Math.round(totalPts - worstStage.actualPoints + simWorstPoints);
+
+      // Rank: this competitor uses simulated pct; all others keep actual pct.
+      const simPcts = new Map<number, number>(actualPcts);
+      simPcts.set(comp.id, simMatchPct);
+      const simRankMap = rankByMatchPct(simPcts);
+
+      return {
+        replacementPct,
+        matchPct: simMatchPct,
+        totalPoints: simTotalPoints,
+        groupRank: simRankMap.get(comp.id) ?? 1,
+      };
+    }
+
+    result[comp.id] = {
+      competitorId: comp.id,
+      worstStageNum: worstStage.stageNum,
+      worstStageGroupPct: worstStage.groupPct,
+      actualMatchPct,
+      actualTotalPoints: totalPts,
+      actualGroupRank: actualRankMap.get(comp.id) ?? 1,
+      medianReplacement: simulate(medianPct),
+      secondWorstReplacement: simulate(secondWorstPct),
+    };
+  }
+
+  return result;
 }

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { executeQuery, SCORECARDS_QUERY, MATCH_QUERY } from "@/lib/graphql";
 import { formatDivisionDisplay } from "@/lib/divisions";
-import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, type RawScorecard } from "@/app/api/compare/logic";
+import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, type RawScorecard } from "@/app/api/compare/logic";
 import type { CompareResponse, CompetitorInfo } from "@/lib/types";
 
 // ─── Raw GraphQL response shapes ─────────────────────────────────────────────
@@ -236,6 +236,8 @@ export async function GET(req: Request) {
     requestedCompetitors.map((c) => [c.id, computeLossBreakdown(stages, c.id)])
   );
 
+  const whatIfStats = simulateWithoutWorstStage(stages, requestedCompetitors);
+
   const response: CompareResponse = {
     match_id: parseInt(id, 10),
     stages,
@@ -244,6 +246,7 @@ export async function GET(req: Request) {
     efficiencyStats,
     consistencyStats,
     lossBreakdownStats,
+    whatIfStats,
   };
 
   return NextResponse.json(response);

--- a/app/match/[ct]/[id]/page.tsx
+++ b/app/match/[ct]/[id]/page.tsx
@@ -231,7 +231,7 @@ export default function MatchPage() {
                     </span>
                   )}
                 </div>
-                <ComparisonTable data={compareQuery.data} />
+                <ComparisonTable data={compareQuery.data} scoringCompleted={match.scoring_completed} />
               </div>
 
               <div className="rounded-lg border p-4 space-y-3">

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -11,10 +11,11 @@ import { AlertTriangle, CheckCircle2, ChevronDown, ChevronUp, ExternalLink, Flam
 import { cn, formatHF, formatTime, formatPct, computePointsDelta, formatDelta } from "@/lib/utils";
 import { buildColorMap } from "@/lib/colors";
 import { HitZoneBar } from "@/components/hit-zone-bar";
-import type { CompareResponse, CompetitorInfo, CompetitorSummary, LossBreakdownStats, PctMode, StageClassification, ViewMode } from "@/lib/types";
+import type { CompareResponse, CompetitorInfo, CompetitorSummary, LossBreakdownStats, PctMode, StageClassification, ViewMode, WhatIfResult } from "@/lib/types";
 
 interface ComparisonTableProps {
   data: CompareResponse;
+  scoringCompleted: number;
 }
 
 /**
@@ -577,11 +578,12 @@ function modeValues(
   }
 }
 
-export function ComparisonTable({ data }: ComparisonTableProps) {
-  const { stages, competitors, penaltyStats, efficiencyStats, consistencyStats, lossBreakdownStats } = data;
+export function ComparisonTable({ data, scoringCompleted }: ComparisonTableProps) {
+  const { stages, competitors, penaltyStats, efficiencyStats, consistencyStats, lossBreakdownStats, whatIfStats } = data;
   const [mode, setMode] = useState<PctMode>("group");
   const [viewMode, setViewMode] = useState<ViewMode>("absolute");
   const [showAnalysis, setShowAnalysis] = useState(false);
+  const [showWhatIf, setShowWhatIf] = useState(false);
 
   // Detect match-level DQ: every scorecard for a competitor has dq: true
   const matchDqCompetitors = competitors.filter((comp) => {
@@ -1091,6 +1093,129 @@ export function ComparisonTable({ data }: ComparisonTableProps) {
           )}
         </div>
       )}
+
+      {/* What if? panel — only rendered when match is ≥ 80 % complete */}
+      {scoringCompleted >= 80 && competitors.some((c) => whatIfStats[c.id] != null) && (
+        <div className="rounded-lg border border-sky-200 dark:border-sky-900/50">
+          <button
+            onClick={() => setShowWhatIf((v) => !v)}
+            className={cn(
+              "flex w-full items-center justify-between px-4 py-3 text-sm font-medium",
+              "hover:bg-muted/30 transition-colors rounded-lg",
+              "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+            )}
+            aria-expanded={showWhatIf}
+            aria-controls="whatif-panel"
+          >
+            <span className="flex items-center gap-2">
+              <span className="text-sky-700 dark:text-sky-400">What if?</span>
+              <span className="text-xs text-muted-foreground font-normal">
+                One stage away
+              </span>
+            </span>
+            {showWhatIf
+              ? <ChevronUp className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
+              : <ChevronDown className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
+            }
+          </button>
+
+          {showWhatIf && (
+            <div
+              id="whatif-panel"
+              className="px-4 pb-4 space-y-4 border-t border-sky-200 dark:border-sky-900/50 pt-4"
+            >
+              <div className="space-y-5">
+                {competitors.map((comp) => {
+                  const wi = whatIfStats[comp.id];
+                  if (!wi) return null;
+                  const stageName =
+                    stages.find((s) => s.stage_num === wi.worstStageNum)?.stage_name ??
+                    `Stage ${wi.worstStageNum}`;
+                  return (
+                    <WhatIfCompetitorPanel
+                      key={comp.id}
+                      comp={comp}
+                      wi={wi}
+                      stageName={stageName}
+                      color={colorMap[comp.id]}
+                    />
+                  );
+                })}
+              </div>
+              <p className="text-xs text-muted-foreground/70">
+                Simulates replacing each competitor&apos;s worst stage (lowest group %) with
+                their median or second-worst stage performance. All other competitors keep
+                their actual scores.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WhatIfCompetitorPanel({
+  comp,
+  wi,
+  stageName,
+  color,
+}: {
+  comp: CompetitorInfo;
+  wi: WhatIfResult;
+  stageName: string;
+  color: string;
+}) {
+  const medianChange = wi.medianReplacement.groupRank - wi.actualGroupRank;
+  const secondWorstChange = wi.secondWorstReplacement.groupRank - wi.actualGroupRank;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-2">
+        <span
+          className="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0"
+          style={{ backgroundColor: color }}
+          aria-hidden="true"
+        />
+        <span className="text-sm font-medium">{comp.name}</span>
+      </div>
+      {/* Median replacement scenario */}
+      <p className="text-xs text-muted-foreground pl-4">
+        If {stageName} ({formatPct(wi.worstStageGroupPct)} group) had been at your
+        median ({formatPct(wi.medianReplacement.replacementPct)}%): match %{" "}
+        <span className="text-foreground font-medium">
+          {formatPct(wi.medianReplacement.matchPct)}
+        </span>{" "}
+        <span className="text-muted-foreground/70">
+          (vs actual {formatPct(wi.actualMatchPct)})
+        </span>
+        {" — "}rank{" "}
+        <span className="font-medium">{ordinal(wi.actualGroupRank)}</span>
+        {" "}
+        <span className={medianChange < 0 ? "text-emerald-600 dark:text-emerald-400 font-medium" : medianChange > 0 ? "text-red-600 dark:text-red-400 font-medium" : "text-muted-foreground"}>
+          →{" "}{ordinal(wi.medianReplacement.groupRank)}
+          {medianChange < 0 && " ↑"}
+          {medianChange > 0 && " ↓"}
+        </span>
+        {" "}in group.
+      </p>
+      {/* Second-worst replacement scenario */}
+      <p className="text-xs text-muted-foreground/75 pl-4">
+        Conservative (second-worst {formatPct(wi.secondWorstReplacement.replacementPct)}%): match %{" "}
+        <span className="font-medium text-muted-foreground">
+          {formatPct(wi.secondWorstReplacement.matchPct)}
+        </span>
+        {" — "}rank{" "}
+        <span className={cn(
+          "font-medium",
+          secondWorstChange < 0 ? "text-emerald-600 dark:text-emerald-400" : ""
+        )}>
+          {ordinal(wi.secondWorstReplacement.groupRank)}
+        </span>
+        {secondWorstChange < 0 && " ↑"}
+        {secondWorstChange > 0 && " ↓"}
+        {" "}in group.
+      </p>
     </div>
   );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -173,6 +173,28 @@ export interface LossBreakdownStats {
   hasHitZoneData: boolean;  // true if at least one stage had zone data (so hit loss is meaningful)
 }
 
+// Result of one what-if simulation scenario: replace the worst stage with
+// a substitute performance and see what the match outcome would have been.
+export interface SimResult {
+  replacementPct: number; // group % used as the substitute for the worst stage
+  matchPct: number;       // simulated avg group % after replacement
+  totalPoints: number;    // simulated total match points after replacement
+  groupRank: number;      // simulated rank within compared group (1-based)
+}
+
+// What-if analysis for one competitor.
+// null = fewer than 2 valid stages — no meaningful simulation is possible.
+export interface WhatIfResult {
+  competitorId: number;
+  worstStageNum: number;        // stage_num of the identified worst stage
+  worstStageGroupPct: number;   // actual group % on the worst stage
+  actualMatchPct: number;       // actual avg group % across all valid stages
+  actualTotalPoints: number;    // actual total match points
+  actualGroupRank: number;      // actual rank within compared group
+  medianReplacement: SimResult;       // scenario 1: replace worst with competitor's median
+  secondWorstReplacement: SimResult;  // scenario 2: replace worst with second-worst (lower bound)
+}
+
 export interface CompareResponse {
   match_id: number;
   stages: StageComparison[];
@@ -181,6 +203,7 @@ export interface CompareResponse {
   efficiencyStats: Record<number, EfficiencyStats>;     // keyed by competitor_id
   consistencyStats: Record<number, ConsistencyStats>;   // keyed by competitor_id
   lossBreakdownStats: Record<number, LossBreakdownStats>; // keyed by competitor_id
+  whatIfStats: Record<number, WhatIfResult | null>;     // keyed by competitor_id; null = not enough stages
 }
 
 export interface EventSummary {

--- a/tests/components/comparison-chart.test.tsx
+++ b/tests/components/comparison-chart.test.tsx
@@ -71,6 +71,7 @@ const baseData: CompareResponse = {
   },
   efficiencyStats: {},
   lossBreakdownStats: {},
+  whatIfStats: {},
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },

--- a/tests/components/comparison-table.test.tsx
+++ b/tests/components/comparison-table.test.tsx
@@ -20,6 +20,7 @@ const baseData: CompareResponse = {
   },
   efficiencyStats: {},
   lossBreakdownStats: {},
+  whatIfStats: {},
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },
@@ -98,18 +99,18 @@ const baseData: CompareResponse = {
 
 describe("ComparisonTable", () => {
   it("renders competitor names", () => {
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     expect(screen.getByText("Alice")).toBeInTheDocument();
     expect(screen.getByText("Bob")).toBeInTheDocument();
   });
 
   it("renders stage name", () => {
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     expect(screen.getByText("Stage One")).toBeInTheDocument();
   });
 
   it("renders hit factors as primary metric", () => {
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     expect(screen.getAllByText("5.02").length).toBeGreaterThan(0);
     expect(screen.getAllByText("5.63").length).toBeGreaterThan(0);
   });
@@ -132,7 +133,7 @@ describe("ComparisonTable", () => {
         },
       ],
     };
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     expect(screen.getByText("DNF")).toBeInTheDocument();
   });
 
@@ -149,7 +150,7 @@ describe("ComparisonTable", () => {
         },
       ],
     };
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     expect(screen.getAllByText("—").length).toBeGreaterThan(0);
   });
 
@@ -166,7 +167,7 @@ describe("ComparisonTable", () => {
         },
       ],
     };
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     expect(screen.getByText("DQ")).toBeInTheDocument();
   });
 
@@ -183,7 +184,7 @@ describe("ComparisonTable", () => {
         },
       ],
     };
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     expect(screen.getByRole("alert")).toBeInTheDocument();
     expect(screen.getByText("— Disqualified from match")).toBeInTheDocument();
   });
@@ -218,26 +219,26 @@ describe("ComparisonTable", () => {
         },
       ],
     };
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
   it("renders totals row with total points", () => {
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     expect(screen.getByText("Total pts")).toBeInTheDocument();
     expect(screen.getAllByText("72").length).toBeGreaterThan(0);
     expect(screen.getAllByText("76").length).toBeGreaterThan(0);
   });
 
   it("renders mode toggle buttons", () => {
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     expect(screen.getByText("Group")).toBeInTheDocument();
     expect(screen.getByText("Division")).toBeInTheDocument();
     expect(screen.getByText("Overall")).toBeInTheDocument();
   });
 
   it("renders SSI stage link when ssi_url is present", () => {
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     const link = screen.getByRole("link", { name: /stage one.*shootnscoreit/i });
     expect(link).toHaveAttribute("href", "https://shootnscoreit.com/event/stage/24/100/");
     expect(link).toHaveAttribute("target", "_blank");
@@ -248,7 +249,7 @@ describe("ComparisonTable", () => {
       ...baseData,
       stages: [{ ...baseData.stages[0], ssi_url: undefined }],
     };
-    renderWithProviders(<ComparisonTable data={dataNoUrl} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={dataNoUrl} />);
     expect(screen.queryByRole("link", { name: /stage one.*shootnscoreit/i })).not.toBeInTheDocument();
     expect(screen.getByText("Stage 1")).toBeInTheDocument();
   });
@@ -258,12 +259,12 @@ describe("ComparisonTable", () => {
       ...baseData,
       stages: [{ ...baseData.stages[0], min_rounds: 16, paper_targets: 8, steel_targets: 0 }],
     };
-    renderWithProviders(<ComparisonTable data={dataWithMeta} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={dataWithMeta} />);
     expect(screen.getByText("16 rds · 8 paper")).toBeInTheDocument();
   });
 
   it("omits metadata row when all optional fields are absent", () => {
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     expect(screen.queryByText(/rds/)).not.toBeInTheDocument();
   });
 });
@@ -292,7 +293,7 @@ describe("ComparisonTable — penalty badge", () => {
       { miss_count: 0, no_shoots: 0, procedurals: 0 },
       { miss_count: 0, no_shoots: 0, procedurals: 0 }
     );
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     expect(screen.queryByText(/\u2212\d+pts/)).not.toBeInTheDocument();
   });
 
@@ -302,7 +303,7 @@ describe("ComparisonTable — penalty badge", () => {
       { miss_count: 2, no_shoots: 1, procedurals: 0 },
       { miss_count: 0, no_shoots: 0, procedurals: 0 }
     );
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     expect(screen.getAllByText("\u221230pts").length).toBeGreaterThan(0);
   });
 
@@ -311,7 +312,7 @@ describe("ComparisonTable — penalty badge", () => {
       { miss_count: 0, no_shoots: 0, procedurals: 2 },
       { miss_count: 0, no_shoots: 0, procedurals: 0 }
     );
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     expect(screen.getAllByText("\u221220pts").length).toBeGreaterThan(0);
   });
 
@@ -320,7 +321,7 @@ describe("ComparisonTable — penalty badge", () => {
       { miss_count: 0, no_shoots: 0, procedurals: 0 },
       { miss_count: 0, no_shoots: 0, procedurals: 0 }
     );
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     expect(screen.getAllByText("✓ Clean").length).toBeGreaterThan(0);
   });
 
@@ -329,14 +330,14 @@ describe("ComparisonTable — penalty badge", () => {
       { miss_count: 1, no_shoots: 0, procedurals: 0 },
       { miss_count: 0, no_shoots: 0, procedurals: 0 }
     );
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     // Only competitor 2 (all zeros) should be clean
     expect(screen.getAllByText("✓ Clean").length).toBe(1);
   });
 
   it("does not show clean match indicator when penalty data is null (unknown)", () => {
     // baseData has all nulls — no penalty data available, so we can't confirm clean
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     expect(screen.queryByText("✓ Clean")).not.toBeInTheDocument();
   });
 
@@ -357,12 +358,12 @@ describe("ComparisonTable — penalty badge", () => {
         },
       ],
     };
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     expect(screen.getByText(/Penalty cost: −8\.5% match/)).toBeInTheDocument();
   });
 
   it("hides penalty cost badge in totals row when totalPenalties is zero", () => {
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     expect(screen.queryByText(/Penalty cost:/)).not.toBeInTheDocument();
   });
 });
@@ -381,14 +382,14 @@ describe("ComparisonTable — incomplete scorecard indicator", () => {
         },
       ],
     };
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     expect(
       screen.getByLabelText("Incomplete scorecard (rule 9.7.6.2)")
     ).toBeInTheDocument();
   });
 
   it("does not show incomplete indicator when incomplete=false", () => {
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     expect(
       screen.queryByLabelText("Incomplete scorecard (rule 9.7.6.2)")
     ).not.toBeInTheDocument();
@@ -397,19 +398,19 @@ describe("ComparisonTable — incomplete scorecard indicator", () => {
 
 describe("ComparisonTable — delta view mode", () => {
   it("renders Absolute and Delta toggle buttons", () => {
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     expect(screen.getByRole("button", { name: "Absolute" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Delta" })).toBeInTheDocument();
   });
 
   it("Absolute toggle is pressed by default", () => {
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     expect(screen.getByRole("button", { name: "Absolute" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: "Delta" })).toHaveAttribute("aria-pressed", "false");
   });
 
   it("switches to delta mode when Delta button is clicked", () => {
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     fireEvent.click(screen.getByRole("button", { name: "Delta" }));
     expect(screen.getByRole("button", { name: "Delta" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: "Absolute" })).toHaveAttribute("aria-pressed", "false");
@@ -417,14 +418,14 @@ describe("ComparisonTable — delta view mode", () => {
 
   it("shows delta value (leader has ±0.0 pts) in delta mode", () => {
     // Bob is the group leader (group_leader_points = 76, Bob.points = 76 → delta = 0)
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     fireEvent.click(screen.getByRole("button", { name: "Delta" }));
     expect(screen.getAllByText("±0.0 pts").length).toBeGreaterThan(0);
   });
 
   it("shows negative delta for the non-leader competitor in delta mode", () => {
     // Alice: points=72, leader=76 → delta = -4 → "−4.0 pts"
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     fireEvent.click(screen.getByRole("button", { name: "Delta" }));
     expect(screen.getAllByText("\u22124.0 pts").length).toBeGreaterThan(0);
   });
@@ -442,7 +443,7 @@ describe("ComparisonTable — delta view mode", () => {
         },
       ],
     };
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     fireEvent.click(screen.getByRole("button", { name: "Delta" }));
     expect(screen.getAllByText("—").length).toBeGreaterThan(0);
   });
@@ -460,7 +461,7 @@ describe("ComparisonTable — delta view mode", () => {
         },
       ],
     };
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     fireEvent.click(screen.getByRole("button", { name: "Delta" }));
     expect(screen.getByText("DNF")).toBeInTheDocument();
   });
@@ -478,20 +479,20 @@ describe("ComparisonTable — delta view mode", () => {
         },
       ],
     };
-    renderWithProviders(<ComparisonTable data={data} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
     fireEvent.click(screen.getByRole("button", { name: "Delta" }));
     expect(screen.getByText("DQ")).toBeInTheDocument();
   });
 
   it("totals row shows 'Total deficit' label in delta mode", () => {
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     fireEvent.click(screen.getByRole("button", { name: "Delta" }));
     expect(screen.getByText("Total deficit")).toBeInTheDocument();
   });
 
   it("totals row shows cumulative deficit for the non-leader in delta mode", () => {
     // Alice: -4 pts across the 1 stage → total deficit = "−4.0 pts"
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     fireEvent.click(screen.getByRole("button", { name: "Delta" }));
     // Leader shows ±0.0 pts, non-leader shows −4.0 pts (appears at least once each)
     expect(screen.getAllByText("±0.0 pts").length).toBeGreaterThanOrEqual(2); // per-stage + totals for leader
@@ -499,7 +500,7 @@ describe("ComparisonTable — delta view mode", () => {
   });
 
   it("hides % reference toggle in delta mode", () => {
-    renderWithProviders(<ComparisonTable data={baseData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     // % toggle visible in absolute mode
     expect(screen.getByText("% relative to:")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Delta" }));
@@ -521,7 +522,7 @@ describe("ComparisonTable — delta view mode", () => {
         },
       ],
     };
-    renderWithProviders(<ComparisonTable data={tieData} />);
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={tieData} />);
     fireEvent.click(screen.getByRole("button", { name: "Delta" }));
     // Both competitors show ±0.0 pts (per-stage); totals row also shows ±0.0 pts
     expect(screen.getAllByText("±0.0 pts").length).toBeGreaterThanOrEqual(2);

--- a/tests/components/radar-chart.test.tsx
+++ b/tests/components/radar-chart.test.tsx
@@ -11,6 +11,7 @@ const baseData: CompareResponse = {
   },
   efficiencyStats: {},
   lossBreakdownStats: {},
+  whatIfStats: {},
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },

--- a/tests/components/scatter-chart.test.tsx
+++ b/tests/components/scatter-chart.test.tsx
@@ -11,6 +11,7 @@ const baseData: CompareResponse = {
   },
   efficiencyStats: {},
   lossBreakdownStats: {},
+  whatIfStats: {},
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -47,6 +47,7 @@ const MOCK_COMPARE: CompareResponse = {
     200: { totalHitLoss: 0, totalPenaltyLoss: 0, totalLoss: 0, stagesFired: 2, hasHitZoneData: false },
     300: { totalHitLoss: 0, totalPenaltyLoss: 0, totalLoss: 0, stagesFired: 2, hasHitZoneData: false },
   },
+  whatIfStats: { 100: null, 200: null, 300: null },
   stages: [
     {
       stage_id: 1,

--- a/tests/unit/compare-logic.test.ts
+++ b/tests/unit/compare-logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeGroupRankings, computePenaltyStats, assignDifficulty, computePercentile, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, computeConsistencyStats, computeLossBreakdown, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
+import { computeGroupRankings, computePenaltyStats, assignDifficulty, computePercentile, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
 import type { CompetitorInfo } from "@/lib/types";
 
 const competitors: CompetitorInfo[] = [
@@ -1592,5 +1592,187 @@ describe("computeLossBreakdown", () => {
     expect(stats.totalPenaltyLoss).toBe(10);
     expect(stats.totalHitLoss).toBe(0);
     expect(stats.totalLoss).toBe(10);
+  });
+});
+
+describe("simulateWithoutWorstStage", () => {
+  it("returns null for a competitor with only one valid stage", () => {
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 4.0, points: 80 }),
+    ];
+    const stages = computeGroupRankings(scorecards, [competitors[0]]);
+    const result = simulateWithoutWorstStage(stages, [competitors[0]]);
+    expect(result[1]).toBeNull();
+  });
+
+  it("returns null for a competitor with all stages DNF", () => {
+    const scorecards = [
+      makeCard(1, 1, { dnf: true, hit_factor: null, points: null }),
+      makeCard(1, 2, { dnf: true, hit_factor: null, points: null }),
+    ];
+    const stages = computeGroupRankings(scorecards, [competitors[0]]);
+    const result = simulateWithoutWorstStage(stages, [competitors[0]]);
+    expect(result[1]).toBeNull();
+  });
+
+  it("identifies the worst stage (lowest group_percent)", () => {
+    // Stage 1: Alice 50%, Stage 2: Alice 90%, Stage 3: Alice 80%
+    // Leader on each stage has HF 5.0. Alice has HF 2.5 / 4.5 / 4.0
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 2.5, points: 50 }),  // 50% of leader
+      makeCard(2, 1, { hit_factor: 5.0, points: 100 }),  // leader
+      makeCard(1, 2, { hit_factor: 4.5, points: 90 }),  // 90% of leader
+      makeCard(2, 2, { hit_factor: 5.0, points: 100 }),  // leader
+      makeCard(1, 3, { hit_factor: 4.0, points: 80 }),  // 80% of leader
+      makeCard(2, 3, { hit_factor: 5.0, points: 100 }),  // leader
+    ];
+    const twoComps = [competitors[0], competitors[1]];
+    const stages = computeGroupRankings(scorecards, twoComps);
+    const result = simulateWithoutWorstStage(stages, twoComps);
+    const wi = result[1];
+    expect(wi).not.toBeNull();
+    expect(wi!.worstStageNum).toBe(1); // stage 1 has the lowest group_percent for Alice
+    expect(wi!.worstStageGroupPct).toBeCloseTo(50, 0);
+  });
+
+  it("computes median of remaining stages correctly", () => {
+    // Alice stages: 50% (worst), 80%, 90%
+    // Median of [80, 90] = 85
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 2.5, points: 50 }),
+      makeCard(2, 1, { hit_factor: 5.0, points: 100 }),
+      makeCard(1, 2, { hit_factor: 4.0, points: 80 }),
+      makeCard(2, 2, { hit_factor: 5.0, points: 100 }),
+      makeCard(1, 3, { hit_factor: 4.5, points: 90 }),
+      makeCard(2, 3, { hit_factor: 5.0, points: 100 }),
+    ];
+    const twoComps = [competitors[0], competitors[1]];
+    const stages = computeGroupRankings(scorecards, twoComps);
+    const result = simulateWithoutWorstStage(stages, twoComps);
+    const wi = result[1]!;
+    // Median of [80, 90] = 85
+    expect(wi.medianReplacement.replacementPct).toBeCloseTo(85, 1);
+    // Second-worst = 80 (lowest of remaining)
+    expect(wi.secondWorstReplacement.replacementPct).toBeCloseTo(80, 1);
+  });
+
+  it("computes simulated match % correctly", () => {
+    // Alice: stages 50%, 80%, 90% → actual avg = 73.33%
+    // With median (85%) replacing 50%: (73.33 * 3 - 50 + 85) / 3 = (220 - 50 + 85)/3 = 255/3 = 85
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 2.5, points: 50 }),
+      makeCard(2, 1, { hit_factor: 5.0, points: 100 }),
+      makeCard(1, 2, { hit_factor: 4.0, points: 80 }),
+      makeCard(2, 2, { hit_factor: 5.0, points: 100 }),
+      makeCard(1, 3, { hit_factor: 4.5, points: 90 }),
+      makeCard(2, 3, { hit_factor: 5.0, points: 100 }),
+    ];
+    const twoComps = [competitors[0], competitors[1]];
+    const stages = computeGroupRankings(scorecards, twoComps);
+    const result = simulateWithoutWorstStage(stages, twoComps);
+    const wi = result[1]!;
+    expect(wi.actualMatchPct).toBeCloseTo((50 + 80 + 90) / 3, 1);
+    expect(wi.medianReplacement.matchPct).toBeCloseTo(85, 1);
+  });
+
+  it("computes rank improvement when simulated pct surpasses another competitor", () => {
+    // Alice: stages 50%, 80%, 90% → avg ≈ 73.3%
+    // Bob:   stages 100%, 100%, 100% → avg = 100%  (always 1st, leader)
+    // Alice is 2nd. With median replacement (85%), Alice avg = 85% → still 2nd behind Bob (100%)
+    // With Charlie at 75%, Alice at 73.3% is 3rd; with 85% Alice moves to 2nd
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 2.5, points: 50 }),
+      makeCard(2, 1, { hit_factor: 5.0, points: 100 }),
+      makeCard(3, 1, { hit_factor: 3.75, points: 75 }),
+      makeCard(1, 2, { hit_factor: 4.0, points: 80 }),
+      makeCard(2, 2, { hit_factor: 5.0, points: 100 }),
+      makeCard(3, 2, { hit_factor: 3.75, points: 75 }),
+      makeCard(1, 3, { hit_factor: 4.5, points: 90 }),
+      makeCard(2, 3, { hit_factor: 5.0, points: 100 }),
+      makeCard(3, 3, { hit_factor: 3.75, points: 75 }),
+    ];
+    const stages = computeGroupRankings(scorecards, competitors);
+    const result = simulateWithoutWorstStage(stages, competitors);
+    const wi = result[1]!; // Alice
+    // Alice actual avg ≈ 73.3%, Charlie actual avg = 75% → Alice is 3rd
+    expect(wi.actualGroupRank).toBe(3);
+    // After median replacement (85%), Alice avg = 85% > Charlie (75%) → Alice moves to 2nd
+    expect(wi.medianReplacement.groupRank).toBe(2);
+  });
+
+  it("handles only two valid stages (median = second-worst)", () => {
+    // With only 2 stages, remaining has 1 stage → median = second-worst = that stage's pct
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 3.0, points: 60 }),
+      makeCard(2, 1, { hit_factor: 5.0, points: 100 }),
+      makeCard(1, 2, { hit_factor: 4.5, points: 90 }),
+      makeCard(2, 2, { hit_factor: 5.0, points: 100 }),
+    ];
+    const twoComps = [competitors[0], competitors[1]];
+    const stages = computeGroupRankings(scorecards, twoComps);
+    const result = simulateWithoutWorstStage(stages, twoComps);
+    const wi = result[1]!;
+    expect(wi).not.toBeNull();
+    // median == second-worst when only one remaining stage
+    expect(wi.medianReplacement.replacementPct).toBeCloseTo(
+      wi.secondWorstReplacement.replacementPct,
+      5
+    );
+  });
+
+  it("handles all stages equal (no improvement)", () => {
+    // All stages: Alice 80% of leader → worst = median = second-worst = 80%
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 4.0, points: 80 }),
+      makeCard(2, 1, { hit_factor: 5.0, points: 100 }),
+      makeCard(1, 2, { hit_factor: 4.0, points: 80 }),
+      makeCard(2, 2, { hit_factor: 5.0, points: 100 }),
+      makeCard(1, 3, { hit_factor: 4.0, points: 80 }),
+      makeCard(2, 3, { hit_factor: 5.0, points: 100 }),
+    ];
+    const twoComps = [competitors[0], competitors[1]];
+    const stages = computeGroupRankings(scorecards, twoComps);
+    const result = simulateWithoutWorstStage(stages, twoComps);
+    const wi = result[1]!;
+    // Replacement = same as actual worst → no change in matchPct or rank
+    expect(wi.medianReplacement.matchPct).toBeCloseTo(wi.actualMatchPct, 5);
+    expect(wi.medianReplacement.groupRank).toBe(wi.actualGroupRank);
+  });
+
+  it("uses stage_num as tiebreaker when two stages have the same worst group_percent", () => {
+    // Alice: stage 1 = 60%, stage 2 = 60%, stage 3 = 90%
+    // Both stage 1 and 2 are tied as worst → picks stage 1 (lower stage_num)
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 3.0, points: 60 }),
+      makeCard(2, 1, { hit_factor: 5.0, points: 100 }),
+      makeCard(1, 2, { hit_factor: 3.0, points: 60 }),
+      makeCard(2, 2, { hit_factor: 5.0, points: 100 }),
+      makeCard(1, 3, { hit_factor: 4.5, points: 90 }),
+      makeCard(2, 3, { hit_factor: 5.0, points: 100 }),
+    ];
+    const twoComps = [competitors[0], competitors[1]];
+    const stages = computeGroupRankings(scorecards, twoComps);
+    const result = simulateWithoutWorstStage(stages, twoComps);
+    const wi = result[1]!;
+    expect(wi.worstStageNum).toBe(1); // stage 1 wins tiebreak (lower stage_num)
+  });
+
+  it("excludes DNF/DQ/zeroed stages from consideration", () => {
+    // Alice: stage 1 = 80%, stage 2 = DNF (excluded), stage 3 = 90%
+    // Worst valid = stage 1 (80%), remaining = [stage 3 (90%)]
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 4.0, points: 80 }),
+      makeCard(2, 1, { hit_factor: 5.0, points: 100 }),
+      makeCard(1, 2, { dnf: true, hit_factor: null, points: null }),
+      makeCard(2, 2, { hit_factor: 5.0, points: 100 }),
+      makeCard(1, 3, { hit_factor: 4.5, points: 90 }),
+      makeCard(2, 3, { hit_factor: 5.0, points: 100 }),
+    ];
+    const twoComps = [competitors[0], competitors[1]];
+    const stages = computeGroupRankings(scorecards, twoComps);
+    const result = simulateWithoutWorstStage(stages, twoComps);
+    const wi = result[1]!;
+    expect(wi).not.toBeNull();
+    expect(wi.worstStageNum).toBe(1); // stage 2 DNF excluded, stage 1 (80%) is worst valid
   });
 });


### PR DESCRIPTION
## Summary

- Adds `simulateWithoutWorstStage()` pure function in `logic.ts` that identifies each competitor's worst stage (lowest group %) and simulates replacing it with two alternatives: their median stage performance and their second-worst stage (conservative lower bound)
- Extends `CompareResponse` with `whatIfStats` (new `WhatIfResult`/`SimResult` types in `lib/types.ts`); API route computes and returns it
- Adds a collapsible **"What if?"** panel to `ComparisonTable`, gated behind `scoringCompleted ≥ 80 %` — panel is not rendered at all during active matches
- Panel shows both scenarios per competitor with colour-coded rank change indicators (↑ green / ↓ red)

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — zero warnings
- [x] `pnpm test` — 333 tests pass (10 new unit tests for `simulateWithoutWorstStage`)
- [ ] Edge cases covered by unit tests: single stage → null, all DNF → null, all-equal stages, tied worst stages (stage_num tiebreaker), 2-stage case (median == second-worst), DNF/DQ/zeroed exclusion, rank improvement check
- [ ] Verify panel is hidden on a match with `scoring_completed < 80`
- [ ] Verify panel is collapsible and hidden by default on a completed match

🤖 Generated with [Claude Code](https://claude.com/claude-code)