### PR TITLE
fix(security): resolve all open CodeQL alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -3,6 +3,9 @@ name: Deploy to Cloudflare
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -209,7 +209,7 @@ export async function cachedExecuteQuery<T>(
       }
     }
   } catch (err) {
-    console.error(`[cache] read error for key "${cacheKey}":`, err);
+    console.error("[cache] read error for key:", cacheKey, err);
   }
 
   const data = await executeQuery<T>(query, variables);
@@ -220,7 +220,7 @@ export async function cachedExecuteQuery<T>(
     const payload = JSON.stringify(entry);
     await cache.set(cacheKey, payload, ttlSeconds);
   } catch (err) {
-    console.error(`[cache] write error for key "${cacheKey}":`, err);
+    console.error("[cache] write error for key:", cacheKey, err);
   }
 
   // Record access for popularity tracking (fire-and-forget, non-fatal).


### PR DESCRIPTION
## Summary

Fixes all 4 open CodeQL code scanning alerts.

- **Alerts #3 & #5 — `js/tainted-format-string`** (`lib/graphql.ts`): `cacheKey` was interpolated into the first argument of `console.error`, which CodeQL treats as a tainted format string. Fixed by passing `cacheKey` as a separate argument instead — behaviour is identical, no format-string risk.
- **Alerts #1 & #2 — `actions/missing-workflow-permissions`** (`.github/workflows/ci.yml`, `.github/workflows/deploy-cloudflare.yml`): workflows had no explicit `permissions:` block, leaving `GITHUB_TOKEN` with broad default scopes. Added `permissions: contents: read` at workflow level (principle of least privilege).

## Test plan

- [ ] CI passes (lint, typecheck, test, build, e2e)
- [ ] CodeQL re-scan closes alerts #1, #2, #3, #5 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)