### PR TITLE
fix(cache-edge): lazily initialise Upstash Redis client to fix CF caching

### DIFF
--- a/lib/cache-edge.ts
+++ b/lib/cache-edge.ts
@@ -4,33 +4,45 @@
 import { Redis } from "@upstash/redis";
 import type { CacheAdapter } from "@/lib/cache";
 
+// Lazily initialised so that Cloudflare secrets (injected into process.env at
+// request time by @opennextjs/cloudflare) are read on first use rather than at
+// module-evaluation time.  A module-level singleton would capture the empty
+// strings present during Worker cold-start and stay broken for the Worker's
+// lifetime, which is why caching silently failed even with secrets configured.
+let _redis: Redis | null = null;
+
 // automaticDeserialization: false keeps values as raw strings so callers
 // can JSON.parse themselves — consistent with the ioredis adapter.
-const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_REST_URL ?? "",
-  token: process.env.UPSTASH_REDIS_REST_TOKEN ?? "",
-  automaticDeserialization: false,
-});
+function getRedis(): Redis {
+  if (!_redis) {
+    _redis = new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL ?? "",
+      token: process.env.UPSTASH_REDIS_REST_TOKEN ?? "",
+      automaticDeserialization: false,
+    });
+  }
+  return _redis;
+}
 
 const adapter: CacheAdapter = {
   async get(key) {
-    return redis.get<string>(key);
+    return getRedis().get<string>(key);
   },
 
   async set(key, value, ttlSeconds) {
     if (ttlSeconds == null) {
-      await redis.set(key, value);
+      await getRedis().set(key, value);
     } else {
-      await redis.set(key, value, { ex: ttlSeconds });
+      await getRedis().set(key, value, { ex: ttlSeconds });
     }
   },
 
   async persist(key) {
-    await redis.persist(key);
+    await getRedis().persist(key);
   },
 
   async del(...keys) {
-    if (keys.length > 0) await redis.del(...keys);
+    if (keys.length > 0) await getRedis().del(...keys);
   },
 
   // OBJECT IDLETIME is not available via the Upstash HTTP API.


### PR DESCRIPTION
@opennextjs/cloudflare injects Cloudflare secrets into process.env at
request time, not during module evaluation (Worker cold-start). The
previous module-level `const redis = new Redis(...)` ran before the
secrets were available, so url and token were always empty strings —
causing every cache operation to fail silently for the entire lifetime
of the Worker instance, even when UPSTASH_REDIS_REST_URL and
UPSTASH_REDIS_REST_TOKEN were correctly configured.

Replace with a lazy `getRedis()` helper that constructs the client on
first use, by which point process.env has been populated. The build-time
warnings ("url property is missing") were the same root cause surfacing
during `next build`.

https://claude.ai/code/session_01XfUfpgk1EJyvuTAHP28ttH