### PR TITLE
fix: quadrant labels, WCAG accordion pattern, coaching panel naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,18 @@ This app is used courtside during live IPSC competitions — on a phone, outdoor
 - Images and icons must have `alt` text or `aria-hidden="true"` if decorative.
 - Use semantic HTML elements (`<button>`, `<nav>`, `<main>`, `<table>`, `<th scope>`, etc.)
   rather than `<div>` with click handlers.
+- **Accordion / disclosure pattern**: always use `<hN><button aria-expanded aria-controls>…</button></hN>`
+  — never nest a heading element inside a button (invalid HTML). Expanded panels should be
+  `<section role="region" aria-labelledby="button-id">` so screen readers can navigate them.
+- **No duplicate landmark names**: every `role="region"` must have a unique `aria-labelledby`
+  label. Two sections on the same page cannot share the same accessible name.
+
+## Chart info popovers
+Every chart section in `app/match/[ct]/[id]/page.tsx` has a `?` (`HelpCircle`) icon button
+that opens a `<Popover>` explaining the chart. **When adding a new chart section, always add
+a matching info popover.** When modifying what a chart shows, update its popover text to match.
+The popover should include: what the axes/axes represent, how to read the visual, and 1–2
+actionable interpretation tips. Keep language concise — max ~4 short paragraphs.
 
 ## Design System & Tailwind v4
 - Use **Tailwind v4** utility classes everywhere — no inline styles.

