### PR TITLE
feat: squad picker, 12-competitor limit, remove stage list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ so a missing Redis at startup is non-fatal — requests fall back to direct Grap
 ## Usage
 1. Browse upcoming or recent competitions via the built-in event search, or paste a match URL
    (e.g. `https://shootnscoreit.com/event/22/26547/`) directly into the input field
-2. Search for and select up to 10 competitors by name, number, or club
+2. Select competitors individually by name, number, or club — or tap **Add squad** to load an
+   entire IPSC squad at once (up to 12 competitors total)
 3. Multiple analysis views update immediately:
    - **Stage table** — hit factors, raw points, time, A/C/D/M hit zone breakdown, rank, percentile
      placement, shooting order, stage difficulty, and run classification per stage; switch to
@@ -62,6 +63,7 @@ so a missing Redis at startup is non-fatal — requests fall back to direct Grap
 
 ## Features
 - **Live data** — works during active matches before official results are published
+- **Squad picker** — add all members of an IPSC squad in one tap; up to 12 competitors total
 - **Dark mode** — toggle between light and dark themes
 - **Group / Division / Overall rankings** — toggle the ranking context in the stage table
 - **Delta heatmap** — colour-coded table view showing each cell relative to the group leader

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -65,7 +65,11 @@ export default function AboutPage() {
           </h2>
           <ul className="text-sm leading-relaxed text-muted-foreground space-y-2 list-disc list-inside">
             <li>Search competitions by name, country, or date range</li>
-            <li>Compare up to 10 competitors side-by-side across all stages</li>
+            <li>Compare up to 12 competitors side-by-side across all stages</li>
+            <li>
+              Add an entire IPSC squad in one tap with the squad picker — no
+              need to select members one by one
+            </li>
             <li>Stage-by-stage scoring breakdown with hit factor and points</li>
             <li>
               What-if analysis — see how rankings would change by group, division,

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { MAX_COMPETITORS } from "@/lib/constants";
 import { cachedExecuteQuery, gqlCacheKey, SCORECARDS_QUERY, MATCH_QUERY } from "@/lib/graphql";
 import redis from "@/lib/redis";
 import { formatDivisionDisplay } from "@/lib/divisions";
@@ -106,9 +107,9 @@ export async function GET(req: Request) {
     .map((s) => parseInt(s.trim(), 10))
     .filter((n) => !isNaN(n));
 
-  if (competitorIds.length === 0 || competitorIds.length > 10) {
+  if (competitorIds.length === 0 || competitorIds.length > MAX_COMPETITORS) {
     return NextResponse.json(
-      { error: "Between 1 and 10 competitor_ids required" },
+      { error: `Between 1 and ${MAX_COMPETITORS} competitor_ids required` },
       { status: 400 }
     );
   }

--- a/app/api/match/[ct]/[id]/route.ts
+++ b/app/api/match/[ct]/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { cachedExecuteQuery, gqlCacheKey, MATCH_QUERY } from "@/lib/graphql";
 import redis from "@/lib/redis";
 import { formatDivisionDisplay } from "@/lib/divisions";
-import type { MatchResponse, StageInfo, CompetitorInfo } from "@/lib/types";
+import type { MatchResponse, StageInfo, CompetitorInfo, SquadInfo } from "@/lib/types";
 
 interface RawStage {
   id: string;
@@ -28,6 +28,13 @@ interface RawCompetitor {
   shoots_handgun_major?: boolean | null;
 }
 
+interface RawSquad {
+  id: string;
+  number?: number;
+  get_squad_display?: string;
+  competitors?: Array<{ id: string }>;
+}
+
 interface RawMatchData {
   event: {
     id: string;
@@ -44,6 +51,7 @@ interface RawMatchData {
     competitors_count?: number;
     stages?: RawStage[];
     competitors_approved_w_wo_results_not_dnf?: RawCompetitor[];
+    squads?: RawSquad[];
   } | null;
 }
 
@@ -120,6 +128,22 @@ export async function GET(
     division: formatDivisionDisplay(c.get_handgun_div_display ?? c.handgun_div, c.shoots_handgun_major),
   }));
 
+  const approvedIds = new Set(competitors.map((c) => c.id));
+  const squads: SquadInfo[] = (ev.squads ?? [])
+    .map((s) => {
+      const competitorIds = (s.competitors ?? [])
+        .map((c) => parseInt(c.id, 10))
+        .filter((cid) => approvedIds.has(cid))
+        .sort((a, b) => a - b);
+      return {
+        id: parseInt(s.id, 10),
+        number: s.number ?? 0,
+        name: s.get_squad_display ?? `Squad ${s.number ?? "?"}`,
+        competitorIds,
+      };
+    })
+    .filter((s) => s.competitorIds.length > 0);
+
   const response: MatchResponse = {
     name: ev.name,
     venue: ev.venue ?? null,
@@ -136,6 +160,7 @@ export async function GET(
     ssi_url: `https://shootnscoreit.com/event/${ct}/${id}/`,
     stages,
     competitors,
+    squads,
     cacheInfo: { cachedAt },
   };
 

--- a/app/match/[ct]/[id]/page.tsx
+++ b/app/match/[ct]/[id]/page.tsx
@@ -8,9 +8,9 @@ const EMPTY_IDS: number[] = [];
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { MatchHeader } from "@/components/match-header";
-import { StageList } from "@/components/stage-list";
 import { ShareButton } from "@/components/share-button";
 import { CompetitorPicker } from "@/components/competitor-picker";
+import { SquadPicker } from "@/components/squad-picker";
 import { ComparisonTable } from "@/components/comparison-table";
 import { ComparisonChart } from "@/components/comparison-chart";
 import { HfPercentChart } from "@/components/hf-percent-chart";
@@ -201,17 +201,23 @@ export default function MatchPage() {
       {/* Match header */}
       <MatchHeader match={match} />
 
-      {/* Stage list */}
-      <StageList stages={match.stages} />
-
       {/* Competitor picker */}
       <div className="space-y-1">
         <p className="text-sm font-medium">Compare competitors</p>
-        <CompetitorPicker
-          competitors={match.competitors}
-          selectedIds={selectedIds}
-          onSelectionChange={handleSelectionChange}
-        />
+        <div className="flex items-start gap-2 flex-wrap">
+          <CompetitorPicker
+            competitors={match.competitors}
+            selectedIds={selectedIds}
+            onSelectionChange={handleSelectionChange}
+          />
+          {match.squads.length > 0 && (
+            <SquadPicker
+              squads={match.squads}
+              selectedIds={selectedIds}
+              onSelectionChange={handleSelectionChange}
+            />
+          )}
+        </div>
       </div>
 
       {/* Comparison views */}
@@ -266,7 +272,11 @@ export default function MatchPage() {
                     </span>
                   )}
                 </div>
-                <ComparisonTable data={compareQuery.data} scoringCompleted={match.scoring_completed} />
+                <ComparisonTable
+                  data={compareQuery.data}
+                  scoringCompleted={match.scoring_completed}
+                  onRemove={(id) => handleSelectionChange(selectedIds.filter((s) => s !== id))}
+                />
               </div>
 
               <div className="rounded-lg border p-4 space-y-3">

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -12,7 +12,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { AlertTriangle, CheckCircle2, ChevronDown, ChevronUp, Crosshair, ExternalLink, Flame, Gauge, HelpCircle, Info, Shield, Target, TrendingUp, Zap } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ChevronDown, ChevronUp, Crosshair, ExternalLink, Flame, Gauge, HelpCircle, Info, Shield, Target, TrendingUp, X, Zap } from "lucide-react";
 import { cn, formatHF, formatTime, formatPct, computePointsDelta, formatDelta } from "@/lib/utils";
 import { buildColorMap } from "@/lib/colors";
 import { HitZoneBar } from "@/components/hit-zone-bar";
@@ -23,6 +23,7 @@ import type { CompareResponse, CompetitorInfo, CompetitorSummary, LossBreakdownS
 interface ComparisonTableProps {
   data: CompareResponse;
   scoringCompleted: number;
+  onRemove?: (id: number) => void;
 }
 
 /**
@@ -322,7 +323,7 @@ function CompetitorLossPanel({
 
 const MODE_LABELS: Record<PctMode, string> = {
   group: "Group",
-  division: "Division",
+  division: "Div",
   overall: "Overall",
 };
 
@@ -474,7 +475,7 @@ function ArchetypePill({ archetype, color }: { archetype: ShooterArchetype; colo
   );
 }
 
-export function ComparisonTable({ data, scoringCompleted }: ComparisonTableProps) {
+export function ComparisonTable({ data, scoringCompleted, onRemove }: ComparisonTableProps) {
   const { stages, competitors, penaltyStats, efficiencyStats, consistencyStats, lossBreakdownStats, whatIfStats, styleFingerprintStats } = data;
   const [mode, setMode] = useState<PctMode>("group");
   const [viewMode, setViewMode] = useState<ViewMode>("absolute");
@@ -595,24 +596,18 @@ export function ComparisonTable({ data, scoringCompleted }: ComparisonTableProps
         </div>
       ))}
 
-      {/* View mode toggle (Absolute / Delta) */}
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <ViewModeToggle viewMode={viewMode} onChange={setViewMode} />
-          {viewMode === "absolute" && (
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-muted-foreground">% relative to:</span>
-              <ModeToggle mode={mode} onChange={setMode} />
-            </div>
-          )}
-        </div>
+      {/* View mode toggle (Absolute / Delta) + percentage context + help */}
+      <div className="flex items-center gap-2">
+        <ViewModeToggle viewMode={viewMode} onChange={setViewMode} />
+        {viewMode === "absolute" && (
+          <ModeToggle mode={mode} onChange={setMode} />
+        )}
         <button
           onClick={() => setHelpOpen(true)}
-          className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground hover:text-foreground rounded px-1.5 py-1 hover:bg-muted transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+          className="ml-auto shrink-0 inline-flex items-center justify-center text-muted-foreground hover:text-foreground rounded p-1.5 hover:bg-muted transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
           aria-label="How to read this table"
         >
-          <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
-          <span>Help</span>
+          <HelpCircle className="w-4 h-4" aria-hidden="true" />
         </button>
       </div>
 
@@ -636,9 +631,18 @@ export function ComparisonTable({ data, scoringCompleted }: ComparisonTableProps
                 return (
                   <th
                     key={comp.id}
-                    className="py-2 px-3 text-center font-medium min-w-[5.5rem] sm:min-w-32"
+                    className="relative py-2 px-3 text-center font-medium min-w-[5.5rem] sm:min-w-32"
                     style={{ borderBottom: `3px solid ${colorMap[comp.id]}` }}
                   >
+                    {onRemove && (
+                      <button
+                        onClick={() => onRemove(comp.id)}
+                        className="absolute top-0 right-0 p-2 rounded-bl text-muted-foreground hover:text-foreground hover:bg-muted transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+                        aria-label={`Remove ${comp.name}`}
+                      >
+                        <X className="w-3 h-3" aria-hidden="true" />
+                      </button>
+                    )}
                     <div className="flex flex-col items-center gap-0.5">
                       <span className="font-mono text-xs text-muted-foreground">
                         #{comp.competitor_number}
@@ -1108,6 +1112,10 @@ export function ComparisonTable({ data, scoringCompleted }: ComparisonTableProps
               aria-labelledby="whatif-heading"
               className="px-4 pb-4 space-y-4 border-t border-sky-200 dark:border-sky-900/50 pt-4"
             >
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">Rank context:</span>
+                <ModeToggle mode={mode} onChange={setMode} />
+              </div>
               <div className="space-y-5">
                 {competitors.map((comp) => {
                   const wi = whatIfStats[comp.id];

--- a/components/competitor-picker.tsx
+++ b/components/competitor-picker.tsx
@@ -16,11 +16,10 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { Users, X, Check } from "lucide-react";
+import { Users, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { CompetitorInfo } from "@/lib/types";
-
-const MAX_SELECTED = 10;
+import { MAX_COMPETITORS } from "@/lib/constants";
 
 interface CompetitorPickerProps {
   competitors: CompetitorInfo[];
@@ -40,97 +39,73 @@ export function CompetitorPicker({
   function toggle(id: number) {
     if (selectedSet.has(id)) {
       onSelectionChange(selectedIds.filter((s) => s !== id));
-    } else if (selectedIds.length < MAX_SELECTED) {
+    } else if (selectedIds.length < MAX_COMPETITORS) {
       onSelectionChange([...selectedIds, id]);
     }
   }
 
-  function remove(id: number) {
-    onSelectionChange(selectedIds.filter((s) => s !== id));
-  }
-
-  const selectedCompetitors = selectedIds
-    .map((id) => competitors.find((c) => c.id === id))
-    .filter(Boolean) as CompetitorInfo[];
-
   return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-2 flex-wrap">
-        <Popover open={open} onOpenChange={setOpen}>
-          <PopoverTrigger asChild>
-            <Button variant="outline" size="sm" className="gap-2">
-              <Users className="w-4 h-4" />
-              Add competitor
-              {selectedIds.length > 0 && (
-                <Badge variant="secondary" className="ml-1">
-                  {selectedIds.length}/{MAX_SELECTED}
-                </Badge>
-              )}
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="p-0 w-[min(18rem,calc(100vw-2rem))]" align="start">
-            <Command>
-              <CommandInput placeholder="Search by name, number, or club…" />
-              <CommandList>
-                <CommandEmpty>No competitors found.</CommandEmpty>
-                <CommandGroup>
-                  {competitors.map((c) => {
-                    const isSelected = selectedSet.has(c.id);
-                    const isDisabled = !isSelected && selectedIds.length >= MAX_SELECTED;
-                    return (
-                      <CommandItem
-                        key={c.id}
-                        value={`${c.competitor_number} ${c.name} ${c.club ?? ""}`}
-                        onSelect={() => toggle(c.id)}
-                        disabled={isDisabled}
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="sm" className="gap-2">
+            <Users className="w-4 h-4" />
+            Add competitor
+            {selectedIds.length > 0 && (
+              <Badge variant="secondary" className="ml-1">
+                {selectedIds.length}/{MAX_COMPETITORS}
+              </Badge>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="p-0 w-[min(18rem,calc(100vw-2rem))]" align="start">
+          <Command>
+            <CommandInput placeholder="Search by name, number, or club…" />
+            <CommandList>
+              <CommandEmpty>No competitors found.</CommandEmpty>
+              <CommandGroup>
+                {competitors.map((c) => {
+                  const isSelected = selectedSet.has(c.id);
+                  const isDisabled = !isSelected && selectedIds.length >= MAX_COMPETITORS;
+                  return (
+                    <CommandItem
+                      key={c.id}
+                      value={`${c.competitor_number} ${c.name} ${c.club ?? ""}`}
+                      onSelect={() => toggle(c.id)}
+                      disabled={isDisabled}
+                      className={cn(
+                        "flex items-center gap-2",
+                        isDisabled && "opacity-50 cursor-not-allowed"
+                      )}
+                    >
+                      <Check
                         className={cn(
-                          "flex items-center gap-2",
-                          isDisabled && "opacity-50 cursor-not-allowed"
+                          "w-4 h-4 shrink-0",
+                          isSelected ? "opacity-100" : "opacity-0"
                         )}
-                      >
-                        <Check
-                          className={cn(
-                            "w-4 h-4 shrink-0",
-                            isSelected ? "opacity-100" : "opacity-0"
-                          )}
-                        />
-                        <span className="font-mono text-xs text-muted-foreground w-8 shrink-0">
-                          #{c.competitor_number}
+                      />
+                      <span className="font-mono text-xs text-muted-foreground w-8 shrink-0">
+                        #{c.competitor_number}
+                      </span>
+                      <span className="flex-1 truncate">{c.name}</span>
+                      {c.club && (
+                        <span className="text-xs text-muted-foreground truncate max-w-20">
+                          {c.club}
                         </span>
-                        <span className="flex-1 truncate">{c.name}</span>
-                        {c.club && (
-                          <span className="text-xs text-muted-foreground truncate max-w-20">
-                            {c.club}
-                          </span>
-                        )}
-                      </CommandItem>
-                    );
-                  })}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
-
-        {selectedCompetitors.map((c) => (
-          <Badge key={c.id} variant="secondary" className="gap-1 pr-1">
-            <span className="font-mono text-xs">#{c.competitor_number}</span>
-            <span>{c.name}</span>
-            <button
-              onClick={() => remove(c.id)}
-              className="ml-1 rounded-sm hover:bg-muted p-0.5"
-              aria-label={`Remove ${c.name}`}
-            >
-              <X className="w-3 h-3" />
-            </button>
-          </Badge>
-        ))}
-      </div>
-      {selectedIds.length >= MAX_SELECTED && (
+                      )}
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {selectedIds.length >= MAX_COMPETITORS && (
         <p className="text-xs text-muted-foreground">
-          Maximum {MAX_SELECTED} competitors selected.
+          Maximum {MAX_COMPETITORS} competitors selected.
         </p>
       )}
-    </div>
+    </>
   );
 }

--- a/components/squad-picker.tsx
+++ b/components/squad-picker.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Check, UsersRound } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { SquadInfo } from "@/lib/types";
+import { MAX_COMPETITORS } from "@/lib/constants";
+
+interface SquadPickerProps {
+  squads: SquadInfo[];
+  selectedIds: number[];
+  onSelectionChange: (ids: number[]) => void;
+}
+
+export function SquadPicker({
+  squads,
+  selectedIds,
+  onSelectionChange,
+}: SquadPickerProps) {
+  const [open, setOpen] = useState(false);
+  // Tracks per-squad add feedback while the popover is open.
+  // key = squad id, value = feedback string
+  const [feedback, setFeedback] = useState<Record<number, string>>({});
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (!nextOpen) setFeedback({});
+  }
+
+  function handleAdd(squad: SquadInfo) {
+    const selectedSet = new Set(selectedIds);
+    const remaining = MAX_COMPETITORS - selectedIds.length;
+    const toAdd = squad.competitorIds.filter((cid) => !selectedSet.has(cid));
+
+    if (toAdd.length === 0) return;
+
+    const added = toAdd.slice(0, remaining);
+    const nextIds = [...selectedIds, ...added];
+    onSelectionChange(nextIds);
+
+    const limitReached = added.length < toAdd.length;
+    const msg = limitReached
+      ? `Added ${added.length} of ${toAdd.length} — limit reached`
+      : `Added ${added.length}`;
+    setFeedback((prev) => ({ ...prev, [squad.id]: msg }));
+  }
+
+  if (squads.length === 0) return null;
+
+  const selectedSet = new Set(selectedIds);
+  const remaining = MAX_COMPETITORS - selectedIds.length;
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-2"
+          aria-label="Add squad"
+        >
+          <UsersRound className="w-4 h-4" />
+          Add squad
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="p-0 w-[min(20rem,calc(100vw-2rem))]"
+        align="start"
+      >
+        <div className="max-h-72 overflow-y-auto">
+          <div className="p-1">
+            {squads.length === 0 ? (
+              <p className="py-3 px-3 text-sm text-muted-foreground text-center">
+                No squads found
+              </p>
+            ) : (
+              squads.map((squad) => {
+                const memberCount = squad.competitorIds.length;
+                const tooLarge = memberCount > MAX_COMPETITORS;
+                const allSelected =
+                  !tooLarge &&
+                  squad.competitorIds.every((cid) => selectedSet.has(cid));
+                const hasFeedback = Boolean(feedback[squad.id]);
+                const isAddable =
+                  !tooLarge && !allSelected && remaining > 0;
+
+                return (
+                  <div
+                    key={squad.id}
+                    className={cn(
+                      "flex items-center justify-between gap-2 rounded-sm px-3 py-2 text-sm",
+                      tooLarge && "opacity-50"
+                    )}
+                  >
+                    <span className="flex-1 truncate">
+                      {squad.name}
+                      <span className="ml-1 text-xs text-muted-foreground">
+                        · {memberCount} member{memberCount !== 1 ? "s" : ""}
+                      </span>
+                    </span>
+
+                    {tooLarge ? (
+                      <span className="text-xs text-muted-foreground whitespace-nowrap">
+                        Exceeds {MAX_COMPETITORS}-competitor limit
+                      </span>
+                    ) : allSelected ? (
+                      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground whitespace-nowrap">
+                        <Check className="w-3 h-3" aria-hidden="true" />
+                        All added
+                      </span>
+                    ) : hasFeedback ? (
+                      <span className="text-xs text-muted-foreground whitespace-nowrap">
+                        {feedback[squad.id]}
+                      </span>
+                    ) : (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 px-2 text-xs"
+                        disabled={!isAddable}
+                        aria-label={`Add ${squad.name}`}
+                        onClick={() => handleAdd(squad)}
+                      >
+                        Add
+                      </Button>
+                    )}
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
+        <div className="border-t px-3 py-2">
+          <p className="text-xs text-muted-foreground">
+            {remaining > 0
+              ? `${remaining} slot${remaining !== 1 ? "s" : ""} remaining`
+              : `Limit of ${MAX_COMPETITORS} reached`}
+          </p>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -11,6 +11,8 @@ const PALETTE = [
   "#f97316", // orange-500
   "#6366f1", // indigo-500
   "#84cc16", // lime-500
+  "#06b6d4", // cyan-500
+  "#f43f5e", // rose-500
 ];
 
 /**

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,3 @@
+// Shared constants used across server and client code.
+
+export const MAX_COMPETITORS = 12;

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -125,6 +125,16 @@ export const MATCH_QUERY = `
             shoots_handgun_major
           }
         }
+        squads {
+          id
+          ... on IpscSquadNode {
+            number
+            get_squad_display
+            competitors {
+              id
+            }
+          }
+        }
       }
     }
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,6 +20,13 @@ export interface CompetitorInfo {
   division: string | null;
 }
 
+export interface SquadInfo {
+  id: number;
+  number: number;
+  name: string;           // e.g. "Squad 1"
+  competitorIds: number[]; // approved, non-DNF competitor IDs in this squad
+}
+
 export interface CacheInfo {
   cachedAt: string | null; // ISO string of when data was cached; null if just fetched fresh
 }
@@ -37,6 +44,7 @@ export interface MatchResponse {
   ssi_url: string | null;
   stages: StageInfo[];
   competitors: CompetitorInfo[];
+  squads: SquadInfo[];
   cacheInfo: CacheInfo;
 }
 

--- a/tests/components/comparison-table.test.tsx
+++ b/tests/components/comparison-table.test.tsx
@@ -236,7 +236,7 @@ describe("ComparisonTable", () => {
   it("renders mode toggle buttons", () => {
     renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     expect(screen.getByText("Group")).toBeInTheDocument();
-    expect(screen.getByText("Division")).toBeInTheDocument();
+    expect(screen.getByText("Div")).toBeInTheDocument();
     expect(screen.getByText("Overall")).toBeInTheDocument();
   });
 
@@ -508,10 +508,10 @@ describe("ComparisonTable — delta view mode", () => {
   it("hides % reference toggle in delta mode", () => {
     renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
     // % toggle visible in absolute mode
-    expect(screen.getByText("% relative to:")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Percentage reference" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Delta" }));
     // % toggle hidden in delta mode
-    expect(screen.queryByText("% relative to:")).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Percentage reference" })).not.toBeInTheDocument();
   });
 
   it("tie case: two competitors with equal points both show ±0.0 pts in delta mode", () => {

--- a/tests/components/match-header.test.tsx
+++ b/tests/components/match-header.test.tsx
@@ -17,6 +17,7 @@ const baseMatch: MatchResponse = {
   ssi_url: "https://shootnscoreit.com/event/22/123/",
   stages: [],
   competitors: [],
+  squads: [],
 };
 
 describe("MatchHeader", () => {

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -23,6 +23,10 @@ const MOCK_MATCH: MatchResponse = {
     { id: 200, name: "Bob Shooter", competitor_number: "50", club: "Test Club", division: "Standard" },
     { id: 300, name: "Charlie Marksman", competitor_number: "116", club: null, division: null },
   ],
+  squads: [
+    { id: 1, number: 1, name: "Squad 1", competitorIds: [100, 200] },
+    { id: 2, number: 2, name: "Squad 2", competitorIds: [300] },
+  ],
 };
 
 const MOCK_COMPARE: CompareResponse = {
@@ -161,8 +165,8 @@ test.describe("Scoreboard E2E", () => {
 
     await page.waitForURL("/match/22/26547");
     await expect(page.getByText("Test IPSC Match")).toBeVisible();
-    // StageList should be present (collapsed by default)
-    await expect(page.getByRole("button", { name: /stages \(3\)/i })).toBeVisible();
+    // Competitor picker should be present
+    await expect(page.getByRole("button", { name: /add competitor/i })).toBeVisible();
   });
 
   test("selecting 3 competitors shows comparison table with 3 columns", async ({ page }) => {
@@ -275,6 +279,29 @@ test.describe("Scoreboard E2E", () => {
     // Deselect Charlie by clicking the X badge
     await page.getByRole("button", { name: /remove charlie/i }).click();
     await expect(page.getByRole("table").getByText("#116")).not.toBeVisible();
+  });
+
+  test("squad picker adds all squad members", async ({ page }) => {
+    await page.route("/api/match/22/26547", (route) =>
+      route.fulfill({ json: MOCK_MATCH })
+    );
+    await page.route(/\/api\/compare/, (route) =>
+      route.fulfill({ json: MOCK_COMPARE_2 })
+    );
+
+    await page.goto("/match/22/26547");
+    await expect(page.getByText("Test IPSC Match")).toBeVisible();
+
+    // Open the squad picker popover
+    await page.getByRole("button", { name: /add squad/i }).click();
+    await expect(page.getByRole("button", { name: /add squad 1/i })).toBeVisible();
+
+    // Add Squad 1 (Alice + Bob)
+    await page.getByRole("button", { name: /add squad 1/i }).click();
+
+    // Both competitor badges should now be visible
+    await expect(page.getByRole("button", { name: /remove alice/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /remove bob/i })).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary

- **Squad picker**: new _Add squad_ button alongside the competitor picker loads an entire IPSC squad in one tap. Each squad row shows member count, an Add button that bulk-adds up to the remaining slots, and live feedback ("Added 5" / "Added 4 of 7 — limit reached" / "All added"). Squads with more than 12 approved members are shown as disabled with an explanation.
- **Comparison limit raised 10 → 12**: single source of truth in `lib/constants.ts`; color palette extended to 12 entries.
- **Remove buttons moved to table header**: competitor badge pills removed from the picker; an × icon button now sits in each competitor column header — saves space on mobile and keeps the action close to the data.
- **Stage list removed**: the expandable stage list is gone from the match page; stage names, links, and metadata are already available in the comparison table.
- **Docs updated**: README and About page reflect the new 12-competitor limit and squad picker feature.

## Test plan

- [ ] `pnpm typecheck` — zero errors
- [ ] `pnpm lint` — zero warnings
- [ ] `pnpm test` — 387 tests pass
- [ ] `pnpm test:e2e` — 12 tests pass (includes new squad picker smoke test)
- [ ] Manual: open a match with squads, tap _Add squad_, verify all members are added as individual competitors
- [ ] Manual: tap × in a table column header to remove a competitor
- [ ] Manual: verify no horizontal overflow at 390px with 2 competitors selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)