### PR TITLE
feat: two-phase loading bar with WCAG SC 4.1.3 compliance

### DIFF
--- a/app/match/[ct]/[id]/page.tsx
+++ b/app/match/[ct]/[id]/page.tsx
@@ -20,6 +20,7 @@ import { StyleFingerprintChart } from "@/components/style-fingerprint-chart";
 import { ShooterStyleRadarChart } from "@/components/shooter-style-radar-chart";
 import { useMatchQuery, useCompareQuery } from "@/lib/queries";
 import { CacheInfoBadge } from "@/components/cache-info-badge";
+import { LoadingBar } from "@/components/loading-bar";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Loader2, AlertCircle, ArrowLeft, RefreshCw, ChevronDown, ChevronUp, HelpCircle } from "lucide-react";
@@ -107,6 +108,8 @@ export default function MatchPage() {
 
   if (matchQuery.isLoading) {
     return (
+      <>
+      <LoadingBar matchLoaded={false} compareLoaded={false} hasCompetitors={selectedIds.length > 0} />
       <div className="min-h-screen p-4 sm:p-6 max-w-6xl mx-auto space-y-6">
         {/* nav row */}
         <div className="flex items-center justify-between">
@@ -139,6 +142,7 @@ export default function MatchPage() {
           <Skeleton className="h-10 w-full rounded-md" />
         </div>
       </div>
+      </>
     );
   }
 
@@ -174,6 +178,11 @@ export default function MatchPage() {
 
   return (
     <div className="min-h-screen p-4 sm:p-6 max-w-6xl mx-auto space-y-6">
+      <LoadingBar
+        matchLoaded={true}
+        compareLoaded={!!compareQuery.data}
+        hasCompetitors={selectedIds.length > 0}
+      />
       {/* Back link + share */}
       <div className="flex items-center justify-between">
         <Link

--- a/components/loading-bar.tsx
+++ b/components/loading-bar.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+// A thin top-of-page progress bar with two-phase loading awareness.
+//
+// Phase 1 (match loading):  bar crawls 0 → ~40% over 12 s
+// Phase 2 (compare loading): bar snaps to 55 %, crawls to ~80% over 12 s
+// Done:                       bar completes to 100 %, fades out
+//
+// The component may mount already in phase 2 (skeleton → content transition),
+// in which case the phase-2 animation starts immediately.
+//
+// WCAG SC 4.1.3 (Status Messages): the aria-live region announces phase
+// changes to screen readers without requiring focus on the bar.
+// The visual bar itself is aria-hidden (decorative only).
+
+import { useEffect, useRef, useState } from "react";
+
+interface LoadingBarProps {
+  matchLoaded: boolean;
+  compareLoaded: boolean;
+  hasCompetitors: boolean;
+}
+
+export function LoadingBar({ matchLoaded, compareLoaded, hasCompetitors }: LoadingBarProps) {
+  const isDone = matchLoaded && (!hasCompetitors || compareLoaded);
+
+  // Capture values at mount time via refs so the mount-only effect can
+  // read them without listing them as dependencies.
+  const mountedAsMatchLoaded = useRef(matchLoaded);
+  const doneRef = useRef(isDone);
+
+  const [pct, setPct] = useState(() => (matchLoaded ? 55 : 0));
+  const [transitionMs, setTransitionMs] = useState(0);
+  const [opacity, setOpacity] = useState(1);
+  // Initialize as hidden if already done (e.g. instant cache-hit render).
+  const [hidden, setHidden] = useState(isDone);
+
+  // ── Mount-time animation ────────────────────────────────────────────────
+  // Runs once. All state updates are inside async callbacks to satisfy the
+  // react-hooks/set-state-in-effect rule.
+  useEffect(() => {
+    if (doneRef.current) return;
+
+    if (mountedAsMatchLoaded.current) {
+      // Mounted already in phase 2 — crawl from 55 → 80%.
+      const t = setTimeout(() => {
+        setTransitionMs(12_000);
+        setPct(80);
+      }, 80);
+      return () => clearTimeout(t);
+    }
+
+    // Phase 1 — crawl from 0 → 40%.
+    // Two nested rAFs ensure width=0 has painted before the transition
+    // starts so the browser actually animates the width change.
+    const raf = requestAnimationFrame(() =>
+      requestAnimationFrame(() => {
+        setTransitionMs(12_000);
+        setPct(40);
+      })
+    );
+    return () => cancelAnimationFrame(raf);
+  }, []); // intentionally empty — mount-only, reads only stable refs
+
+  // ── Phase 1 → 2 transition (within the same component instance) ────────
+  useEffect(() => {
+    if (!matchLoaded || !hasCompetitors || compareLoaded) return;
+    if (doneRef.current || mountedAsMatchLoaded.current) return;
+
+    // Snap to 55 % (setState inside setTimeout — not synchronous in effect body).
+    const t0 = setTimeout(() => {
+      setTransitionMs(300);
+      setPct(55);
+    }, 0);
+    // Then crawl toward 80 %.
+    const t1 = setTimeout(() => {
+      setTransitionMs(12_000);
+      setPct(80);
+    }, 320);
+    return () => {
+      clearTimeout(t0);
+      clearTimeout(t1);
+    };
+  }, [matchLoaded, hasCompetitors, compareLoaded]);
+
+  // ── Completion ──────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!isDone || doneRef.current) return;
+    doneRef.current = true;
+
+    const t0 = setTimeout(() => {
+      setTransitionMs(350);
+      setPct(100);
+    }, 0);
+    const t1 = setTimeout(() => setOpacity(0), 450);
+    const t2 = setTimeout(() => setHidden(true), 800);
+    return () => {
+      clearTimeout(t0);
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, [isDone]);
+
+  if (hidden) return null;
+
+  const srText = !matchLoaded
+    ? "Loading match…"
+    : hasCompetitors && !compareLoaded
+      ? "Loading scores…"
+      : "";
+
+  return (
+    <>
+      {/* Screen-reader status announcement (WCAG SC 4.1.3) */}
+      <p aria-live="polite" aria-atomic="true" className="sr-only">
+        {srText}
+      </p>
+
+      {/* Visual bar — decorative, hidden from assistive technology */}
+      <div
+        aria-hidden="true"
+        className="fixed top-0 inset-x-0 z-50 h-[3px] pointer-events-none"
+        style={{
+          opacity,
+          transition: opacity < 1 ? "opacity 350ms ease-out" : undefined,
+        }}
+      >
+        <div
+          className="h-full bg-primary"
+          style={{
+            width: `${pct}%`,
+            transition: transitionMs > 0 ? `width ${transitionMs}ms ease-out` : "none",
+          }}
+        />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a thin 3 px top-of-page progress bar that shows the two distinct loading phases instead of leaving the user with a silent skeleton for 5–13 s on cold loads
- Handles the React render-branch switch (skeleton → content) by initialising from the correct phase at mount time — no visual reset
- Satisfies **WCAG SC 4.1.3 (Status Messages, AA)**: a visually-hidden `aria-live="polite"` `<p>` announces `"Loading match…"` and `"Loading scores…"` to screen readers without moving focus; the visual bar is `aria-hidden` (decorative only)

## Phase behaviour

| Phase | Trigger | Bar |
|---|---|---|
| 1 | Match data loading | Crawls 0 → ~40 % over 12 s ease-out |
| 2 | Compare data loading | Snaps to 55 %, crawls to ~80 % over 12 s |
| Done | Both loaded (or no competitors) | Jumps to 100 %, fades out |

On a **warm Redis cache** (~25 ms) the bar appears and disappears before the user notices — effectively invisible.

## Test plan

- [ ] Cold load (no Redis / first hit): skeleton visible → bar crawls visibly for several seconds → content appears, bar continues briefly → bar completes and fades
- [ ] Warm load (Redis hit): bar flashes and disappears immediately
- [ ] No competitors selected: bar completes after phase 1 only
- [ ] With competitors pre-selected (localStorage): bar shows both phases from the start
- [ ] Screen reader: NVDA/VoiceOver should announce "Loading match…" then "Loading scores…" without focus being moved
- [ ] `pnpm typecheck && pnpm lint && pnpm test` — zero errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)