### PR TITLE
feat: Redis-backed GraphQL cache with smart TTL and admin purge

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,3 +3,12 @@
 
 # ShootNScoreIt API key — get it from your account settings on shootnscoreit.com
 SSI_API_KEY=your_api_key_here
+
+# Redis connection URL (used for GraphQL response caching)
+# Default: redis://localhost:6379 (matches the docker-compose redis service locally)
+# Production: set to your managed Redis URL, e.g. rediss://... for Upstash
+REDIS_URL=redis://localhost:6379
+
+# Secret for the cache purge endpoint — any strong random string
+# Used as the Bearer token in: DELETE /api/admin/cache/purge?ct=22&id=<id>
+CACHE_PURGE_SECRET=change-me-to-a-strong-random-string

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,8 @@ actionable interpretation tips. Keep language concise — max ~4 short paragraph
 | Variable | Where used | Notes |
 |---|---|---|
 | `SSI_API_KEY` | `lib/graphql.ts` (server-only) | Never use `NEXT_PUBLIC_` prefix |
+| `REDIS_URL` | `lib/redis.ts` | `redis://localhost:6379` locally, `rediss://...` for Upstash etc. |
+| `CACHE_PURGE_SECRET` | `app/api/admin/cache/purge/route.ts` | Any strong random string; never `NEXT_PUBLIC_` |
 
 ## Package Manager
 This project uses **pnpm@10.30.1**. Do not use npm or yarn. Use `pnpm add` / `pnpm add -D`.

--- a/app/api/admin/cache/purge/route.ts
+++ b/app/api/admin/cache/purge/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import redis from "@/lib/redis";
+import { gqlCacheKey } from "@/lib/graphql";
+
+// DELETE /api/admin/cache/purge?ct=22&id=<match-id>
+// Requires Authorization: Bearer <CACHE_PURGE_SECRET>
+export async function DELETE(req: Request) {
+  const secret = process.env.CACHE_PURGE_SECRET;
+  const auth = req.headers.get("Authorization");
+  if (!secret || auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const ct = searchParams.get("ct");
+  const id = searchParams.get("id");
+  if (!ct || !id) {
+    return NextResponse.json({ error: "ct and id are required" }, { status: 400 });
+  }
+
+  const ctNum = parseInt(ct, 10);
+  if (isNaN(ctNum)) {
+    return NextResponse.json({ error: "Invalid content_type" }, { status: 400 });
+  }
+
+  const matchKey = gqlCacheKey("GetMatch", { ct: ctNum, id });
+  const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
+
+  await redis.del(matchKey, scorecardsKey);
+
+  return NextResponse.json({ purged: [matchKey, scorecardsKey] });
+}

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { executeQuery, SCORECARDS_QUERY, MATCH_QUERY } from "@/lib/graphql";
+import { cachedExecuteQuery, gqlCacheKey, SCORECARDS_QUERY, MATCH_QUERY } from "@/lib/graphql";
+import redis from "@/lib/redis";
 import { formatDivisionDisplay } from "@/lib/divisions";
 import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles, type RawScorecard } from "@/app/api/compare/logic";
 import type { CompareResponse, CompetitorInfo } from "@/lib/types";
