### PR TITLE
feat: add About page and Buy Me a Coffee links

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,150 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Github, Crosshair, Coffee } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "About – SSI Scoreboard",
+  description:
+    "About SSI Scoreboard – a free, open-source stage-by-stage IPSC competitor comparison tool.",
+};
+
+export default function AboutPage() {
+  return (
+    <main className="min-h-screen flex flex-col items-center p-4 pt-8 sm:p-6 sm:pt-12">
+      <div className="w-full max-w-2xl space-y-10">
+        <div>
+          <Link
+            href="/"
+            className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4"
+          >
+            ← Back to SSI Scoreboard
+          </Link>
+        </div>
+
+        <h1 className="text-2xl font-bold">About SSI Scoreboard</h1>
+
+        <section aria-labelledby="about-what-heading" className="space-y-4">
+          <h2
+            id="about-what-heading"
+            className="text-xl font-semibold border-b border-border pb-2"
+          >
+            What is this?
+          </h2>
+          <div className="text-sm leading-relaxed text-muted-foreground space-y-3">
+            <p>
+              SSI Scoreboard is a free, open-source tool for comparing IPSC
+              competitors stage by stage. Whether you&apos;re reviewing your own
+              match after the fact, comparing scores with friends, or breaking
+              down a squad&apos;s performance for coaching — this is the fastest way
+              to get a clear picture.
+            </p>
+            <p>
+              Match data is fetched from{" "}
+              <a
+                href="https://shootnscoreit.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline underline-offset-4 hover:text-foreground"
+                aria-label="Shoot'n Score It (opens in new tab)"
+              >
+                ShootNScoreIt
+              </a>
+              , the scoring platform used at IPSC competitions across Scandinavia
+              and beyond. SSI Scoreboard is an independent application and is not
+              affiliated with or endorsed by ShootNScoreIt.
+            </p>
+          </div>
+        </section>
+
+        <section aria-labelledby="about-features-heading" className="space-y-4">
+          <h2
+            id="about-features-heading"
+            className="text-xl font-semibold border-b border-border pb-2"
+          >
+            Features
+          </h2>
+          <ul className="text-sm leading-relaxed text-muted-foreground space-y-2 list-disc list-inside">
+            <li>Search competitions by name, country, or date range</li>
+            <li>Compare up to 10 competitors side-by-side across all stages</li>
+            <li>Stage-by-stage scoring breakdown with hit factor and points</li>
+            <li>
+              What-if analysis — see how rankings would change by group, division,
+              or overall
+            </li>
+            <li>Great for post-match review, squad comparisons, and coaching</li>
+            <li>No login required — paste a match URL and go</li>
+          </ul>
+        </section>
+
+        <section aria-labelledby="about-links-heading" className="space-y-4">
+          <h2
+            id="about-links-heading"
+            className="text-xl font-semibold border-b border-border pb-2"
+          >
+            Links
+          </h2>
+          <div className="flex flex-col gap-3">
+            <a
+              href="https://github.com/mandakan/ssi-scoreboard"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-3 p-4 rounded-lg border border-border hover:bg-accent hover:text-accent-foreground transition-colors"
+              aria-label="Source code on GitHub (opens in new tab)"
+            >
+              <Github className="w-5 h-5 shrink-0" aria-hidden="true" />
+              <div>
+                <p className="font-medium text-sm">GitHub</p>
+                <p className="text-xs text-muted-foreground">
+                  View the source code, report issues, or contribute
+                </p>
+              </div>
+            </a>
+            <a
+              href="https://shootnscoreit.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-3 p-4 rounded-lg border border-border hover:bg-accent hover:text-accent-foreground transition-colors"
+              aria-label="Shoot'n Score It (opens in new tab)"
+            >
+              <Crosshair className="w-5 h-5 shrink-0" aria-hidden="true" />
+              <div>
+                <p className="font-medium text-sm">Shoot&apos;n Score It</p>
+                <p className="text-xs text-muted-foreground">
+                  The match scoring platform powering this app
+                </p>
+              </div>
+            </a>
+            <a
+              href="https://www.buymeacoffee.com/thias"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-3 p-4 rounded-lg border border-[#FFDD00] bg-[#FFDD00]/10 hover:bg-[#FFDD00]/20 text-foreground transition-colors"
+              aria-label="Buy me a coffee on Buy Me a Coffee (opens in new tab)"
+            >
+              <Coffee className="w-5 h-5 shrink-0" aria-hidden="true" />
+              <div>
+                <p className="font-medium text-sm">Buy me a coffee</p>
+                <p className="text-xs text-muted-foreground">
+                  If this tool is useful to you, a coffee is always appreciated!
+                </p>
+              </div>
+            </a>
+          </div>
+        </section>
+
+        <section aria-labelledby="about-built-heading" className="space-y-4">
+          <h2
+            id="about-built-heading"
+            className="text-xl font-semibold border-b border-border pb-2"
+          >
+            Built with
+          </h2>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            Next.js 15, React, Tailwind CSS v4, shadcn/ui, TanStack Query v5,
+            and Redis for caching. Open source — contributions welcome.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
-import { Crosshair, Github } from "lucide-react";
+import { Coffee, Crosshair, Github } from "lucide-react";
 import { Providers } from "@/components/providers";
 import { ThemeToggle } from "@/components/theme-toggle";
 import "./globals.css";
@@ -32,6 +32,17 @@ export default function RootLayout({
         <Providers>
           {children}
           <footer className="w-full flex flex-col items-center gap-2 p-4 text-xs text-muted-foreground border-t border-border mt-auto">
+            {/* Buy me a coffee button – visible on sm+ screens */}
+            <a
+              href="https://www.buymeacoffee.com/thias"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hidden sm:inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[#FFDD00] text-black font-medium text-sm hover:opacity-90 transition-opacity"
+              aria-label="Buy me a coffee on Buy Me a Coffee (opens in new tab)"
+            >
+              <Coffee className="w-4 h-4" aria-hidden="true" />
+              Buy me a coffee
+            </a>
             <div className="flex items-center gap-4">
               <ThemeToggle />
               <a
@@ -52,6 +63,22 @@ export default function RootLayout({
               >
                 <Github className="w-4 h-4" aria-hidden="true" />
               </a>
+              {/* Coffee icon link – mobile only (hidden on sm+) */}
+              <a
+                href="https://www.buymeacoffee.com/thias"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="sm:hidden inline-flex items-center hover:text-foreground transition-colors"
+                aria-label="Buy me a coffee on Buy Me a Coffee (opens in new tab)"
+              >
+                <Coffee className="w-4 h-4" aria-hidden="true" />
+              </a>
+              <Link
+                href="/about"
+                className="inline-flex items-center hover:text-foreground transition-colors"
+              >
+                About
+              </Link>
               <Link
                 href="/legal"
                 className="inline-flex items-center hover:text-foreground transition-colors"


### PR DESCRIPTION
## Summary

- New `/about` page with app background, features list, and card-style links to GitHub, ShootNScoreIt, and Buy Me a Coffee
- Footer: yellow BMC button (BMC brand colours) on `sm+` screens; coffee icon link on mobile
- Footer: "About" link added alongside "Terms & Privacy"

## Notes

- Custom styled link used instead of the external BMC script tag — no third-party JS, no privacy policy changes needed
- Max competitors corrected to 10 (confirmed from `MAX_SELECTED` in `competitor-picker.tsx`)
- About page framing emphasises post-match review, squad comparison, and coaching rather than live tracking

## Test plan

- [ ] Visit `/about` — verify all three link cards render and open correct URLs
- [ ] Check footer at mobile width (390px): coffee icon visible, yellow button hidden
- [ ] Check footer at desktop width (≥640px): yellow "Buy me a coffee" button visible, icon hidden
- [ ] Verify dark mode looks correct on both the About page and footer BMC button
- [ ] `pnpm typecheck && pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)