### PR TITLE
feat: shooter style radar chart — four-axis style profile (closes #73)

### DIFF
--- a/app/api/compare/logic.ts
+++ b/app/api/compare/logic.ts
@@ -1001,6 +1001,8 @@ export function computeStyleFingerprint(
     accuracyPercentile: null,
     speedPercentile: null,
     archetype: null,
+    composurePercentile: 50,
+    consistencyPercentile: 50,
   };
 }
 
@@ -1034,6 +1036,7 @@ export function computeAllFingerprintPoints(
       totalPenalties: number;
       totalRounds: number;
       hasZoneData: boolean;
+      hfValues: number[];
     }
   >();
 
@@ -1046,6 +1049,7 @@ export function computeAllFingerprintPoints(
       totalPoints: 0, totalTime: 0,
       totalPenalties: 0, totalRounds: 0,
       hasZoneData: false,
+      hfValues: [],
     };
 
     const a = sc.a_hits ?? 0;
@@ -1066,6 +1070,9 @@ export function computeAllFingerprintPoints(
     entry.totalTime += sc.time;
     entry.totalPenalties += miss + ns + proc;
     entry.totalRounds += a + c + d + miss;
+    if (sc.points != null) {
+      entry.hfValues.push(sc.points / sc.time);
+    }
 
     byComp.set(sc.competitor_id, entry);
   }
@@ -1080,12 +1087,23 @@ export function computeAllFingerprintPoints(
     const zoneTotal = agg.totalA + agg.totalC + agg.totalD;
     if (zoneTotal <= 0) continue;
 
+    // Compute coefficient of variation of per-stage HF
+    let cv: number | null = null;
+    if (agg.hfValues.length >= 2) {
+      const hfMean = agg.hfValues.reduce((a, b) => a + b, 0) / agg.hfValues.length;
+      if (hfMean > 0) {
+        const variance = agg.hfValues.reduce((sum, v) => sum + (v - hfMean) ** 2, 0) / agg.hfValues.length;
+        cv = Math.sqrt(variance) / hfMean;
+      }
+    }
+
     rawPoints.push({
       competitorId,
       division: divisionMap.get(competitorId) ?? null,
       alphaRatio: agg.totalA / zoneTotal,
       pointsPerSecond: agg.totalPoints / agg.totalTime,
       penaltyRate: agg.totalRounds > 0 ? agg.totalPenalties / agg.totalRounds : 0,
+      cv,
     });
   }
 
@@ -1098,4 +1116,32 @@ export function computeAllFingerprintPoints(
     accuracyPercentile: computePercentileRank(p.alphaRatio, allAlphaRatios) ?? 50,
     speedPercentile: computePercentileRank(p.pointsPerSecond, allSpeeds) ?? 50,
   }));
+}
+
+/**
+ * Compute composure and consistency percentile ranks for a competitor vs. the full field.
+ *
+ *   composurePercentile   = 100 − percentile rank of penaltyRate (100 = fewest penalties)
+ *   consistencyPercentile = 100 − percentile rank of CV (100 = most consistent);
+ *                           defaults to 50 when competitorCv is null
+ *
+ * Speed and accuracy percentiles are handled separately in route.ts via computePercentileRank.
+ */
+export function computeStylePercentiles(
+  stats: StyleFingerprintStats,
+  competitorCv: number | null,
+  field: FieldFingerprintPoint[]
+): Pick<StyleFingerprintStats, "composurePercentile" | "consistencyPercentile"> {
+  const allPenaltyRates = field.map((p) => p.penaltyRate);
+  const allCvs = field.map((p) => p.cv).filter((v): v is number => v !== null);
+
+  const composurePercentile =
+    100 - (computePercentileRank(stats.penaltyRate ?? 0, allPenaltyRates) ?? 50);
+
+  const consistencyPercentile =
+    competitorCv !== null
+      ? 100 - (computePercentileRank(competitorCv, allCvs) ?? 50)
+      : 50;
+
+  return { composurePercentile, consistencyPercentile };
 }

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { executeQuery, SCORECARDS_QUERY, MATCH_QUERY } from "@/lib/graphql";
 import { formatDivisionDisplay } from "@/lib/divisions";