@@ -61,6 +62,8 @@ interface RawCompetitor {
 
 interface RawMatchData {
   event: {
+    starts?: string | null;
+    scoring_completed?: string | number | null;
     stages?: {
       id: string;
       number: number;
@@ -110,19 +113,54 @@ export async function GET(req: Request) {
     );
   }
 
-  // Fetch match scorecards and competitor metadata in parallel
-  let scorecardsData: RawScorecardsData;
+  // Step 1 — fetch match metadata to determine TTL for scorecards
+  const matchKey = gqlCacheKey("GetMatch", { ct: ctNum, id });
   let matchData: RawMatchData;
-
+  let matchCachedAt: string | null;
   try {
-    [scorecardsData, matchData] = await Promise.all([
-      executeQuery<RawScorecardsData>(SCORECARDS_QUERY, { ct: ctNum, id }, 30),
-      executeQuery<RawMatchData>(MATCH_QUERY, { ct: ctNum, id }, 30),
-    ]);
+    ({ data: matchData, cachedAt: matchCachedAt } =
+      await cachedExecuteQuery<RawMatchData>(matchKey, MATCH_QUERY, { ct: ctNum, id }, 30));
   } catch (err) {
     const message = err instanceof Error ? err.message : "Upstream error";
     return NextResponse.json({ error: message }, { status: 502 });
   }
+
+  // Determine match completion state to set appropriate TTL
+  const scoringPct = Math.round(
+    parseFloat(String(matchData.event?.scoring_completed ?? 0))
+  );
+  const matchDate = matchData.event?.starts ? new Date(matchData.event.starts) : null;
+  const daysSince = matchDate ? (Date.now() - matchDate.getTime()) / 86_400_000 : 0;
+  const isComplete = scoringPct >= 95 || daysSince > 3;
+  const dataTtl: number | null = isComplete ? null : 30;
+
+  // Upgrade match cache entry to permanent if match is now complete
+  if (isComplete) {
+    try {
+      const raw = await redis.get(matchKey);
+      if (raw) await redis.persist(matchKey); // remove TTL → permanent
+    } catch { /* ignore */ }
+  }
+
+  // Step 2 — fetch scorecards with TTL determined by match state
+  const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
+  let scorecardsData: RawScorecardsData;
+  let scorecardsCachedAt: string | null;
+  try {
+    ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
+      await cachedExecuteQuery<RawScorecardsData>(
+        scorecardsKey,
+        SCORECARDS_QUERY,
+        { ct: ctNum, id },
+        dataTtl,
+      ));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Upstream error";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+
+  // Report the older of the two cache timestamps (most stale data wins)
+  const cacheInfo = { cachedAt: matchCachedAt ?? scorecardsCachedAt };
 
   const tFetch = performance.now();
   console.log(`[compare] graphql fetch: ${(tFetch - t0).toFixed(0)}ms`);
@@ -306,6 +344,7 @@ export async function GET(req: Request) {
     whatIfStats,
     styleFingerprintStats,
     fieldFingerprintPoints,
+    cacheInfo,
   };
 
   const serverTiming = [

--- a/app/api/match/[ct]/[id]/route.ts
+++ b/app/api/match/[ct]/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { executeQuery, MATCH_QUERY } from "@/lib/graphql";
+import { cachedExecuteQuery, gqlCacheKey, MATCH_QUERY } from "@/lib/graphql";
+import redis from "@/lib/redis";
 import { formatDivisionDisplay } from "@/lib/divisions";
 import type { MatchResponse, StageInfo, CompetitorInfo } from "@/lib/types";
 
@@ -58,9 +59,16 @@ export async function GET(
     return NextResponse.json({ error: "Invalid content_type" }, { status: 400 });
   }
 
+  const matchKey = gqlCacheKey("GetMatch", { ct: ctNum, id });
   let data: RawMatchData;
+  let cachedAt: string | null;
   try {
-    data = await executeQuery<RawMatchData>(MATCH_QUERY, { ct: ctNum, id }, 30);
+    ({ data, cachedAt } = await cachedExecuteQuery<RawMatchData>(
+      matchKey,
+      MATCH_QUERY,
+      { ct: ctNum, id },
+      30,
+    ));
   } catch (err) {
     const message = err instanceof Error ? err.message : "Upstream error";
     return NextResponse.json({ error: message }, { status: 502 });
@@ -74,6 +82,18 @@ export async function GET(
   }
 
   const ev = data.event;
+
+  // Determine if match is complete — upgrade to permanent cache if so
+  const scoringPct = Math.round(parseFloat(String(ev.scoring_completed ?? 0)));
+  const matchDate = ev.starts ? new Date(ev.starts) : null;
+  const daysSince = matchDate ? (Date.now() - matchDate.getTime()) / 86_400_000 : 0;
+  const isComplete = scoringPct >= 95 || daysSince > 3;
+  if (isComplete) {
+    try {
+      const raw = await redis.get(matchKey);
+      if (raw) await redis.persist(matchKey); // remove TTL → permanent
+    } catch { /* ignore */ }
+  }
 
   const stages: StageInfo[] = (ev.stages ?? []).map((s) => ({
     id: parseInt(s.id, 10),
@@ -116,6 +136,7 @@ export async function GET(
     ssi_url: `https://shootnscoreit.com/event/${ct}/${id}/`,
     stages,
     competitors,
+    cacheInfo: { cachedAt },
   };
 
   const tDone = performance.now();

--- a/app/match/[ct]/[id]/page.tsx
+++ b/app/match/[ct]/[id]/page.tsx
@@ -19,6 +19,7 @@ import { StageBalanceChart } from "@/components/radar-chart";
 import { StyleFingerprintChart } from "@/components/style-fingerprint-chart";
 import { ShooterStyleRadarChart } from "@/components/shooter-style-radar-chart";
 import { useMatchQuery, useCompareQuery } from "@/lib/queries";
+import { CacheInfoBadge } from "@/components/cache-info-badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Loader2, AlertCircle, ArrowLeft, RefreshCw, ChevronDown, ChevronUp, HelpCircle } from "lucide-react";
@@ -160,6 +161,17 @@ export default function MatchPage() {
 
   const match = matchQuery.data;
 
+  // Pick the older (more stale) cachedAt between match and compare responses.
+  // null means "just fetched live" — prefer non-null if one is cached.
+  const matchCachedAt = match.cacheInfo.cachedAt;
+  const compareCachedAt = compareQuery.data?.cacheInfo.cachedAt ?? null;
+  const stalestCachedAt =
+    matchCachedAt && compareCachedAt
+      ? new Date(matchCachedAt) < new Date(compareCachedAt)
+        ? matchCachedAt
+        : compareCachedAt
+      : matchCachedAt ?? compareCachedAt;
+
   return (
     <div className="min-h-screen p-4 sm:p-6 max-w-6xl mx-auto space-y-6">
       {/* Back link + share */}
@@ -171,7 +183,10 @@ export default function MatchPage() {
           <ArrowLeft className="w-3.5 h-3.5" />
           All matches
         </Link>
-        <ShareButton title={match.name} />
+        <div className="flex items-center gap-3">
+          <CacheInfoBadge ct={ct} id={id} cachedAt={stalestCachedAt} />
+          <ShareButton title={match.name} />
+        </div>
       </div>
 
       {/* Match header */}

--- a/components/cache-info-badge.tsx
+++ b/components/cache-info-badge.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+import { RefreshCw, Clock } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface CacheInfoBadgeProps {
+  ct: string;
+  id: string;
+  /** The most-stale cachedAt timestamp from match + compare responses (null = freshly fetched) */
+  cachedAt: string | null;
+}
+
+function formatTimeAgo(isoString: string): string {
+  const seconds = Math.floor((Date.now() - new Date(isoString).getTime()) / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function CacheInfoBadge({ ct, id, cachedAt }: CacheInfoBadgeProps) {
+  const [open, setOpen] = useState(false);
+  const [password, setPassword] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+  const queryClient = useQueryClient();
+
+  async function handleForceRefresh() {
+    setStatus("loading");
+    setErrorMsg("");
+    try {
+      const res = await fetch(
+        `/api/admin/cache/purge?ct=${ct}&id=${id}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${password}` },
+        }
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: "Request failed" }));
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      setStatus("success");
+      // Invalidate both queries so they re-fetch fresh data
+      await queryClient.invalidateQueries({ queryKey: ["match", ct, id] });
+      await queryClient.invalidateQueries({ queryKey: ["compare", ct, id] });
+      setOpen(false);
+      setPassword("");
+      setStatus("idle");
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Unknown error");
+      setStatus("error");
+    }
+  }
+
+  const label = cachedAt ? `Updated ${formatTimeAgo(cachedAt)}` : "Live";
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring rounded"
+        aria-label={`Cache status: ${label}. Click to manage cache.`}
+      >
+        <Clock className="w-3 h-3" aria-hidden="true" />
+        <span>{label}</span>
+        <RefreshCw className="w-3 h-3" aria-hidden="true" />
+      </button>
+
+      <Dialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) { setPassword(""); setStatus("idle"); setErrorMsg(""); } }}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Cache status</DialogTitle>
+            <DialogDescription>
+              {cachedAt
+                ? `Data was cached at ${new Date(cachedAt).toLocaleString()}.`
+                : "Data was just fetched fresh."}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 pt-2">
+            <p className="text-sm text-muted-foreground">
+              Enter the admin secret to force a cache refresh. The next page load will
+              re-fetch from shootnscoreit.com.
+            </p>
+
+            <div className="space-y-1.5">
+              <label htmlFor="purge-secret" className="text-sm font-medium">Admin secret</label>
+              <Input
+                id="purge-secret"
+                type="password"
+                placeholder="CACHE_PURGE_SECRET"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter" && password) handleForceRefresh(); }}
+                autoComplete="off"
+              />
+            </div>
+
+            {status === "error" && (
+              <p role="alert" className="text-sm text-destructive">{errorMsg}</p>
+            )}
+
+            <Button
+              onClick={handleForceRefresh}
+              disabled={!password || status === "loading"}
+              className="w-full"
+            >
+              {status === "loading" ? (
+                <>
+                  <RefreshCw className="w-4 h-4 mr-2 animate-spin" aria-hidden="true" />
+                  Purging…
+                </>
+              ) : (
+                <>
+                  <RefreshCw className="w-4 h-4 mr-2" aria-hidden="true" />
+                  Force refresh
+                </>
+              )}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,10 @@
 services:
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
+
   app:
     build:
       context: .
@@ -6,4 +12,10 @@ services:
       - "${PORT:-3666}:3000"
     environment:
       SSI_API_KEY: ${SSI_API_KEY}
+      REDIS_URL: redis://redis:6379
+      CACHE_PURGE_SECRET: ${CACHE_PURGE_SECRET}
+    depends_on: [redis]
     restart: unless-stopped
+
+volumes:
+  redis_data:

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -1,6 +1,8 @@
 // Server-only — never import from client components or files with "use client".
 // SSI_API_KEY lives here and must never be sent to the browser.
 
+import redis from "@/lib/redis";
+
 const GRAPHQL_ENDPOINT = "https://shootnscoreit.com/graphql/";
 
 interface GraphQLError {
@@ -148,6 +150,60 @@ export const EVENTS_QUERY = `
     }
   }
 `;
+
+// ─── Redis cache helpers ──────────────────────────────────────────────────────
+
+export function gqlCacheKey(
+  operationName: string,
+  variables: Record<string, unknown>,
+): string {
+  return `gql:${operationName}:${JSON.stringify(variables)}`;
+}
+
+interface CacheEntry<T> {
+  data: T;
+  cachedAt: string; // ISO timestamp
+}
+
+/**
+ * Returns cached data + cachedAt timestamp, or fetches fresh and stores it.
+ * ttlSeconds = null → no expiry (permanent cache).
+ * Falls back to a direct fetch on Redis error.
+ *
+ * Return value:
+ *   cachedAt — ISO string when the data was first stored (cache hit)
+ *              null when the data was just fetched (cache miss — not yet stored)
+ */
+export async function cachedExecuteQuery<T>(
+  cacheKey: string,
+  query: string,
+  variables: Record<string, unknown>,
+  ttlSeconds: number | null,
+): Promise<{ data: T; cachedAt: string | null }> {
+  try {
+    const raw = await redis.get(cacheKey);
+    if (raw) {
+      const entry = JSON.parse(raw) as CacheEntry<T>;
+      return { data: entry.data, cachedAt: entry.cachedAt };
+    }
+  } catch { /* fall through to fetch */ }
+
+  const data = await executeQuery<T>(query, variables);
+  const cachedAt = new Date().toISOString();
+
+  try {
+    const entry: CacheEntry<T> = { data, cachedAt };
+    const payload = JSON.stringify(entry);
+    if (ttlSeconds === null) {
+      await redis.set(cacheKey, payload);
+    } else {
+      await redis.set(cacheKey, payload, "EX", ttlSeconds);
+    }
+  } catch { /* best-effort — store failure is non-fatal */ }
+
+  // Return null for cachedAt: freshly fetched, not served from cache
+  return { data, cachedAt: null };
+}
 
 // ─── Query: all stage scorecards for a match ─────────────────────────────────
 // Returns raw scorecard data for every competitor on every stage.

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,0 +1,12 @@
+// Server-only — never import from client components or files with "use client".
+import Redis from "ioredis";
+
+const redis = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", {
+  maxRetriesPerRequest: 1,
+  enableReadyCheck: false,
+  lazyConnect: true,
+});
+
+redis.on("error", (err: Error) => console.error("[redis]", err.message));
+
+export default redis;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,6 +20,10 @@ export interface CompetitorInfo {
   division: string | null;
 }
 
+export interface CacheInfo {
+  cachedAt: string | null; // ISO string of when data was cached; null if just fetched fresh
+}
+
 export interface MatchResponse {
   name: string;
   venue: string | null;
@@ -33,6 +37,7 @@ export interface MatchResponse {
   ssi_url: string | null;
   stages: StageInfo[];
   competitors: CompetitorInfo[];
+  cacheInfo: CacheInfo;
 }
 
 export interface StageResult {
@@ -251,6 +256,7 @@ export interface CompareResponse {
   whatIfStats: Record<number, WhatIfResult | null>;     // keyed by competitor_id; null = not enough stages
   styleFingerprintStats: Record<number, StyleFingerprintStats>; // keyed by competitor_id
   fieldFingerprintPoints: FieldFingerprintPoint[]; // all match competitors (for cohort cloud)
+  cacheInfo: CacheInfo;
 }
 
 export interface EventSummary {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "ioredis": "5.9.3",
     "lucide-react": "0.575.0",
     "next": "16.1.6",
     "radix-ui": "^1.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      ioredis:
+        specifier: 5.9.3
+        version: 5.9.3
       lucide-react:
         specifier: 0.575.0
         version: 0.575.0(react@19.2.3)
@@ -742,6 +745,9 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@ioredis/commands@1.5.0':
+    resolution: {integrity: sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2365,6 +2371,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
     peerDependencies:
@@ -2575,6 +2585,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -3162,6 +3176,10 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  ioredis@5.9.3:
+    resolution: {integrity: sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==}
+    engines: {node: '>=12.22.0'}
+
   ip-address@10.0.1:
     resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
     engines: {node: '>= 12'}
@@ -3517,6 +3535,12 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -3994,6 +4018,14 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -4177,6 +4209,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -5245,6 +5280,8 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@20.19.33)':
     optionalDependencies:
       '@types/node': 20.19.33
+
+  '@ioredis/commands@1.5.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6858,6 +6895,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
@@ -7039,6 +7078,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -7804,6 +7845,20 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  ioredis@5.9.3:
+    dependencies:
+      '@ioredis/commands': 1.5.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ip-address@10.0.1: {}
 
   ipaddr.js@1.9.1: {}
@@ -8116,6 +8171,10 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -8647,6 +8706,12 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
       redux: 5.0.1
@@ -8959,6 +9024,8 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
 

--- a/tests/components/comparison-chart.test.tsx
+++ b/tests/components/comparison-chart.test.tsx
@@ -65,6 +65,7 @@ const baseStageCompetitors = {
 
 const baseData: CompareResponse = {
   match_id: 26547,
+  cacheInfo: { cachedAt: null },
   penaltyStats: {
     1: { totalPenalties: 0, penaltyCostPercent: 0, matchPctActual: 100, matchPctClean: 100, penaltiesPerStage: 0, penaltiesPer100Rounds: 0 },
     2: { totalPenalties: 0, penaltyCostPercent: 0, matchPctActual: 80, matchPctClean: 80, penaltiesPerStage: 0, penaltiesPer100Rounds: 0 },

--- a/tests/components/comparison-table.test.tsx
+++ b/tests/components/comparison-table.test.tsx
@@ -10,6 +10,7 @@ function renderWithProviders(ui: React.ReactElement) {
 
 const baseData: CompareResponse = {
   match_id: 26547,
+  cacheInfo: { cachedAt: null },
   competitors: [
     { id: 1, name: "Alice Smith", competitor_number: "35", club: null, division: "Open Major" },
     { id: 2, name: "Bob Jones", competitor_number: "50", club: null, division: "Production Minor" },

--- a/tests/components/match-header.test.tsx
+++ b/tests/components/match-header.test.tsx
@@ -5,6 +5,7 @@ import type { MatchResponse } from "@/lib/types";
 
 const baseMatch: MatchResponse = {
   name: "Test Championship",
+  cacheInfo: { cachedAt: null },
   venue: "Shooting Range Alpha",
   date: "2026-03-15T09:00:00+00:00",
   level: "l2",

--- a/tests/components/radar-chart.test.tsx
+++ b/tests/components/radar-chart.test.tsx
@@ -5,6 +5,7 @@ import type { CompareResponse } from "@/lib/types";
 
 const baseData: CompareResponse = {
   match_id: 26547,
+  cacheInfo: { cachedAt: null },
   penaltyStats: {
     1: { totalPenalties: 0, penaltyCostPercent: 0, matchPctActual: 100, matchPctClean: 100, penaltiesPerStage: 0, penaltiesPer100Rounds: 0 },
     2: { totalPenalties: 0, penaltyCostPercent: 0, matchPctActual: 80, matchPctClean: 80, penaltiesPerStage: 0, penaltiesPer100Rounds: 0 },

--- a/tests/components/scatter-chart.test.tsx
+++ b/tests/components/scatter-chart.test.tsx
@@ -5,6 +5,7 @@ import type { CompareResponse } from "@/lib/types";
 
 const baseData: CompareResponse = {
   match_id: 26547,
+  cacheInfo: { cachedAt: null },
   penaltyStats: {
     1: { totalPenalties: 0, penaltyCostPercent: 0, matchPctActual: 100, matchPctClean: 100, penaltiesPerStage: 0, penaltiesPer100Rounds: 0 },
     2: { totalPenalties: 0, penaltyCostPercent: 0, matchPctActual: 80, matchPctClean: 80, penaltiesPerStage: 0, penaltiesPer100Rounds: 0 },

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -3,6 +3,7 @@ import type { MatchResponse, CompareResponse } from "@/lib/types";
 
 const MOCK_MATCH: MatchResponse = {
   name: "Test IPSC Match",
+  cacheInfo: { cachedAt: null },
   venue: "Test Range",
   date: "2026-03-01T09:00:00+00:00",
   level: "l2",
@@ -26,6 +27,7 @@ const MOCK_MATCH: MatchResponse = {
 
 const MOCK_COMPARE: CompareResponse = {
   match_id: 26547,
+  cacheInfo: { cachedAt: null },
   competitors: [
     MOCK_MATCH.competitors[0],
     MOCK_MATCH.competitors[1],


### PR DESCRIPTION
## Summary

- Replaces Next.js ISR (in-process, lost on restart) with an external Redis cache — responses survive container restarts and are shared across multiple backend instances
- Smart TTL: live matches cached for 30 s; finished matches (scoring ≥ 95 % or > 3 days old) cached permanently via `redis.persist()`
- New `DELETE /api/admin/cache/purge` endpoint (Bearer-token protected) deletes both Redis keys for a match
- `CacheInfoBadge` component in the match header shows "Updated Xs ago" and provides an admin dialog to force-purge + re-fetch

## Cache behaviour

| Match state | TTL |
|---|---|
| Live (`scoring_completed < 95%` AND `< 3 days old`) | 30 s |
| Complete (`scoring_completed ≥ 95%` OR `> 3 days old`) | Permanent (no expiry) |

## Expected latency

| Scenario | Before | After |
|---|---|---|
| Cache miss (first load) | 7–13 s | ~same (primes cache) |
| Cache hit | 7–13 s | ~5–15 ms |
| After force-purge | — | One slow reload, then fast |

## New env vars

| Variable | Notes |
|---|---|
| `REDIS_URL` | `redis://localhost:6379` locally; `rediss://...` for Upstash/managed Redis |
| `CACHE_PURGE_SECRET` | Any strong random string; Bearer token for the purge endpoint |

## Test plan

- [ ] Copy `.env.local.example` → `.env.local`, set `REDIS_URL=redis://localhost:6379` and a `CACHE_PURGE_SECRET`
- [ ] `docker compose up redis -d`, then `pnpm dev`
- [ ] Load a match — first load slow, see `[compare] graphql fetch: Xms` in server log
- [ ] Reload — fetch time drops to ~5 ms; badge shows "Updated Xs ago"
- [ ] `docker compose restart app` — reload is still fast (Redis volume persists)
- [ ] Click badge → enter `CACHE_PURGE_SECRET` → Force refresh → one slow reload, then fast again
- [ ] `pnpm typecheck && pnpm test` — zero errors/warnings ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)