### PR TITLE
feat: new-version detection banner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ actionable interpretation tips. Keep language concise — max ~4 short paragraph
 | `SSI_API_KEY` | `lib/graphql.ts` (server-only) | Never use `NEXT_PUBLIC_` prefix |
 | `REDIS_URL` | `lib/redis.ts` | `redis://localhost:6379` locally, `rediss://...` for Upstash etc. |
 | `CACHE_PURGE_SECRET` | `app/api/admin/cache/purge/route.ts` | Any strong random string; never `NEXT_PUBLIC_` |
+| `NEXT_PUBLIC_BUILD_ID` | `components/update-banner.tsx`, `app/api/version/route.ts` | Git SHA baked into the client bundle at Docker build time; powers new-version detection. Auto-injected by `pnpm docker:build`. Unset in `pnpm dev` — version check is skipped. |
 
 ## Package Manager
 This project uses **pnpm@10.30.1**. Do not use npm or yarn. Use `pnpm add` / `pnpm add -D`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,11 @@ COPY . .
 # Ensure public/ exists so the runner COPY never fails on an empty/absent dir
 RUN mkdir -p /app/public
 
+# Optional: git commit SHA passed by the build script for client-side version
+# detection. Baked into the JS bundle as process.env.NEXT_PUBLIC_BUILD_ID.
+ARG BUILD_ID
+ENV NEXT_PUBLIC_BUILD_ID=${BUILD_ID}
+
 RUN pnpm build
 
 # ─── Runner ──────────────────────────────────────────────────────────────────
@@ -26,6 +31,10 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 ENV PORT=3000
+
+# Carry the build ID into the runtime image so /api/version can return it.
+ARG BUILD_ID
+ENV NEXT_PUBLIC_BUILD_ID=${BUILD_ID}
 
 # Create non-root user
 RUN addgroup --system --gid 1001 nodejs && \

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ so a missing Redis at startup is non-fatal — requests fall back to direct Grap
 | `SSI_API_KEY` | ShootNScoreIt API key — server-side only, never exposed to browser |
 | `REDIS_URL` | Redis connection string (`redis://localhost:6379` locally, `rediss://…` for cloud) |
 | `CACHE_PURGE_SECRET` | Secret for the admin cache-purge endpoint — any strong random string |
+| `NEXT_PUBLIC_BUILD_ID` | Git SHA baked into the bundle at build time for version detection (auto-injected by `pnpm docker:build`) |
 
 ## Usage
 1. Browse upcoming or recent competitions via the built-in event search, or paste a match URL
@@ -91,6 +92,7 @@ so a missing Redis at startup is non-fatal — requests fall back to direct Grap
 - **Country filter** — filter event search by country (ISO 3166-1 alpha-3), defaults to Sweden (SWE)
 - **Extended date range** — event search window up to 5 years back (Upcoming / 3 mo / 6 mo / 1 yr / 2 yr / 3 yr / 5 yr)
 - **Redis cache** — server-side GraphQL caching with smart TTL and admin purge endpoint
+- **New-version banner** — polls `/api/version` every 60 s; shows a non-blocking refresh prompt when a new deployment is detected
 - **Mobile-first** — designed for one-handed use at 390px; no unintentional horizontal overflow
 
 ## Development Commands

--- a/app/api/version/route.ts
+++ b/app/api/version/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+// Always dynamic — must return the live server value, never a cached snapshot.
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json(
+    { buildId: process.env.NEXT_PUBLIC_BUILD_ID ?? null },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Crosshair, Github } from "lucide-react";
 import { Providers } from "@/components/providers";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { UpdateBanner } from "@/components/update-banner";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -30,6 +31,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}>
         <Providers>
+          <UpdateBanner />
           {children}
           <footer className="w-full flex flex-col items-center gap-2 p-4 text-xs text-muted-foreground border-t border-border mt-auto">
             <div className="flex items-center gap-4">

