### PR TITLE
fix: cache schema versioning to auto-invalidate stale Redis entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,18 @@ actionable interpretation tips. Keep language concise — max ~4 short paragraph
 - `group_leader_points` on `StageComparison` is reserved for the future benchmark overlay feature — do not remove
 - shadcn components live in `components/ui/` — do not modify generated files directly
 
+## Cache Schema Versioning
+`CACHE_SCHEMA_VERSION` in `lib/constants.ts` is embedded in every Redis cache entry as `v`.
+Whenever the **shape** of a cached GraphQL response changes (new fields, removed fields,
+renamed fields), bump `CACHE_SCHEMA_VERSION` by 1 and add a one-line history comment.
+
+Entries missing `v` or carrying an older version are treated as cache misses and re-fetched
+automatically — no manual `CACHE_PURGE_SECRET` flush is needed. The new entry is written
+with the current version on the first request, so the cache self-heals within one TTL cycle.
+
+**Rule of thumb:** bump whenever you add or remove a field on `MatchResponse`, `CompareResponse`,
+or any other type that is serialised into Redis via `cachedExecuteQuery`.
+
 ## Environment Variables
 | Variable | Where used | Target | Notes |
 |---|---|---|---|

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,3 +1,16 @@
 // Shared constants used across server and client code.
 
 export const MAX_COMPETITORS = 12;
+
+/**
+ * Cache schema version — embedded in every cached GraphQL response.
+ * Bump this (by 1) whenever the *shape* of a cached API response changes
+ * (e.g. new fields added to MatchResponse, CompareResponse, etc.).
+ * Old entries missing this field or carrying an older version are treated
+ * as cache misses and re-fetched automatically — no manual flush needed.
+ *
+ * History:
+ *   1 → initial (implicit, unversioned entries)
+ *   2 → added squads[] to MatchResponse (squad picker feature)
+ */
+export const CACHE_SCHEMA_VERSION = 2;

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -2,6 +2,7 @@
 // SSI_API_KEY lives here and must never be sent to the browser.
 
 import cache from "@/lib/cache-impl";
+import { CACHE_SCHEMA_VERSION } from "@/lib/constants";
 
 const GRAPHQL_ENDPOINT = "https://shootnscoreit.com/graphql/";
 
@@ -176,6 +177,7 @@ export function gqlCacheKey(
 interface CacheEntry<T> {
   data: T;
   cachedAt: string; // ISO timestamp
+  v?: number;       // CACHE_SCHEMA_VERSION — absent on legacy entries (treated as v1)
 }
 
 /**
@@ -197,7 +199,11 @@ export async function cachedExecuteQuery<T>(
     const raw = await cache.get(cacheKey);
     if (raw) {
       const entry = JSON.parse(raw) as CacheEntry<T>;
-      return { data: entry.data, cachedAt: entry.cachedAt };
+      // Schema version gate: entries without a version or with an older version
+      // are treated as misses. They will be overwritten on the next fetch.
+      if (entry.v === CACHE_SCHEMA_VERSION) {
+        return { data: entry.data, cachedAt: entry.cachedAt };
+      }
     }
   } catch { /* fall through to fetch */ }
 
@@ -205,7 +211,7 @@ export async function cachedExecuteQuery<T>(
   const cachedAt = new Date().toISOString();
 
   try {
-    const entry: CacheEntry<T> = { data, cachedAt };
+    const entry: CacheEntry<T> = { data, cachedAt, v: CACHE_SCHEMA_VERSION };
     const payload = JSON.stringify(entry);
     await cache.set(cacheKey, payload, ttlSeconds);
   } catch { /* best-effort — store failure is non-fatal */ }


### PR DESCRIPTION
## Summary

- Adds `CACHE_SCHEMA_VERSION = 2` constant to `lib/constants.ts` (with history comments)
- Embeds `v: CACHE_SCHEMA_VERSION` in every Redis cache entry written by `cachedExecuteQuery`
- On read, entries with a missing or older `v` are treated as cache misses and transparently re-fetched
- Documents the convention in `CLAUDE.md` so future developers know to bump the version when cached response shapes change

## Why

After deploying the squad picker feature (#90), users with cached match data couldn't see the squad picker because old Redis entries lacked the `squads` field. This fix makes that class of problem self-healing: old entries are automatically replaced on first access, with no manual cache purge required.

## Test plan
- [x] `pnpm lint` — zero warnings
- [x] `pnpm test` — 387 tests pass
- [x] Pre-existing `@upstash/redis` typecheck error is unrelated (CF-only optional dep, present on `main` before this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)