### PR TITLE
feat: social preview image generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ Thumbs.db
 /playwright-report/
 /playwright/.cache/
 
+# Generated assets
+/social-preview.png
+
 # TypeScript
 *.tsbuildinfo
 next-env.d.ts

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "social-preview": "node scripts/generate-social-preview.mjs",
     "check": "pnpm lint && pnpm typecheck && pnpm test",
     "docker:build": "BUILD_ID=$(git rev-parse --short HEAD 2>/dev/null || echo '') BUILD_DATE=$(date +%Y.%m.%d) docker compose build",
     "docker:up": "docker compose --env-file .env.local up",

--- a/scripts/generate-social-preview.mjs
+++ b/scripts/generate-social-preview.mjs
@@ -1,0 +1,75 @@
+/**
+ * Generates social-preview.png (1280×640) for GitHub repository settings.
+ *
+ * Content is pulled dynamically from project sources:
+ *   - Logo:    public/logo-dark.svg
+ *   - Name:    public/manifest.json  → .name
+ *   - Tagline: public/manifest.json  → .description
+ *
+ * Layout is defined in scripts/social-preview.html (placeholders replaced below).
+ *
+ * Usage:
+ *   pnpm social-preview
+ *   node scripts/generate-social-preview.mjs
+ */
+
+import { chromium } from "@playwright/test";
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+// ── Read source files ──────────────────────────────────────────────────────
+
+const iconSvg = readFileSync(resolve(root, "public/logo-dark.svg"), "utf8")
+  // Strip the XML declaration — not valid inside HTML
+  .replace(/<\?xml[^?]*\?>\s*/i, "")
+  .trim();
+
+const manifest = JSON.parse(
+  readFileSync(resolve(root, "public/manifest.json"), "utf8")
+);
+
+const appName = manifest.name ?? "SSI Scoreboard";
+// Split "SSI Scoreboard" → prefix="SSI", suffix="Scoreboard"
+// Splits on the first space so "My App Name" → "My" / "App Name"
+const spaceIndex = appName.indexOf(" ");
+const namePrefx = spaceIndex === -1 ? appName : appName.slice(0, spaceIndex);
+const nameSuffix = spaceIndex === -1 ? "" : appName.slice(spaceIndex + 1);
+
+const tagline = manifest.description ?? "";
+
+// ── Build HTML from template ───────────────────────────────────────────────
+
+const template = readFileSync(
+  resolve(__dirname, "social-preview.html"),
+  "utf8"
+);
+
+const html = template
+  .replace("__ICON_SVG__", iconSvg)
+  .replace("__APP_NAME_PREFIX__", namePrefx)
+  .replace("__APP_NAME_SUFFIX__", nameSuffix)
+  .replace("__TAGLINE__", tagline);
+
+// ── Render with Playwright ─────────────────────────────────────────────────
+
+const outPath = resolve(root, "social-preview.png");
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+await page.setViewportSize({ width: 1280, height: 640 });
+
+// Load from data URI so no file-server is needed and relative asset paths
+// (the Google Fonts <link>) still resolve correctly over the network.
+await page.setContent(html, { waitUntil: "networkidle" });
+
+await page.screenshot({ path: outPath });
+await browser.close();
+
+console.log(`✓ social-preview.png written to ${outPath}`);
+console.log(`  Name:    ${appName}`);
+console.log(`  Tagline: ${tagline}`);
+console.log(`  Icon:    public/logo-dark.svg`);

--- a/scripts/social-preview.html
+++ b/scripts/social-preview.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    html, body {
+      width: 1280px;
+      height: 640px;
+      overflow: hidden;
+      background: #0a0a0a;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    }
+
+    .container {
+      display: flex;
+      align-items: center;
+      width: 1280px;
+      height: 640px;
+      padding: 0 80px;
+      position: relative;
+      gap: 72px;
+    }
+
+    /* Dot-grid background texture */
+    .bg-grid {
+      position: absolute;
+      inset: 0;
+      background-image: radial-gradient(circle, rgba(255,255,255,0.04) 1px, transparent 1px);
+      background-size: 36px 36px;
+      pointer-events: none;
+    }
+
+    /* Radial glow behind the icon */
+    .icon-glow {
+      position: absolute;
+      left: -20px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 480px;
+      height: 480px;
+      background: radial-gradient(circle at 50% 50%, rgba(0,188,124,0.12) 0%, transparent 65%);
+      pointer-events: none;
+    }
+
+    .icon-col {
+      flex-shrink: 0;
+      position: relative;
+      z-index: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .icon-col svg {
+      width: 300px;
+      height: 300px;
+    }
+
+    /* Vertical separator */
+    .divider {
+      flex-shrink: 0;
+      width: 1px;
+      height: 280px;
+      background: linear-gradient(to bottom, transparent 0%, #1f2937 30%, #1f2937 70%, transparent 100%);
+    }
+
+    .text-col {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+      position: relative;
+      z-index: 1;
+    }
+
+    .eyebrow {
+      font-size: 14px;
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: #00bc7c;
+      margin-bottom: 14px;
+    }
+
+    .app-name {
+      font-size: 76px;
+      font-weight: 900;
+      line-height: 0.95;
+      letter-spacing: -3px;
+      color: #f9fafb;
+    }
+
+    .app-name .accent {
+      color: #00bc7c;
+    }
+
+    .tagline {
+      margin-top: 22px;
+      font-size: 22px;
+      font-weight: 400;
+      color: #6b7280;
+      line-height: 1.5;
+    }
+
+    .tagline strong {
+      color: #9ca3af;
+      font-weight: 500;
+    }
+
+    .badges {
+      display: flex;
+      gap: 10px;
+      margin-top: 28px;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      background: rgba(255,255,255,0.04);
+      border: 1px solid #1f2937;
+      border-radius: 100px;
+      padding: 7px 16px;
+      font-size: 13px;
+      font-weight: 500;
+      color: #6b7280;
+    }
+
+    .badge-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: #00bc7c;
+      flex-shrink: 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="bg-grid"></div>
+    <div class="icon-glow"></div>
+
+    <div class="icon-col">
+      __ICON_SVG__
+    </div>
+
+    <div class="divider"></div>
+
+    <div class="text-col">
+      <div class="eyebrow">IPSC Shooting Sports</div>
+      <div class="app-name">__APP_NAME_PREFIX__<br><span class="accent">__APP_NAME_SUFFIX__</span></div>
+      <div class="tagline">__TAGLINE__</div>
+      <div class="badges">
+        <div class="badge"><div class="badge-dot"></div>Real-time</div>
+        <div class="badge"><div class="badge-dot"></div>Mobile-first</div>
+        <div class="badge"><div class="badge-dot"></div>Open source</div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `scripts/social-preview.html` — layout template with placeholders for logo, app name, and tagline
- Adds `scripts/generate-social-preview.mjs` — reads `public/logo-dark.svg` and `public/manifest.json`, fills the template, renders with Playwright at 1280×640, writes `social-preview.png`
- `social-preview.png` is gitignored (generated artifact; upload manually in GitHub repo settings)
- Adds `pnpm social-preview` script

## Test plan

- [ ] Run `pnpm social-preview` — confirm `social-preview.png` is written to repo root
- [ ] Verify logo, name, and tagline are correct in the output image
- [ ] Edit `public/manifest.json` description, re-run — confirm tagline updates
- [ ] Upload `social-preview.png` in GitHub → Settings → Social preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)