### PR TITLE
feat: popular matches via sorted sets (works on Redis + Upstash)

### DIFF
--- a/app/api/popular-matches/route.ts
+++ b/app/api/popular-matches/route.ts
@@ -2,15 +2,11 @@ import { NextResponse } from "next/server";
 import cache from "@/lib/cache-impl";
 import type { PopularMatch } from "@/lib/types";
 
-
-/** Maximum time (seconds) since last access to qualify as "popular". */
-const MAX_IDLE_SECONDS = 14 * 24 * 60 * 60; // 14 days
+/** Maximum age (seconds) a match access must be within to qualify. */
+const MAX_AGE_SECONDS = 14 * 24 * 60 * 60; // 14 days
 
 /** Maximum number of results to return. */
 const MAX_RESULTS = 8;
-
-/** Key prefix used by cachedExecuteQuery for GetMatch calls. */
-const KEY_PREFIX = "gql:GetMatch:";
 
 interface RawMatchEvent {
   name: string;
@@ -27,23 +23,27 @@ interface MatchCacheEntry {
 /**
  * GET /api/popular-matches
  *
- * Scans the cache for recently-accessed match keys (gql:GetMatch:*) and
- * returns up to 8 matches accessed within the last 14 days, sorted by
- * most-recently-accessed first.
+ * Returns up to 8 matches that have been accessed within the last 14 days,
+ * sorted by access frequency (most-accessed first).
  *
- * Returns [] when the cache adapter doesn't support idle-time scanning
- * (e.g. Cloudflare edge deployment) or on any cache error.
+ * Popularity is tracked via two Redis sorted sets written by cachedExecuteQuery
+ * on every GetMatch cache hit or fresh fetch:
+ *   popular:matches:seen  — score = Unix timestamp of last access
+ *   popular:matches:hits  — score = cumulative access count
+ *
+ * Works on both the ioredis (Docker/Node) and @upstash/redis (Cloudflare)
+ * cache adapters. Returns [] on any cache error.
  */
 export async function GET() {
   try {
-    const recentKeys = await cache.scanRecentKeys(KEY_PREFIX, MAX_IDLE_SECONDS);
+    const popular = await cache.getPopularKeys(MAX_AGE_SECONDS, MAX_RESULTS);
 
-    if (recentKeys.length === 0) {
+    if (popular.length === 0) {
       return NextResponse.json([] as PopularMatch[]);
     }
 
     const results: PopularMatch[] = [];
-    for (const { key } of recentKeys) {
+    for (const { key } of popular) {
       if (results.length >= MAX_RESULTS) break;
       try {
         const raw = await cache.get(key);
@@ -53,7 +53,7 @@ export async function GET() {
         if (!entry.data?.event) continue;
 
         // Key format: gql:GetMatch:{"ct":22,"id":"26547"}
-        const vars = JSON.parse(key.slice(KEY_PREFIX.length)) as {
+        const vars = JSON.parse(key.slice("gql:GetMatch:".length)) as {
           ct: number;
           id: string;
         };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Cloudflare / opennextjs build artifacts:
+    ".open-next/**",
   ]),
 ]);
 

--- a/lib/cache-edge.ts
+++ b/lib/cache-edge.ts
@@ -28,6 +28,57 @@ function getRedis(): Redis {
   return _redis;
 }
 
+// Extracted as module-level functions so tsc can resolve the return type unambiguously.
+
+async function recordMatchAccess(key: string): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  await Promise.all([
+    getRedis().zadd("popular:matches:seen", { score: now, member: key }),
+    getRedis().zincrby("popular:matches:hits", 1, key),
+  ]);
+}
+
+async function getPopularKeys(
+  maxAgeSeconds: number,
+  limit: number,
+): Promise<{ key: string; hits: number }[]> {
+  const now = Math.floor(Date.now() / 1000);
+  const cutoff = now - maxAgeSeconds;
+
+  // Prune entries that haven't been seen within the window.
+  await getRedis().zremrangebyscore("popular:matches:seen", "-inf", cutoff - 1);
+
+  // Fetch all keys that were seen within the window.
+  // zrange with byScore: true is equivalent to ZRANGEBYSCORE.
+  // Use now + 86400 as upper bound (well beyond any valid timestamp).
+  const recentKeys = (await getRedis().zrange(
+    "popular:matches:seen",
+    cutoff,
+    now + 86400,
+    { byScore: true },
+  )) as string[];
+
+  if (recentKeys.length === 0) return [];
+
+  // Look up hit counts for each recent key in parallel.
+  // zscore always returns number | null (scores are numeric in Redis).
+  const hitScores = await Promise.all(
+    recentKeys.map((k: string) => getRedis().zscore("popular:matches:hits", k)),
+  );
+
+  const results = recentKeys.map((k: string, i: number) => ({
+    key: k,
+    hits: Math.round(hitScores[i] ?? 0),
+  }));
+
+  return results
+    .sort(
+      (a: { key: string; hits: number }, b: { key: string; hits: number }) =>
+        b.hits - a.hits,
+    )
+    .slice(0, limit);
+}
+
 const adapter: CacheAdapter = {
   async get(key) {
     return getRedis().get<string>(key);
@@ -49,11 +100,8 @@ const adapter: CacheAdapter = {
     if (keys.length > 0) await getRedis().del(...keys);
   },
 
-  // OBJECT IDLETIME is not available via the Upstash HTTP API.
-  // The popular-matches feature degrades gracefully to [] on edge.
-  async scanRecentKeys() {
-    return [];
-  },
+  recordMatchAccess,
+  getPopularKeys,
 };
 
 export default adapter;

--- a/lib/cache-node.ts
+++ b/lib/cache-node.ts
@@ -32,38 +32,43 @@ const adapter: CacheAdapter = {
     if (keys.length > 0) await redis.del(...keys);
   },
 
-  async scanRecentKeys(prefix, maxIdleSeconds) {
-    const keys: string[] = [];
-    let cursor = "0";
-    do {
-      const [nextCursor, batch] = await redis.scan(
-        cursor,
-        "MATCH",
-        `${prefix}*`,
-        "COUNT",
-        100,
-      );
-      cursor = nextCursor;
-      keys.push(...batch);
-    } while (cursor !== "0");
+  async recordMatchAccess(key) {
+    const now = Math.floor(Date.now() / 1000);
+    const pipeline = redis.pipeline();
+    pipeline.zadd("popular:matches:seen", now, key);
+    pipeline.zincrby("popular:matches:hits", 1, key);
+    await pipeline.exec();
+  },
 
-    const results = await Promise.all(
-      keys.map(async (key): Promise<{ key: string; idleSeconds: number }> => {
-        try {
-          const result = await redis.object("IDLETIME", key);
-          const idleSeconds = typeof result === "number" ? result : 0;
-          return { key, idleSeconds };
-        } catch {
-          // OBJECT IDLETIME unsupported on some managed Redis configs —
-          // treat as idle=0 so the entry is included.
-          return { key, idleSeconds: 0 };
-        }
-      }),
+  async getPopularKeys(maxAgeSeconds, limit) {
+    const cutoff = Math.floor(Date.now() / 1000) - maxAgeSeconds;
+
+    // Prune entries that haven't been seen within the window.
+    await redis.zremrangebyscore("popular:matches:seen", "-inf", cutoff);
+
+    // Fetch all keys that were seen within the window.
+    const recentKeys = await redis.zrangebyscore(
+      "popular:matches:seen",
+      cutoff,
+      "+inf",
     );
 
-    return results
-      .filter(({ idleSeconds }) => idleSeconds <= maxIdleSeconds)
-      .sort((a, b) => a.idleSeconds - b.idleSeconds);
+    if (recentKeys.length === 0) return [];
+
+    // Look up hit counts for each recent key.
+    const pipeline = redis.pipeline();
+    for (const key of recentKeys) {
+      pipeline.zscore("popular:matches:hits", key);
+    }
+    const scores = await pipeline.exec();
+
+    const results = recentKeys.map((key, i) => {
+      const raw = scores?.[i]?.[1];
+      const hits = typeof raw === "string" ? parseFloat(raw) : (raw as number | null) ?? 0;
+      return { key, hits: isNaN(hits) ? 0 : Math.round(hits) };
+    });
+
+    return results.sort((a, b) => b.hits - a.hits).slice(0, limit);
   },
 };
 

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -13,12 +13,24 @@ export interface CacheAdapter {
   persist(key: string): Promise<void>;
   del(...keys: string[]): Promise<void>;
   /**
-   * Scan for keys with the given prefix, filtered to those accessed within
-   * maxIdleSeconds, sorted by most-recently-accessed first.
-   * Returns [] on adapters that don't support idle-time inspection (edge).
+   * Record that a match cache key was accessed.
+   *
+   * Updates two sorted sets:
+   *   popular:matches:seen  — score = current Unix timestamp (last-seen)
+   *   popular:matches:hits  — score incremented by 1 on every access (hit count)
+   *
+   * Implementations should be fire-and-forget safe (errors silently ignored).
    */
-  scanRecentKeys(
-    prefix: string,
-    maxIdleSeconds: number,
-  ): Promise<{ key: string; idleSeconds: number }[]>;
+  recordMatchAccess(key: string): Promise<void>;
+  /**
+   * Return the most-accessed match cache keys that have been seen within
+   * the last maxAgeSeconds, sorted by hit count descending.
+   *
+   * Prunes the seen set on each call to prevent unbounded growth.
+   * Returns [] on any error.
+   */
+  getPopularKeys(
+    maxAgeSeconds: number,
+    limit: number,
+  ): Promise<{ key: string; hits: number }[]>;
 }

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -202,6 +202,9 @@ export async function cachedExecuteQuery<T>(
       // Schema version gate: entries without a version or with an older version
       // are treated as misses. They will be overwritten on the next fetch.
       if (entry.v === CACHE_SCHEMA_VERSION) {
+        if (cacheKey.startsWith("gql:GetMatch:")) {
+          void cache.recordMatchAccess(cacheKey).catch(() => {});
+        }
         return { data: entry.data, cachedAt: entry.cachedAt };
       }
     }
@@ -218,6 +221,11 @@ export async function cachedExecuteQuery<T>(
     await cache.set(cacheKey, payload, ttlSeconds);
   } catch (err) {
     console.error(`[cache] write error for key "${cacheKey}":`, err);
+  }
+
+  // Record access for popularity tracking (fire-and-forget, non-fatal).
+  if (cacheKey.startsWith("gql:GetMatch:")) {
+    void cache.recordMatchAccess(cacheKey).catch(() => {});
   }
 
   // Return null for cachedAt: freshly fetched, not served from cache


### PR DESCRIPTION
## Summary

- Replaces `OBJECT IDLETIME` (Redis-native, unavailable on Upstash HTTP API) with two explicit Redis sorted sets that work identically on both the ioredis and `@upstash/redis` adapters
- Adds **frequency tracking**: `popular:matches:hits` accumulates a hit count per match via `ZINCRBY`, so results are now sorted by access frequency rather than only recency
- Popular matches on the **Cloudflare Pages** deployment now work (previously always returned `[]`)

## How it works

Two sorted sets are maintained by `cachedExecuteQuery` on every `GetMatch` response (cache hit or fresh fetch), fire-and-forget:

| Set | Member | Score |
|---|---|---|
| `popular:matches:seen` | full GQL cache key | Unix timestamp of last access |
| `popular:matches:hits` | full GQL cache key | cumulative access count |

`getPopularKeys()` prunes the `seen` set to the configured window (14 days) on each call, then returns keys sorted by hit count descending.

## Files changed

| File | Change |
|---|---|
| `lib/cache.ts` | Replace `scanRecentKeys` with `recordMatchAccess` + `getPopularKeys` |
| `lib/cache-node.ts` | Implement via ioredis pipeline (`ZADD`, `ZINCRBY`, `ZRANGEBYSCORE`) |
| `lib/cache-edge.ts` | Implement via `@upstash/redis` (`zadd`, `zincrby`, `zrange` with `byScore`) |
| `lib/graphql.ts` | Fire-and-forget `recordMatchAccess` in `cachedExecuteQuery` |
| `app/api/popular-matches/route.ts` | Use `getPopularKeys`; metadata fetch loop unchanged |
| `eslint.config.mjs` | Add `.open-next/**` to ignore list (CF build artifacts) |

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — zero warnings
- [x] `pnpm test` — 387 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)