### PR TITLE
feat: add Cloudflare staging deployment with shared Redis key prefixing

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,50 @@
+name: Deploy to Cloudflare (Staging)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to deploy to staging'
+        required: false
+        default: 'main'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-staging:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.1
+          run_install: false
+
+      - name: Get pnpm store path
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm cf:deploy:staging
+        env:
+          SSI_API_KEY: ${{ secrets.SSI_API_KEY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/lib/cache-edge.ts
+++ b/lib/cache-edge.ts
@@ -28,13 +28,20 @@ function getRedis(): Redis {
   return _redis;
 }
 
+// Prefix all Redis key names with CACHE_KEY_PREFIX (e.g. "staging:") so that
+// multiple environments can safely share a single Upstash instance.
+// Members stored inside sorted sets are bare cache keys, not Redis key names,
+// so they are not prefixed — callers receive them as-is.
+const PREFIX = process.env.CACHE_KEY_PREFIX ?? "";
+const pk = (key: string) => `${PREFIX}${key}`;
+
 // Extracted as module-level functions so tsc can resolve the return type unambiguously.
 
 async function recordMatchAccess(key: string): Promise<void> {
   const now = Math.floor(Date.now() / 1000);
   await Promise.all([
-    getRedis().zadd("popular:matches:seen", { score: now, member: key }),
-    getRedis().zincrby("popular:matches:hits", 1, key),
+    getRedis().zadd(pk("popular:matches:seen"), { score: now, member: key }),
+    getRedis().zincrby(pk("popular:matches:hits"), 1, key),
   ]);
 }
 
@@ -46,13 +53,13 @@ async function getPopularKeys(
   const cutoff = now - maxAgeSeconds;
 
   // Prune entries that haven't been seen within the window.
-  await getRedis().zremrangebyscore("popular:matches:seen", "-inf", cutoff - 1);
+  await getRedis().zremrangebyscore(pk("popular:matches:seen"), "-inf", cutoff - 1);
 
   // Fetch all keys that were seen within the window.
   // zrange with byScore: true is equivalent to ZRANGEBYSCORE.
   // Use now + 86400 as upper bound (well beyond any valid timestamp).
   const recentKeys = (await getRedis().zrange(
-    "popular:matches:seen",
+    pk("popular:matches:seen"),
     cutoff,
     now + 86400,
     { byScore: true },
@@ -63,7 +70,7 @@ async function getPopularKeys(
   // Look up hit counts for each recent key in parallel.
   // zscore always returns number | null (scores are numeric in Redis).
   const hitScores = await Promise.all(
-    recentKeys.map((k: string) => getRedis().zscore("popular:matches:hits", k)),
+    recentKeys.map((k: string) => getRedis().zscore(pk("popular:matches:hits"), k)),
   );
 
   const results = recentKeys.map((k: string, i: number) => ({
@@ -81,23 +88,23 @@ async function getPopularKeys(
 
 const adapter: CacheAdapter = {
   async get(key) {
-    return getRedis().get<string>(key);
+    return getRedis().get<string>(pk(key));
   },
 
   async set(key, value, ttlSeconds) {
     if (ttlSeconds == null) {
-      await getRedis().set(key, value);
+      await getRedis().set(pk(key), value);
     } else {
-      await getRedis().set(key, value, { ex: ttlSeconds });
+      await getRedis().set(pk(key), value, { ex: ttlSeconds });
     }
   },
 
   async persist(key) {
-    await getRedis().persist(key);
+    await getRedis().persist(pk(key));
   },
 
   async del(...keys) {
-    if (keys.length > 0) await getRedis().del(...keys);
+    if (keys.length > 0) await getRedis().del(...keys.map(pk));
   },
 
   recordMatchAccess,

--- a/lib/cache-node.ts
+++ b/lib/cache-node.ts
@@ -11,32 +11,39 @@ const redis = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", {
 
 redis.on("error", (err: Error) => console.error("[redis]", err.message));
 
+// Prefix all Redis key names with CACHE_KEY_PREFIX (e.g. "staging:") so that
+// multiple environments can safely share a single Redis instance.
+// Members stored inside sorted sets are bare cache keys, not Redis key names,
+// so they are not prefixed — callers receive them as-is.
+const PREFIX = process.env.CACHE_KEY_PREFIX ?? "";
+const pk = (key: string) => `${PREFIX}${key}`;
+
 const adapter: CacheAdapter = {
   async get(key) {
-    return redis.get(key);
+    return redis.get(pk(key));
   },
 
   async set(key, value, ttlSeconds) {
     if (ttlSeconds == null) {
-      await redis.set(key, value);
+      await redis.set(pk(key), value);
     } else {
-      await redis.set(key, value, "EX", ttlSeconds);
+      await redis.set(pk(key), value, "EX", ttlSeconds);
     }
   },
 
   async persist(key) {
-    await redis.persist(key);
+    await redis.persist(pk(key));
   },
 
   async del(...keys) {
-    if (keys.length > 0) await redis.del(...keys);
+    if (keys.length > 0) await redis.del(...keys.map(pk));
   },
 
   async recordMatchAccess(key) {
     const now = Math.floor(Date.now() / 1000);
     const pipeline = redis.pipeline();
-    pipeline.zadd("popular:matches:seen", now, key);
-    pipeline.zincrby("popular:matches:hits", 1, key);
+    pipeline.zadd(pk("popular:matches:seen"), now, key);
+    pipeline.zincrby(pk("popular:matches:hits"), 1, key);
     await pipeline.exec();
   },
 
@@ -44,11 +51,11 @@ const adapter: CacheAdapter = {
     const cutoff = Math.floor(Date.now() / 1000) - maxAgeSeconds;
 
     // Prune entries that haven't been seen within the window.
-    await redis.zremrangebyscore("popular:matches:seen", "-inf", cutoff);
+    await redis.zremrangebyscore(pk("popular:matches:seen"), "-inf", cutoff);
 
     // Fetch all keys that were seen within the window.
     const recentKeys = await redis.zrangebyscore(
-      "popular:matches:seen",
+      pk("popular:matches:seen"),
       cutoff,
       "+inf",
     );
@@ -58,7 +65,7 @@ const adapter: CacheAdapter = {
     // Look up hit counts for each recent key.
     const pipeline = redis.pipeline();
     for (const key of recentKeys) {
-      pipeline.zscore("popular:matches:hits", key);
+      pipeline.zscore(pk("popular:matches:hits"), key);
     }
     const scores = await pipeline.exec();
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "docker:down": "docker compose down",
     "cf:build": "DEPLOY_TARGET=cloudflare npx @opennextjs/cloudflare@1.17.0 build",
     "cf:deploy": "pnpm cf:build && wrangler deploy",
+    "cf:deploy:staging": "pnpm cf:build && wrangler deploy --env staging",
     "setup": "cp -n .env.local.example .env.local || true"
   },
   "dependencies": {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,11 +1,17 @@
-# Cloudflare Pages deployment configuration.
-# Used by: pnpm cf:deploy  (runs next build + @opennextjs/cloudflare + wrangler pages deploy)
+# Cloudflare Workers deployment configuration.
+# Used by: pnpm cf:deploy          → production worker (ssi-scoreboard)
+#          pnpm cf:deploy:staging   → staging worker  (ssi-scoreboard-staging)
 #
-# Secrets must be set via Cloudflare dashboard or wrangler CLI, NOT committed here:
-#   wrangler secret put SSI_API_KEY
-#   wrangler secret put UPSTASH_REDIS_REST_URL
-#   wrangler secret put UPSTASH_REDIS_REST_TOKEN
-#   wrangler secret put CACHE_PURGE_SECRET
+# Secrets must be set via wrangler CLI, NOT committed here:
+#   Production:  wrangler secret put SSI_API_KEY
+#                wrangler secret put UPSTASH_REDIS_REST_URL
+#                wrangler secret put UPSTASH_REDIS_REST_TOKEN
+#                wrangler secret put CACHE_PURGE_SECRET
+#   Staging:     wrangler secret put SSI_API_KEY --env staging
+#                wrangler secret put UPSTASH_REDIS_REST_URL --env staging
+#                wrangler secret put UPSTASH_REDIS_REST_TOKEN --env staging
+#                wrangler secret put CACHE_PURGE_SECRET --env staging
+#                wrangler secret put CACHE_KEY_PREFIX --env staging   # value: "staging:"
 
 name = "ssi-scoreboard"
 compatibility_date = "2024-09-23"
@@ -19,3 +25,8 @@ directory = ".open-next/assets"
 
 [observability]
 enabled = true
+
+# Staging environment — separate worker, inherits all top-level settings except name.
+# Secrets set independently via: wrangler secret put <NAME> --env staging
+[env.staging]
+name = "ssi-scoreboard-staging"


### PR DESCRIPTION
## Summary

- Adds a `[env.staging]` wrangler environment that deploys as a separate Worker (`ssi-scoreboard-staging`), inheriting all top-level config
- Adds `cf:deploy:staging` npm script
- Adds `.github/workflows/deploy-staging.yml`: auto-deploys to staging on every push to `main`; also supports manual dispatch with a configurable branch/tag/SHA input
- Prefixes all Redis key names with `CACHE_KEY_PREFIX` (e.g. `staging:`) in both `cache-edge.ts` and `cache-node.ts`, allowing staging and production to safely share a single Upstash free-tier instance without key collisions

## One-time setup required

After merging, set secrets for the staging Worker:

```bash
wrangler secret put SSI_API_KEY --env staging
wrangler secret put UPSTASH_REDIS_REST_URL --env staging
wrangler secret put UPSTASH_REDIS_REST_TOKEN --env staging
wrangler secret put CACHE_PURGE_SECRET --env staging
wrangler secret put CACHE_KEY_PREFIX --env staging   # value: staging:
```

`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` GitHub secrets are already in place from the production workflow.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] First staging deploy succeeds via Actions after merge
- [ ] Verify `ssi-scoreboard-staging` Worker appears in Cloudflare dashboard
- [ ] Confirm Redis keys in Upstash are prefixed with `staging:` after a cache hit on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)