### PR TITLE
fix: show stage metadata in compare view for future matches with no scorecards

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -3,7 +3,7 @@ import { cachedExecuteQuery, gqlCacheKey, SCORECARDS_QUERY, MATCH_QUERY } from "
 import redis from "@/lib/redis";
 import { formatDivisionDisplay } from "@/lib/divisions";
 import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles, type RawScorecard } from "@/app/api/compare/logic";
-import type { CompareResponse, CompetitorInfo } from "@/lib/types";
+import type { CompareResponse, CompetitorInfo, StageComparison } from "@/lib/types";
 
 // ─── Raw GraphQL response shapes ─────────────────────────────────────────────
 
@@ -255,9 +255,34 @@ export async function GET(req: Request) {
     ])
   );
 
-  const stages = computeGroupRankings(rawScorecards, requestedCompetitors).map(
+  let stages: StageComparison[] = computeGroupRankings(rawScorecards, requestedCompetitors).map(
     (s) => ({ ...s, ...stageMetaMap.get(s.stage_id) })
   );
+
+  // Fallback for future matches: if no scorecards exist yet but stage metadata is
+  // available from the match query, build placeholder rows so the comparison table
+  // shows stage names and metadata. Competitor cells render "—" for undefined entries.
+  if (stages.length === 0 && stageMetaMap.size > 0) {
+    stages = (matchData.event.stages ?? []).map((s) => {
+      const stageId = parseInt(s.id, 10);
+      const meta = stageMetaMap.get(stageId);
+      return {
+        stage_id: stageId,
+        stage_name: s.name,
+        stage_num: s.number,
+        max_points: s.max_points ?? 0,
+        group_leader_hf: null,
+        group_leader_points: null,
+        overall_leader_hf: null,
+        field_median_hf: null,
+        field_competitor_count: 0,
+        stageDifficultyLevel: 3 as const,
+        stageDifficultyLabel: "—",
+        competitors: {},
+        ...(meta ?? {}),
+      } satisfies StageComparison;
+    });
+  }
 
   const tRankings = performance.now();
   console.log(`[compare] computeGroupRankings: ${(tRankings - tFlatten).toFixed(0)}ms`);


### PR DESCRIPTION
## Root cause

The `/api/compare` endpoint builds its `stages` list entirely from `computeGroupRankings()`, which derives stages from raw scorecard records. For future/not-yet-started matches the scorecards array is empty, so `computeGroupRankings([], competitors)` returns `[]` — and the whole comparison view shows nothing when competitors are selected, even though the match already has full stage definitions.

The MATCH_QUERY half of the same request already fetched all stage metadata into `stageMetaMap`, but that map was only used to *enrich* scorecard-derived rows, never as a source of truth on its own.

Verified against live SSI API: match [ESs Black Handgun 2026](https://shootnscoreit.com/event/22/25460/) (starts 2026-06-26) returns 12 stages and 191 competitors but zero scorecards today.

## Fix

In `app/api/compare/route.ts`, after the normal `computeGroupRankings()` call, add a fallback: when `stages.length === 0` but `stageMetaMap.size > 0`, build placeholder `StageComparison` rows directly from the match metadata. Each row carries the stage name, number, `max_points`, and target/round metadata. `competitors: {}` is left empty — `StageCell` in the comparison table already handles `undefined` entries by rendering `—`, so no component changes are needed.

## What users see after the fix

- Selecting competitors on a future match shows the full stage list with stage names, max points, round counts, and links to each stage on SSI
- All numeric cells show `—` (no results yet)
- Charts and coaching panels render their empty/no-data states as usual
- Once the match starts and scorecards arrive, the real data replaces the placeholders automatically (TTL = 30 s for active matches)

## Test plan

- [ ] `pnpm typecheck && pnpm lint && pnpm test` — all pass (387 tests)
- [ ] Open match [ESs Black Handgun 2026](https://shootnscoreit.com/event/22/25460/), select any competitors → 12 stage rows should appear with `—` in each cell
- [ ] A completed match still renders full scorecard data (fallback only activates when `stages.length === 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)