--- a/app/match/[ct]/[id]/page.tsx
+++ b/app/match/[ct]/[id]/page.tsx
@@ -358,28 +358,37 @@ export default function MatchPage() {
 
               {/* Coaching / analysis view — hidden by default (not for courtside use) */}
               <div className="rounded-lg border p-4 space-y-3">
-                <button
-                  type="button"
-                  onClick={() => setShowCoachingView((v) => !v)}
-                  className="flex w-full items-center justify-between text-left"
-                  aria-expanded={showCoachingView}
-                  aria-controls="coaching-view-panel"
-                >
-                  <div>
-                    <h2 className="font-semibold">Coaching analysis</h2>
-                    <p className="text-xs text-muted-foreground">
-                      Post-match aggregate view — not recommended during active shooting.
-                    </p>
-                  </div>
-                  {showCoachingView ? (
-                    <ChevronUp className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />
-                  ) : (
-                    <ChevronDown className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />
-                  )}
-                </button>
+                {/* WAI-ARIA accordion pattern: heading wraps the disclosure button */}
+                <h2 className="font-semibold text-base m-0 leading-none">
+                  <button
+                    type="button"
+                    id="coaching-view-heading"
+                    onClick={() => setShowCoachingView((v) => !v)}
+                    className="flex w-full items-center justify-between text-left gap-2"
+                    aria-expanded={showCoachingView}
+                    aria-controls="coaching-view-panel"
+                  >
+                    <span>
+                      Coaching analysis
+                      <span className="block text-xs font-normal text-muted-foreground mt-0.5">
+                        Post-match aggregate view — not recommended during active shooting.
+                      </span>
+                    </span>
+                    {showCoachingView ? (
+                      <ChevronUp className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />
+                    ) : (
+                      <ChevronDown className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />
+                    )}
+                  </button>
+                </h2>
 
                 {showCoachingView && (
-                  <div id="coaching-view-panel" className="space-y-6 pt-2">
+                  <section
+                    id="coaching-view-panel"
+                    role="region"
+                    aria-labelledby="coaching-view-heading"
+                    className="space-y-6 pt-2"
+                  >
                     <div className="space-y-2">
                       <div className="flex items-center gap-1.5">
                         <h3 className="text-sm font-semibold">Shooter style fingerprint</h3>
@@ -408,7 +417,7 @@ export default function MatchPage() {
                       </div>
                       <StyleFingerprintChart data={compareQuery.data} />
                     </div>
-                  </div>
+                  </section>
                 )}
               </div>
             </>

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -887,13 +887,14 @@ export function ComparisonTable({ data, scoringCompleted }: ComparisonTableProps
         </table>
       </div>
 
-      {/* Coaching analysis panel — collapsible, hidden by default */}
+      {/* Points on the table panel — collapsible, hidden by default */}
       {competitors.some((c) => {
         const lbs = lossBreakdownStats[c.id];
         return lbs && lbs.totalLoss > 0;
       }) && (
         <div className="rounded-lg border border-amber-200 dark:border-amber-900/50">
           <button
+            id="loss-breakdown-heading"
             onClick={() => setShowAnalysis((v) => !v)}
             className={cn(
               "flex w-full items-center justify-between px-4 py-3 text-sm font-medium",
@@ -901,12 +902,12 @@ export function ComparisonTable({ data, scoringCompleted }: ComparisonTableProps
               "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
             )}
             aria-expanded={showAnalysis}
-            aria-controls="coaching-analysis-panel"
+            aria-controls="loss-breakdown-panel"
           >
             <span className="flex items-center gap-2">
-              <span className="text-amber-700 dark:text-amber-400">Coaching analysis</span>
+              <span className="text-amber-700 dark:text-amber-400">Points on the table</span>
               <span className="text-xs text-muted-foreground font-normal">
-                Points left on the table per shooter
+                Hit quality vs. penalty losses per shooter
               </span>
             </span>
             {showAnalysis
@@ -916,8 +917,10 @@ export function ComparisonTable({ data, scoringCompleted }: ComparisonTableProps
           </button>
 
           {showAnalysis && (
-            <div
-              id="coaching-analysis-panel"
+            <section
+              id="loss-breakdown-panel"
+              role="region"
+              aria-labelledby="loss-breakdown-heading"
               className="px-4 pb-4 space-y-5 border-t border-amber-200 dark:border-amber-900/50 pt-4"
             >
               {/* Legend */}
@@ -959,7 +962,7 @@ export function ComparisonTable({ data, scoringCompleted }: ComparisonTableProps
                 Penalty loss = miss + no-shoot + procedural penalties (10 pts each).
                 Only valid (non-DQ, non-zeroed, non-DNF) stages are included.
               </p>
-            </div>
+            </section>
           )}
         </div>
       )}
@@ -968,6 +971,7 @@ export function ComparisonTable({ data, scoringCompleted }: ComparisonTableProps
       {scoringCompleted >= 80 && competitors.some((c) => whatIfStats[c.id] != null) && (
         <div className="rounded-lg border border-sky-200 dark:border-sky-900/50">
           <button
+            id="whatif-heading"
             onClick={() => setShowWhatIf((v) => !v)}
             className={cn(
               "flex w-full items-center justify-between px-4 py-3 text-sm font-medium",
@@ -990,8 +994,10 @@ export function ComparisonTable({ data, scoringCompleted }: ComparisonTableProps
           </button>
 
           {showWhatIf && (
-            <div
+            <section
               id="whatif-panel"
+              role="region"
+              aria-labelledby="whatif-heading"
               className="px-4 pb-4 space-y-4 border-t border-sky-200 dark:border-sky-900/50 pt-4"
             >
               <div className="space-y-5">
@@ -1017,7 +1023,7 @@ export function ComparisonTable({ data, scoringCompleted }: ComparisonTableProps
                 their median or second-worst stage performance. All other competitors keep
                 their actual scores.
               </p>
-            </div>
+            </section>
           )}
         </div>
       )}

--- a/components/style-fingerprint-chart.tsx
+++ b/components/style-fingerprint-chart.tsx
@@ -167,27 +167,37 @@ function QuadrantLabels({ fieldMedianX, fieldMedianY }: QuadrantLabelsProps) {
     fill: "var(--foreground)",
   };
 
-  const pad = 8;
+  // Centre each label in its quadrant rather than nudging from the crosshair.
+  // This keeps labels readable regardless of where the field-median crosshair falls.
+  const leftEdge  = plotArea.x;
+  const rightEdge = plotArea.x + plotArea.width;
+  const topEdge   = plotArea.y;
+  const botEdge   = plotArea.y + plotArea.height;
+
+  const qTopY = (topEdge  + crossY) / 2;
+  const qBotY = (crossY   + botEdge) / 2;
+  const qLeftX  = (leftEdge  + crossX) / 2;
+  const qRightX = (crossX    + rightEdge) / 2;
 
   return (
     <g aria-hidden="true">
       {/* Crosshair lines */}
       <line
-        x1={crossX} y1={plotArea.y}
-        x2={crossX} y2={plotArea.y + plotArea.height}
+        x1={crossX} y1={topEdge}
+        x2={crossX} y2={botEdge}
         style={{ stroke: "var(--border)", strokeDasharray: "4 3", strokeWidth: 1, opacity: 0.6 }}
       />
       <line
-        x1={plotArea.x} y1={crossY}
-        x2={plotArea.x + plotArea.width} y2={crossY}
+        x1={leftEdge} y1={crossY}
+        x2={rightEdge} y2={crossY}
         style={{ stroke: "var(--border)", strokeDasharray: "4 3", strokeWidth: 1, opacity: 0.6 }}
       />
 
-      {/* Quadrant labels */}
-      <text x={crossX + pad} y={plotArea.y + pad + 11} textAnchor="start" style={labelStyle}>IDEAL</text>
-      <text x={crossX - pad} y={plotArea.y + pad + 11} textAnchor="end" style={labelStyle}>FAST / SLOPPY</text>
-      <text x={crossX + pad} y={plotArea.y + plotArea.height - pad} textAnchor="start" style={labelStyle}>CONSERVATIVE</text>
-      <text x={crossX - pad} y={plotArea.y + plotArea.height - pad} textAnchor="end" style={labelStyle}>STRUGGLING</text>
+      {/* Quadrant labels — centred in each quadrant */}
+      <text x={qRightX} y={qTopY} textAnchor="middle" style={labelStyle}>IDEAL</text>
+      <text x={qLeftX}  y={qTopY} textAnchor="middle" style={labelStyle}>FAST / SLOPPY</text>
+      <text x={qRightX} y={qBotY} textAnchor="middle" style={labelStyle}>CONSERVATIVE</text>
+      <text x={qLeftX}  y={qBotY} textAnchor="middle" style={labelStyle}>STRUGGLING</text>
     </g>
   );
 }


### PR DESCRIPTION
## What

Three focused fixes in one PR:

### 1. Quadrant labels positioned in wrong places (bug in image)

Labels were placed `±8 px` from the crosshair. When the field-median crosshair sits at ~75% x-axis, all four labels cluster together near the right side of the chart instead of being spread across their quadrants.

**Fix**: each label is now centred at the midpoint between the crosshair and its respective plot edge (`(crosshair + edge) / 2` on both axes), so they always sit squarely in the middle of their quadrant regardless of where the median falls.

### 2. `<h2>` inside `<button>` (invalid HTML / WCAG fail)

The coaching section toggle in `page.tsx` wrapped an `<h2>` inside a `<button>`, which is invalid HTML and breaks the heading tree for screen readers.

**Fix**: WAI-ARIA accordion pattern — `<h2><button aria-expanded aria-controls>…</button></h2>`. The expanded panel is now `<section role="region" aria-labelledby="button-id">`.

Same treatment applied to the What-if panel in `comparison-table.tsx` (was missing `role="region"`).

### 3. Duplicate landmark name collision

Both the comparison table and the page-level section were named "Coaching analysis", producing two identical `role="region"` landmarks — confusing for screen readers that list landmarks by name.

**Fix**: renamed the table's panel to **"Points on the table"** with subtitle "Hit quality vs. penalty losses per shooter".

### 4. CLAUDE.md — chart info popovers and WCAG patterns documented

Added two new rules:
- Accordion / disclosure WCAG pattern (heading-wraps-button, `role="region"`, no duplicate landmark names)
- Chart info popovers: every new chart section must include a `?` HelpCircle popover; update text when chart behaviour changes

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — 345 tests pass
- [x] `pnpm lint` — zero warnings
- [x] `pnpm test:e2e` — 11 E2E tests pass
- [x] Rebased onto main (includes #70 info popovers — coaching section popover intact)
- [ ] Manual: quadrant labels now centred in each quadrant at any crosshair position
- [ ] Manual: heading tree correct in browser accessibility inspector
- [ ] Manual: "Points on the table" replaces "Coaching analysis" label in table

🤖 Generated with [Claude Code](https://claude.com/claude-code)