### PR TITLE
feat: show CalVer + commit SHA in footer

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -34,8 +34,15 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Set build vars
+        run: |
+          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "BUILD_DATE=$(date -u +%Y.%m.%d)" >> $GITHUB_ENV
+
       - run: pnpm cf:deploy
         env:
           SSI_API_KEY: ${{ secrets.SSI_API_KEY }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          NEXT_PUBLIC_BUILD_ID: ${{ env.SHORT_SHA }}
+          NEXT_PUBLIC_BUILD_DATE: ${{ env.BUILD_DATE }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -43,8 +43,15 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Set build vars
+        run: |
+          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "BUILD_DATE=$(date -u +%Y.%m.%d)" >> $GITHUB_ENV
+
       - run: pnpm cf:deploy:staging
         env:
           SSI_API_KEY: ${{ secrets.SSI_API_KEY }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          NEXT_PUBLIC_BUILD_ID: ${{ env.SHORT_SHA }}
+          NEXT_PUBLIC_BUILD_DATE: ${{ env.BUILD_DATE }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,12 @@ COPY . .
 # Ensure public/ exists so the runner COPY never fails on an empty/absent dir
 RUN mkdir -p /app/public
 
-# Optional: git commit SHA passed by the build script for client-side version
-# detection. Baked into the JS bundle as process.env.NEXT_PUBLIC_BUILD_ID.
+# Optional: git commit SHA and build date passed by the build script.
+# Baked into the JS bundle for client-side version display / update detection.
 ARG BUILD_ID
+ARG BUILD_DATE
 ENV NEXT_PUBLIC_BUILD_ID=${BUILD_ID}
+ENV NEXT_PUBLIC_BUILD_DATE=${BUILD_DATE}
 
 RUN pnpm build
 
@@ -32,9 +34,11 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000
 
-# Carry the build ID into the runtime image so /api/version can return it.
+# Carry build vars into the runtime image so /api/version can return them.
 ARG BUILD_ID
+ARG BUILD_DATE
 ENV NEXT_PUBLIC_BUILD_ID=${BUILD_ID}
+ENV NEXT_PUBLIC_BUILD_DATE=${BUILD_DATE}
 
 # Create non-root user
 RUN addgroup --system --gid 1001 nodejs && \

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -93,6 +93,22 @@ export default function RootLayout({
               this app. SSI is not responsible for the privacy, security, or
               integrity of data shown here.
             </p>
+            {process.env.NEXT_PUBLIC_BUILD_ID && (
+              <p className="text-[11px] text-muted-foreground/50">
+                {process.env.NEXT_PUBLIC_BUILD_DATE && (
+                  <span>{process.env.NEXT_PUBLIC_BUILD_DATE} · </span>
+                )}
+                <a
+                  href={`https://github.com/mandakan/ssi-scoreboard/commit/${process.env.NEXT_PUBLIC_BUILD_ID}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono hover:text-muted-foreground transition-colors"
+                  aria-label={`View source at commit ${process.env.NEXT_PUBLIC_BUILD_ID} on GitHub (opens in new tab)`}
+                >
+                  {process.env.NEXT_PUBLIC_BUILD_ID}
+                </a>
+              </p>
+            )}
           </footer>
         </Providers>
       </body>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       context: .
       args:
         BUILD_ID: ${BUILD_ID:-}
+        BUILD_DATE: ${BUILD_DATE:-}
     ports:
       - "${PORT:-3666}:3000"
     environment:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "check": "pnpm lint && pnpm typecheck && pnpm test",
-    "docker:build": "BUILD_ID=$(git rev-parse --short HEAD 2>/dev/null || echo '') docker compose build",
+    "docker:build": "BUILD_ID=$(git rev-parse --short HEAD 2>/dev/null || echo '') BUILD_DATE=$(date +%Y.%m.%d) docker compose build",
     "docker:up": "docker compose --env-file .env.local up",
     "docker:down": "docker compose down",
     "cf:build": "DEPLOY_TARGET=cloudflare npx @opennextjs/cloudflare@1.17.0 build",


### PR DESCRIPTION
## Summary

Adds a discreet build version line to the footer showing the deployment date and exact commit, e.g.:

```
2026.02.25 · abc1234
```

The date uses CalVer (`YYYY.MM.DD`) so operators can tell at a glance how fresh a deployment is. The SHA links to the exact GitHub commit. Both are invisible in local dev (env vars unset).

## Changes

- **`Dockerfile`** — threads new `BUILD_DATE` arg through builder and runner stages alongside existing `BUILD_ID`
- **`docker-compose.yml`** — passes `BUILD_DATE` build arg
- **`package.json`** — `docker:build` now also sets `BUILD_DATE=$(date +%Y.%m.%d)`
- **Both CF deploy workflows** — new "Set build vars" step computes `SHORT_SHA` and `BUILD_DATE` after checkout; passed as `NEXT_PUBLIC_BUILD_ID` / `NEXT_PUBLIC_BUILD_DATE` to the build
- **`app/layout.tsx`** — renders `YYYY.MM.DD · <sha>` (linked to GitHub commit) at the bottom of the footer when vars are present

## Test plan

- [ ] `pnpm typecheck` and `pnpm test` pass
- [ ] Local dev: version line absent from footer (env vars unset)
- [ ] After CF deploy: footer shows correct date and 7-char SHA linking to the right commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)