-import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, type RawScorecard } from "@/app/api/compare/logic";
+import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles, type RawScorecard } from "@/app/api/compare/logic";
 import type { CompareResponse, CompetitorInfo } from "@/lib/types";
 
 // ─── Raw GraphQL response shapes ─────────────────────────────────────────────
@@ -260,6 +260,9 @@ export async function GET(req: Request) {
         base.pointsPerSecond != null
           ? computePercentileRank(base.pointsPerSecond, fieldSpeeds)
           : null;
+      const fieldPoint = fieldFingerprintPoints.find((p) => p.competitorId === c.id);
+      const { composurePercentile, consistencyPercentile } =
+        computeStylePercentiles(base, fieldPoint?.cv ?? null, fieldFingerprintPoints);
       return [
         c.id,
         {
@@ -267,6 +270,8 @@ export async function GET(req: Request) {
           accuracyPercentile,
           speedPercentile,
           archetype: assignArchetype(accuracyPercentile, speedPercentile),
+          composurePercentile,
+          consistencyPercentile,
         },
       ];
     })

--- a/app/match/[ct]/[id]/page.tsx
+++ b/app/match/[ct]/[id]/page.tsx
@@ -17,6 +17,7 @@ import { HfPercentChart } from "@/components/hf-percent-chart";
 import { SpeedAccuracyChart } from "@/components/scatter-chart";
 import { StageBalanceChart } from "@/components/radar-chart";
 import { StyleFingerprintChart } from "@/components/style-fingerprint-chart";
+import { ShooterStyleRadarChart } from "@/components/shooter-style-radar-chart";
 import { useMatchQuery, useCompareQuery } from "@/lib/queries";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -416,6 +417,36 @@ export default function MatchPage() {
                         </Popover>
                       </div>
                       <StyleFingerprintChart data={compareQuery.data} />
+                    </div>
+
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-1.5">
+                        <h3 className="text-sm font-semibold">Shooter style profile</h3>
+                        <Popover>
+                          <PopoverTrigger asChild>
+                            <button
+                              className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+                              aria-label="About this chart"
+                            >
+                              <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                            </button>
+                          </PopoverTrigger>
+                          <PopoverContent className="w-80" side="bottom" align="start">
+                            <PopoverHeader>
+                              <PopoverTitle>Shooter style profile</PopoverTitle>
+                              <PopoverDescription>Four-axis radar showing where each competitor ranks across key shooting dimensions.</PopoverDescription>
+                            </PopoverHeader>
+                            <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
+                              <p><strong>Speed</strong> — points-per-second percentile rank. 100 = fastest scorer in the field.</p>
+                              <p><strong>Accuracy</strong> — A-zone ratio percentile rank. 100 = highest proportion of alpha hits.</p>
+                              <p><strong>Composure</strong> — inverse penalty-rate rank. 100 = fewest misses, no-shoots, and procedurals per round fired.</p>
+                              <p><strong>Consistency</strong> — inverse stage-to-stage hit-factor variability rank. 100 = most repeatable across stages. Shows 50 when only one stage is available.</p>
+                              <p>The dashed polygon marks the field median (50th percentile on all axes). A larger polygon means a stronger overall profile.</p>
+                            </div>
+                          </PopoverContent>
+                        </Popover>
+                      </div>
+                      <ShooterStyleRadarChart data={compareQuery.data} />
                     </div>
                   </section>
                 )}

