### PR TITLE
feat: dark mode toggle with next-themes and CSS-var SVG fixes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -49,6 +49,9 @@
 
 :root {
   --radius: 0.625rem;
+  --perf-red: oklch(0.577 0.245 27.325);
+  --perf-amber: oklch(0.769 0.188 70.08);
+  --perf-green: oklch(0.696 0.17 162.48);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -84,6 +87,9 @@
 
 .dark {
   --background: oklch(0.145 0 0);
+  --perf-red: oklch(0.704 0.191 22.216);
+  --perf-amber: oklch(0.828 0.189 84.429);
+  --perf-green: oklch(0.696 0.17 162.48);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
 import { Providers } from "@/components/providers";
+import { ThemeToggle } from "@/components/theme-toggle";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -25,12 +26,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}>
         <Providers>
           {children}
           <footer className="w-full flex flex-col items-center gap-2 p-4 text-xs text-muted-foreground border-t border-border mt-auto">
-            <div className="flex flex-wrap justify-center gap-4">
+            <div className="flex flex-wrap justify-center items-center gap-4">
+              <ThemeToggle />
               <span>
                 Powered by{" "}
                 <a

--- a/components/hf-percent-chart.tsx
+++ b/components/hf-percent-chart.tsx
@@ -103,9 +103,9 @@ export function HfPercentChart({ data }: HfPercentChartProps) {
           margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
         >
           {/* Colored performance bands — rendered first to sit below grid and lines */}
-          <ReferenceArea y1={0} y2={85} fill="#ef4444" fillOpacity={0.07} />
-          <ReferenceArea y1={85} y2={95} fill="#f59e0b" fillOpacity={0.07} />
-          <ReferenceArea y1={95} y2={300} fill="#22c55e" fillOpacity={0.07} />
+          <ReferenceArea y1={0} y2={85} style={{ fill: "var(--perf-red)" }} fillOpacity={0.07} />
+          <ReferenceArea y1={85} y2={95} style={{ fill: "var(--perf-amber)" }} fillOpacity={0.07} />
+          <ReferenceArea y1={95} y2={300} style={{ fill: "var(--perf-green)" }} fillOpacity={0.07} />
 
           <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
           <XAxis
@@ -181,13 +181,13 @@ export function HfPercentChart({ data }: HfPercentChartProps) {
         className="flex flex-wrap justify-center gap-x-4 gap-y-1 pt-1 text-xs"
         aria-label="Performance bands"
       >
-        <span style={{ color: "#22c55e" }}>
+        <span className="text-green-600 dark:text-green-400">
           <span aria-hidden="true">■</span> &gt;95% solid
         </span>
-        <span style={{ color: "#f59e0b" }}>
+        <span className="text-amber-600 dark:text-amber-400">
           <span aria-hidden="true">■</span> 85–95% mediocre
         </span>
-        <span style={{ color: "#ef4444" }}>
+        <span className="text-red-600 dark:text-red-400">
           <span aria-hidden="true">■</span> &lt;85% leak
         </span>
       </div>

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "next-themes";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 export function Providers({ children }: { children: React.ReactNode }) {
@@ -18,8 +19,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>{children}</TooltipProvider>
-    </QueryClientProvider>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>{children}</TooltipProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
   );
 }

--- a/components/scatter-chart.tsx
+++ b/components/scatter-chart.tsx
@@ -93,7 +93,7 @@ function StageNumberDot({ cx, cy, fill, payload }: DotProps) {
         cy={cy}
         r={9}
         fill={fill}
-        stroke="white"
+        style={{ stroke: "var(--background)" }}
         strokeWidth={1.5}
         opacity={0.9}
       />
@@ -102,7 +102,7 @@ function StageNumberDot({ cx, cy, fill, payload }: DotProps) {
         y={cy + 3.5}
         textAnchor="middle"
         fontSize={8}
-        fill="white"
+        style={{ fill: "var(--background)" }}
         fontWeight="bold"
         className="pointer-events-none select-none"
       >

--- a/components/stage-cell-parts.tsx
+++ b/components/stage-cell-parts.tsx
@@ -26,10 +26,10 @@ export const CLASSIFICATION_CONFIG: Record<
   StageClassification,
   { label: string; color: string; Icon: ComponentType<{ className?: string; "aria-hidden"?: boolean }> }
 > = {
-  solid: { label: "Solid", color: "text-emerald-500", Icon: CheckCircle2 },
-  conservative: { label: "Conservative", color: "text-yellow-500", Icon: Shield },
-  "over-push": { label: "Over-push", color: "text-orange-500", Icon: Zap },
-  meltdown: { label: "Meltdown", color: "text-red-500", Icon: Flame },
+  solid: { label: "Solid", color: "text-emerald-600 dark:text-emerald-400", Icon: CheckCircle2 },
+  conservative: { label: "Conservative", color: "text-yellow-600 dark:text-yellow-400", Icon: Shield },
+  "over-push": { label: "Over-push", color: "text-orange-600 dark:text-orange-400", Icon: Zap },
+  meltdown: { label: "Meltdown", color: "text-red-600 dark:text-red-400", Icon: Flame },
 };
 
 export function RankBadge({

--- a/components/style-fingerprint-chart.tsx
+++ b/components/style-fingerprint-chart.tsx
@@ -226,7 +226,7 @@ function PenaltyDot({ cx, cy, fill, payload }: DotProps) {
   return (
     <g>
       <circle cx={cx} cy={cy} r={Math.max(r, 22)} fill="transparent" />
-      <circle cx={cx} cy={cy} r={r} fill={fill} stroke="white" strokeWidth={1.5} opacity={0.88} />
+      <circle cx={cx} cy={cy} r={r} fill={fill} style={{ stroke: "var(--background)" }} strokeWidth={1.5} opacity={0.88} />
     </g>
   );
 }

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Monitor, Moon, Sun } from "lucide-react";
+
+type Theme = "system" | "light" | "dark";
+
+const CYCLE: Theme[] = ["system", "light", "dark"];
+
+const NEXT_THEME: Record<Theme, Theme> = {
+  system: "light",
+  light: "dark",
+  dark: "system",
+};
+
+const ICONS: Record<Theme, React.ReactNode> = {
+  system: <Monitor className="h-4 w-4" aria-hidden="true" />,
+  light: <Sun className="h-4 w-4" aria-hidden="true" />,
+  dark: <Moon className="h-4 w-4" aria-hidden="true" />,
+};
+
+const LABELS: Record<Theme, string> = {
+  system: "system",
+  light: "light",
+  dark: "dark",
+};
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  // theme is undefined before mount (SSR / initial hydration)
+  if (theme === undefined) {
+    return <div className="h-9 w-9" />;
+  }
+
+  const current = (CYCLE.includes(theme as Theme) ? theme : "system") as Theme;
+  const next = NEXT_THEME[current];
+
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(next)}
+      aria-label={`Switch to ${LABELS[next]} theme`}
+      className="inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+    >
+      {ICONS[current]}
+    </button>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ioredis": "5.9.3",
     "lucide-react": "0.575.0",
     "next": "16.1.6",
+    "next-themes": "0.4.6",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next-themes:
+        specifier: 0.4.6
+        version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -3665,6 +3668,12 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@16.1.6:
     resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
@@ -8282,6 +8291,11 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  next-themes@0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/tests/components/theme-toggle.test.tsx
+++ b/tests/components/theme-toggle.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeToggle } from "@/components/theme-toggle";
+
+const mockSetTheme = vi.fn();
+let mockTheme = "system";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({
+    theme: mockTheme,
+    setTheme: mockSetTheme,
+  }),
+}));
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    mockSetTheme.mockClear();
+    mockTheme = "system";
+  });
+
+  it("renders without error", () => {
+    const { container } = render(<ThemeToggle />);
+    expect(container).toBeTruthy();
+  });
+
+  it("shows aria-label pointing to next theme when system", () => {
+    mockTheme = "system";
+    render(<ThemeToggle />);
+    // After mount, the button should be present
+    const btn = screen.getByRole("button");
+    expect(btn.getAttribute("aria-label")).toBe("Switch to light theme");
+  });
+
+  it("shows aria-label pointing to next theme when light", () => {
+    mockTheme = "light";
+    render(<ThemeToggle />);
+    const btn = screen.getByRole("button");
+    expect(btn.getAttribute("aria-label")).toBe("Switch to dark theme");
+  });
+
+  it("shows aria-label pointing to next theme when dark", () => {
+    mockTheme = "dark";
+    render(<ThemeToggle />);
+    const btn = screen.getByRole("button");
+    expect(btn.getAttribute("aria-label")).toBe("Switch to system theme");
+  });
+
+  it("cycles system → light on click", () => {
+    mockTheme = "system";
+    render(<ThemeToggle />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(mockSetTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("cycles light → dark on click", () => {
+    mockTheme = "light";
+    render(<ThemeToggle />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("cycles dark → system on click", () => {
+    mockTheme = "dark";
+    render(<ThemeToggle />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(mockSetTheme).toHaveBeenCalledWith("system");
+  });
+});


### PR DESCRIPTION
## Summary

- Install `next-themes@0.4.6` and wrap `<Providers>` with `ThemeProvider` (`attribute="class"`, `defaultTheme="system"`, `enableSystem`)
- New `<ThemeToggle>` component in the footer — cycles system → light → dark → system using Monitor/Sun/Moon icons; uses `theme === undefined` as the SSR/hydration guard (avoids the `react-hooks/set-state-in-effect` lint rule)
- Add `suppressHydrationWarning` to `<html>` to prevent React class-mismatch warnings when next-themes injects `.dark`
- Add `--perf-red`, `--perf-amber`, `--perf-green` OKLCH tokens to `:root` and `.dark` in `globals.css`
- Fix `hf-percent-chart`: `ReferenceArea` fills replaced with `style={{ fill: "var(--perf-*)" }}`; band legend text uses `text-*-600 dark:text-*-400`
- Fix `scatter-chart` `StageNumberDot`: `stroke="white"` / `fill="white"` replaced with `style={{ stroke/fill: "var(--background)" }}`
- Fix `style-fingerprint-chart` `PenaltyDot`: same `stroke` fix
- Fix `stage-cell-parts` classification colors: bumped to `600`-level with `dark:400` variants for WCAG AA contrast

## Test plan

- [ ] `pnpm typecheck` — zero errors
- [ ] `pnpm lint` — zero warnings
- [ ] `pnpm test` — all 374 unit + component tests pass (includes 7 new theme-toggle tests)
- [ ] `pnpm test:e2e` — Playwright tests pass
- [ ] Manual: open app → click theme toggle in footer → verify system/light/dark cycle
- [ ] Manual: check every chart type in dark mode — performance bands visible, dot labels readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)