--- a/components/update-banner.tsx
+++ b/components/update-banner.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { RefreshCw, X } from "lucide-react";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export function UpdateBanner() {
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+
+  useEffect(() => {
+    const clientBuildId = process.env.NEXT_PUBLIC_BUILD_ID;
+    // No build ID means local dev — skip entirely.
+    if (!clientBuildId) return;
+
+    async function checkVersion() {
+      if (document.visibilityState !== "visible") return;
+      try {
+        const res = await fetch("/api/version", { cache: "no-store" });
+        if (!res.ok) return;
+        const { buildId } = (await res.json()) as { buildId: string | null };
+        if (buildId && buildId !== clientBuildId) {
+          setUpdateAvailable(true);
+        }
+      } catch {
+        // Network error — silently ignore, try again next interval.
+      }
+    }
+
+    const id = setInterval(checkVersion, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!updateAvailable) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-0 inset-x-0 z-50 flex items-center justify-between gap-3 px-4 py-3 bg-primary text-primary-foreground text-sm shadow-lg"
+    >
+      <div className="flex items-center gap-2">
+        <RefreshCw className="w-4 h-4 shrink-0" aria-hidden="true" />
+        <span>A new version is available.</span>
+      </div>
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="px-3 py-1 rounded-full bg-primary-foreground/15 hover:bg-primary-foreground/25 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-primary"
+        >
+          Refresh
+        </button>
+        <button
+          type="button"
+          aria-label="Dismiss update notification"
+          onClick={() => setUpdateAvailable(false)}
+          className="flex items-center justify-center min-w-[44px] min-h-[44px] opacity-70 hover:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-primary"
+        >
+          <X className="w-4 h-4" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
   app:
     build:
       context: .
+      args:
+        BUILD_ID: ${BUILD_ID:-}
     ports:
       - "${PORT:-3666}:3000"
     environment:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "check": "pnpm lint && pnpm typecheck && pnpm test",
-    "docker:build": "docker compose build",
+    "docker:build": "BUILD_ID=$(git rev-parse --short HEAD 2>/dev/null || echo '') docker compose build",
     "docker:up": "docker compose --env-file .env.local up",
     "docker:down": "docker compose down",
     "setup": "cp -n .env.local.example .env.local || true"


### PR DESCRIPTION
## What and why

Next.js has no built-in mechanism to tell clients when a new deployment has happened. Since this app is deployed frequently and used live at competitions, stale clients silently serving old JS is undesirable.

## How it works

**Build time:** `pnpm docker:build` now injects `BUILD_ID=$(git rev-parse --short HEAD)` as a Docker build arg. The Dockerfile exposes it in both the builder stage (so Next.js bakes it into the client bundle as the compile-time constant `process.env.NEXT_PUBLIC_BUILD_ID`) and the runner stage (so the same value is available to the Node.js server process at runtime).

**Runtime:** `/api/version` (new, force-dynamic, no-store) returns `{ buildId: process.env.NEXT_PUBLIC_BUILD_ID }` — always the value for the *currently running* deployment.

**Client:** `UpdateBanner` polls `/api/version` every 60 s (only when the tab is visible). When the server's `buildId` differs from the compile-time constant baked into the bundle, `updateAvailable` flips to `true` and the banner appears.

**Local dev:** `NEXT_PUBLIC_BUILD_ID` is not set → the `if (!clientBuildId) return` guard skips all polling. Zero overhead in development.

## UI

Fixed bottom strip with:
- `role="status" aria-live="polite"` for screen-reader announcement
- **Refresh** button → `window.location.reload()` (full reload to pick up new bundles)
- **✕** dismiss button with 44 px touch target and visible focus ring against the dark background

## Files changed

| File | Change |
|---|---|
| `app/api/version/route.ts` | New — returns current `NEXT_PUBLIC_BUILD_ID` |
| `components/update-banner.tsx` | New — polling hook + banner UI |
| `app/layout.tsx` | Mount `<UpdateBanner />` once in root layout |
| `Dockerfile` | `ARG BUILD_ID` + `ENV NEXT_PUBLIC_BUILD_ID` in both builder and runner stages |
| `docker-compose.yml` | `build.args.BUILD_ID: ${BUILD_ID:-}` to pass the arg through |
| `package.json` | `docker:build` script auto-injects git SHA |
| `CLAUDE.md` / `README.md` | Document `NEXT_PUBLIC_BUILD_ID` |

## Test plan

- [ ] `pnpm typecheck && pnpm lint && pnpm test` — all pass
- [ ] `pnpm dev` — no polling, no banner, no console errors
- [ ] Build with `BUILD_ID=abc123 docker compose build`, set `NEXT_PUBLIC_BUILD_ID=xyz999` in the running container's env → banner appears within 60 s
- [ ] Refresh button reloads the page; dismiss button hides the banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)