--- a/components/shooter-style-radar-chart.tsx
+++ b/components/shooter-style-radar-chart.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useState } from "react";
+import {
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { buildColorMap } from "@/lib/colors";
+import type { CompareResponse, StyleFingerprintStats } from "@/lib/types";
+
+// --------------------------------------------------------------------------
+// Types
+// --------------------------------------------------------------------------
+
+const AXES = ["Speed", "Accuracy", "Composure", "Consistency"] as const;
+type Axis = (typeof AXES)[number];
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+function getPercentile(stats: StyleFingerprintStats | undefined, axis: Axis): number {
+  if (!stats) return 50;
+  switch (axis) {
+    case "Speed":       return stats.speedPercentile ?? 50;
+    case "Accuracy":    return stats.accuracyPercentile ?? 50;
+    case "Composure":   return stats.composurePercentile;
+    case "Consistency": return stats.consistencyPercentile;
+  }
+}
+
+// --------------------------------------------------------------------------
+// Custom tooltip
+// --------------------------------------------------------------------------
+
+const REFERENCE_KEY = "__reference__";
+
+interface TooltipPayloadEntry {
+  name: string;
+  value: number;
+  color: string;
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: TooltipPayloadEntry[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+
+  const filtered = payload.filter((p) => p.name !== REFERENCE_KEY);
+  if (filtered.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        backgroundColor: "var(--popover)",
+        color: "var(--popover-foreground)",
+        border: "1px solid var(--border)",
+        borderRadius: 6,
+        padding: "8px 10px",
+        fontSize: 12,
+        lineHeight: 1.6,
+        boxShadow: "0 4px 16px rgba(0,0,0,0.14), 0 1px 4px rgba(0,0,0,0.08)",
+      }}
+    >
+      <p style={{ fontWeight: 600, marginBottom: 4 }}>{label}</p>
+      {filtered.map((entry) => (
+        <div key={entry.name} style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          <span
+            style={{
+              display: "inline-block",
+              width: 8,
+              height: 8,
+              borderRadius: "50%",
+              backgroundColor: entry.color,
+              flexShrink: 0,
+            }}
+          />
+          <span style={{ color: "var(--muted-foreground)" }}>{entry.name}:</span>
+          <span>{Math.round(entry.value)}th pct.</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// --------------------------------------------------------------------------
+// Main component
+// --------------------------------------------------------------------------
+
+interface ShooterStyleRadarChartProps {
+  data: CompareResponse;
+}
+
+export function ShooterStyleRadarChart({ data }: ShooterStyleRadarChartProps) {
+  const { competitors, styleFingerprintStats } = data;
+  const colorMap = buildColorMap(competitors.map((c) => c.id));
+  const [hiddenIds, setHiddenIds] = useState<Set<number>>(new Set());
+
+  const radarData = AXES.map((axis) => {
+    const row: Record<string, string | number> = { axis };
+    for (const comp of competitors) {
+      const stats = styleFingerprintStats[comp.id];
+      row[String(comp.id)] = getPercentile(stats, axis);
+    }
+    row[REFERENCE_KEY] = 50;
+    return row;
+  });
+
+  const hasData = competitors.some((c) => styleFingerprintStats[c.id] != null);
+  if (!hasData) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Not enough scored stages to display the style profile.
+      </p>
+    );
+  }
+
+  const formatLabel = (id: number) => {
+    const comp = competitors.find((c) => c.id === id);
+    return comp ? `#${comp.competitor_number} ${comp.name.split(" ")[0]}` : String(id);
+  };
+
+  const toggleSeries = (id: number) => {
+    setHiddenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const popoverStyle = {
+    backgroundColor: "var(--popover)",
+    color: "var(--popover-foreground)",
+    border: "1px solid var(--border)",
+    borderRadius: 6,
+    fontSize: 12,
+    boxShadow: "0 4px 16px rgba(0,0,0,0.14), 0 1px 4px rgba(0,0,0,0.08)",
+  };
+
+  return (
+    <div>
+      <ResponsiveContainer width="100%" height={300}>
+        <RadarChart data={radarData} margin={{ top: 8, right: 24, bottom: 8, left: 24 }}>
+          <PolarGrid stroke="var(--border)" />
+          <PolarAngleAxis
+            dataKey="axis"
+            tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
+          />
+          <PolarRadiusAxis
+            domain={[0, 100]}
+            tickCount={5}
+            tick={{ fontSize: 10 }}
+            tickFormatter={(v: number) => String(v)}
+          />
+          <Tooltip
+            content={<CustomTooltip />}
+            contentStyle={popoverStyle}
+          />
+
+          {/* Reference polygon at field median (50th percentile on all axes) */}
+          <Radar
+            dataKey={REFERENCE_KEY}
+            stroke="var(--muted-foreground)"
+            strokeDasharray="4 2"
+            strokeWidth={1}
+            fill="none"
+            dot={false}
+            isAnimationActive={false}
+            legendType="none"
+          />
+
+          {/* Selected competitors */}
+          {competitors
+            .filter((c) => !hiddenIds.has(c.id))
+            .map((comp) => (
+              <Radar
+                key={comp.id}
+                name={formatLabel(comp.id)}
+                dataKey={String(comp.id)}
+                stroke={colorMap[comp.id]}
+                strokeWidth={2}
+                fill={colorMap[comp.id]}
+                fillOpacity={0.15}
+                dot={{ fill: colorMap[comp.id], r: 3, stroke: "var(--background)", strokeWidth: 1 }}
+              />
+            ))}
+        </RadarChart>
+      </ResponsiveContainer>
+
+      <p className="text-center text-xs text-muted-foreground mt-1 mb-2">
+        Field percentile ranks (0–100) · dashed = field median (50th pct.)
+      </p>
+
+      {/* Competitor toggle legend */}
+      <div
+        role="group"
+        aria-label="Toggle competitors"
+        className="flex flex-wrap justify-center gap-2"
+      >
+        {competitors.map((comp) => {
+          const hidden = hiddenIds.has(comp.id);
+          const label = formatLabel(comp.id);
+          const color = colorMap[comp.id];
+          return (
+            <button
+              key={comp.id}
+              type="button"
+              onClick={() => toggleSeries(comp.id)}
+              aria-pressed={!hidden}
+              className="flex items-center gap-2 rounded-full border px-3 text-sm transition-opacity"
+              style={{
+                borderColor: hidden ? "transparent" : color + "55",
+                backgroundColor: hidden ? undefined : color + "18",
+                opacity: hidden ? 0.4 : undefined,
+              }}
+            >
+              <span
+                className="inline-block h-3 w-3 flex-none rounded-full"
+                style={{ backgroundColor: color }}
+                aria-hidden="true"
+              />
+              <span className={hidden ? "line-through" : ""}>{label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -188,6 +188,7 @@ export interface FieldFingerprintPoint {
   accuracyPercentile: number;
   /** Percentile rank within the full field, 0–100 (100 = fastest). */
   speedPercentile: number;
+  cv: number | null;         // coefficient of variation of per-stage HF; null when < 2 stages
 }
 
 // Match-level aggregate "style fingerprint" for one competitor.
@@ -211,6 +212,10 @@ export interface StyleFingerprintStats {
   speedPercentile: number | null;
   /** Archetype derived from quadrant of (accuracyPercentile, speedPercentile). */
   archetype: ShooterArchetype | null;
+  /** 100 − penaltyRate rank; 100 = fewest penalties in field. */
+  composurePercentile: number;
+  /** 100 − CV rank; 100 = most consistent stage-to-stage HF. Defaults to 50 when CV unavailable. */
+  consistencyPercentile: number;
 }
 
 // Result of one what-if simulation scenario: replace the worst stage with

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -49,9 +49,9 @@ const MOCK_COMPARE: CompareResponse = {
   },
   whatIfStats: { 100: null, 200: null, 300: null },
   styleFingerprintStats: {
-    100: { alphaRatio: null, pointsPerSecond: null, penaltyRate: null, totalA: 0, totalC: 0, totalD: 0, totalPoints: 0, totalTime: 0, totalPenalties: 0, totalRounds: 0, stagesFired: 0, accuracyPercentile: null, speedPercentile: null, archetype: null },
-    200: { alphaRatio: null, pointsPerSecond: null, penaltyRate: null, totalA: 0, totalC: 0, totalD: 0, totalPoints: 0, totalTime: 0, totalPenalties: 0, totalRounds: 0, stagesFired: 0, accuracyPercentile: null, speedPercentile: null, archetype: null },
-    300: { alphaRatio: null, pointsPerSecond: null, penaltyRate: null, totalA: 0, totalC: 0, totalD: 0, totalPoints: 0, totalTime: 0, totalPenalties: 0, totalRounds: 0, stagesFired: 0, accuracyPercentile: null, speedPercentile: null, archetype: null },
+    100: { alphaRatio: null, pointsPerSecond: null, penaltyRate: null, totalA: 0, totalC: 0, totalD: 0, totalPoints: 0, totalTime: 0, totalPenalties: 0, totalRounds: 0, stagesFired: 0, accuracyPercentile: null, speedPercentile: null, archetype: null, composurePercentile: 50, consistencyPercentile: 50 },
+    200: { alphaRatio: null, pointsPerSecond: null, penaltyRate: null, totalA: 0, totalC: 0, totalD: 0, totalPoints: 0, totalTime: 0, totalPenalties: 0, totalRounds: 0, stagesFired: 0, accuracyPercentile: null, speedPercentile: null, archetype: null, composurePercentile: 50, consistencyPercentile: 50 },
+    300: { alphaRatio: null, pointsPerSecond: null, penaltyRate: null, totalA: 0, totalC: 0, totalD: 0, totalPoints: 0, totalTime: 0, totalPenalties: 0, totalRounds: 0, stagesFired: 0, accuracyPercentile: null, speedPercentile: null, archetype: null, composurePercentile: 50, consistencyPercentile: 50 },
   },
   fieldFingerprintPoints: [],
   stages: [

--- a/tests/unit/compare-logic.test.ts
+++ b/tests/unit/compare-logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeGroupRankings, computePenaltyStats, assignDifficulty, computePercentile, computePercentileRank, assignArchetype, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
+import { computeGroupRankings, computePenaltyStats, assignDifficulty, computePercentile, computePercentileRank, assignArchetype, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computeStylePercentiles, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
 import type { CompetitorInfo } from "@/lib/types";
 
 const competitors: CompetitorInfo[] = [
@@ -2032,4 +2032,94 @@ describe("computeAllFingerprintPoints", () => {
     // penaltyRate = 1 / (10+0+0+0 + 6+4+0+1) = 1/21
     expect(p.penaltyRate).toBeCloseTo(1 / 21, 6);
   });
+
+  it("sets cv=null for competitor with 1 stage (< 2 hfValues)", () => {
+    const cards = [
+      makeCard(1, 1, { a_hits: 8, c_hits: 2, d_hits: 0, miss_count: 0, points: 40, time: 10 }),
+    ];
+    const result = computeAllFingerprintPoints(cards, divMap);
+    expect(result).toHaveLength(1);
+    expect(result[0].cv).toBeNull();
+  });
+
+  it("sets cv to a number for competitor with 2+ stages", () => {
+    const cards = [
+      makeCard(1, 1, { a_hits: 8, c_hits: 2, d_hits: 0, miss_count: 0, points: 40, time: 10 }),
+      makeCard(1, 2, { a_hits: 6, c_hits: 2, d_hits: 2, miss_count: 0, points: 30, time: 8 }),
+    ];
+    const result = computeAllFingerprintPoints(cards, divMap);
+    expect(result).toHaveLength(1);
+    expect(result[0].cv).not.toBeNull();
+    expect(typeof result[0].cv).toBe("number");
+  });
+
+  it("sets cv=0 when all stages have the same HF", () => {
+    // Both stages: 40pts / 10s = HF 4.0 → σ=0 → CV=0
+    const cards = [
+      makeCard(1, 1, { a_hits: 8, c_hits: 2, d_hits: 0, miss_count: 0, points: 40, time: 10 }),
+      makeCard(1, 2, { a_hits: 8, c_hits: 2, d_hits: 0, miss_count: 0, points: 40, time: 10 }),
+    ];
+    const result = computeAllFingerprintPoints(cards, divMap);
+    expect(result[0].cv).toBe(0);
+  });
+});
+
+// ─── computeStylePercentiles ──────────────────────────────────────────────────
+
+describe("computeStylePercentiles", () => {
+  function makeFieldPoint(competitorId: number, alphaRatio: number, pointsPerSecond: number, penaltyRate: number, cv: number | null) {
+    return { competitorId, division: null, alphaRatio, pointsPerSecond, penaltyRate, cv, accuracyPercentile: 50, speedPercentile: 50 };
+  }
+
+  it("high penalty rate → low composure percentile (inversion correct)", () => {
+    const field = [
+      makeFieldPoint(1, 0.8, 4.0, 0.01, 0.1),
+      makeFieldPoint(2, 0.7, 3.5, 0.05, 0.2),
+      makeFieldPoint(3, 0.6, 3.0, 0.20, 0.3),
+    ];
+    // Competitor with high penalty rate (0.20) should have low composure
+    const highPenaltyStats = computeStyleFingerprint(
+      computeGroupRankings([
+        makeCard(1, 1, { a_hits: 6, c_hits: 2, d_hits: 2, miss_count: 2, no_shoots: 0, procedurals: 0, points: 30, time: 10 }),
+      ], [competitors[0]]),
+      1
+    );
+    const lowPenaltyStats = computeStyleFingerprint(
+      computeGroupRankings([
+        makeCard(1, 1, { a_hits: 10, c_hits: 2, d_hits: 0, miss_count: 0, no_shoots: 0, procedurals: 0, points: 50, time: 10 }),
+      ], [competitors[0]]),
+      1
+    );
+    const highPenResult = computeStylePercentiles(highPenaltyStats, null, field);
+    const lowPenResult = computeStylePercentiles(lowPenaltyStats, null, field);
+    expect(highPenResult.composurePercentile).toBeLessThan(lowPenResult.composurePercentile);
+  });
+
+  it("high CV → low consistency percentile (inversion correct)", () => {
+    const field = [
+      makeFieldPoint(1, 0.8, 4.0, 0.01, 0.1),
+      makeFieldPoint(2, 0.7, 3.5, 0.05, 0.2),
+      makeFieldPoint(3, 0.6, 3.0, 0.05, 0.4),
+    ];
+    const baseStats = computeStyleFingerprint(
+      computeGroupRankings([makeCard(1, 1, { points: 50, time: 10 })], [competitors[0]]),
+      1
+    );
+    const lowCv = 0.05;
+    const highCv = 0.4;
+    const lowCvResult = computeStylePercentiles(baseStats, lowCv, field);
+    const highCvResult = computeStylePercentiles(baseStats, highCv, field);
+    expect(highCvResult.consistencyPercentile).toBeLessThan(lowCvResult.consistencyPercentile);
+  });
+
+  it("competitorCv=null → consistencyPercentile=50", () => {
+    const field = [makeFieldPoint(1, 0.8, 4.0, 0.01, 0.1)];
+    const baseStats = computeStyleFingerprint(
+      computeGroupRankings([makeCard(1, 1, { points: 50, time: 10 })], [competitors[0]]),
+      1
+    );
+    const result = computeStylePercentiles(baseStats, null, field);
+    expect(result.consistencyPercentile).toBe(50);
+  });
+
 });


### PR DESCRIPTION
## Summary

- Adds a **Shooter style profile** radar chart to the coaching panel, complementing the existing fingerprint scatter chart
- Four axes, all expressed as field percentile ranks (0–100):
  - **Speed** — pts/s vs full field
  - **Accuracy** — α-ratio vs full field
  - **Composure** — inverse penalty rate (100 = fewest penalties)
  - **Consistency** — inverse stage-to-stage HF variability (100 = most repeatable; 50 when only one stage available)
- Dashed reference polygon at 50 on all axes marks the field median
- Competitor toggle legend + custom tooltip
- Full `?` popover explaining all four axes

## Implementation notes

- `FieldFingerprintPoint` gains `cv` (coefficient of variation of per-stage HF), computed in `computeAllFingerprintPoints`
- `StyleFingerprintStats` gains `composurePercentile` and `consistencyPercentile` (always `number`, default 50); `speedPercentile`/`accuracyPercentile`/`archetype` from #74 preserved unchanged
- New `computeStylePercentiles()` pure function enriches the two new fields; called in `route.ts` alongside existing speed/accuracy/archetype enrichment
- Merged cleanly on top of #74 (the `computePercentileRank` deduplication and `assignArchetype` are kept from #74)

## Test plan

- [ ] `pnpm typecheck` — zero errors
- [ ] `pnpm test` — 367 tests pass (includes new unit tests for `computeStylePercentiles` and CV in `computeAllFingerprintPoints`)
- [ ] `pnpm lint` — zero warnings
- [ ] Manual: open coaching panel, verify radar chart appears below fingerprint chart with all four labelled axes, dashed reference polygon, and working legend toggles
- [ ] Manual at 390px: chart is readable, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)