### PR TITLE
feat: PWA install prompt and in-app install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ custom subdomain, verifying the deployment, and troubleshooting — see
 - **Month browser** — navigate competitions month by month from the landing page; typing a query switches to full-history search mode automatically
 - **Server-side cache** — GraphQL response caching with smart TTL and admin purge endpoint; ioredis on Docker, @upstash/redis on Cloudflare Pages
 - **New-version banner** — polls `/api/version` every 60 s; shows a non-blocking refresh prompt when a new deployment is detected
+- **PWA installable** — add to home screen on Android, iOS, and desktop; runs fullscreen without browser chrome
 - **Mobile-first** — designed for one-handed use at 390px; no unintentional horizontal overflow
 
 ## Development Commands

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Github, Crosshair, Coffee } from "lucide-react";
+import { InstallInstructions } from "@/components/install-instructions";
 
 export const metadata: Metadata = {
   title: "About – SSI Scoreboard",
@@ -134,6 +135,21 @@ export default function AboutPage() {
               </div>
             </a>
           </div>
+        </section>
+
+        <section id="install" aria-labelledby="about-install-heading" className="space-y-4">
+          <h2
+            id="about-install-heading"
+            className="text-xl font-semibold border-b border-border pb-2"
+          >
+            Install as an app
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            SSI Scoreboard is a Progressive Web App — you can add it to your
+            home screen for instant courtside access, fullscreen view, and a
+            native-app feel. No app store required.
+          </p>
+          <InstallInstructions />
         </section>
 
         <section aria-labelledby="about-built-heading" className="space-y-4">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Coffee, Crosshair, Github } from "lucide-react";
 import { Providers } from "@/components/providers";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { InstallBanner } from "@/components/install-banner";
 import { UpdateBanner } from "@/components/update-banner";
 import "./globals.css";
 
@@ -47,6 +48,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}>
         <Providers>
+          <InstallBanner />
           <UpdateBanner />
           {children}
           <footer className="w-full flex flex-col items-center gap-2 p-4 text-xs text-muted-foreground border-t border-border mt-auto">
@@ -91,6 +93,12 @@ export default function RootLayout({
               >
                 <Coffee className="w-4 h-4" aria-hidden="true" />
               </a>
+              <Link
+                href="/about#install"
+                className="inline-flex items-center hover:text-foreground transition-colors"
+              >
+                Install app
+              </Link>
               <Link
                 href="/about"
                 className="inline-flex items-center hover:text-foreground transition-colors"

--- a/components/install-banner.tsx
+++ b/components/install-banner.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+import { Download, Share, X } from "lucide-react";
+import { usePWAInstall } from "@/lib/pwa-install";
+
+const DISMISSED_KEY = "pwa-install-dismissed";
+
+export function InstallBanner() {
+  const { canInstall, isIos, isInstalled, triggerInstall } = usePWAInstall();
+  const [dismissed, setDismissed] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      !!localStorage.getItem(DISMISSED_KEY)
+  );
+
+  function dismiss() {
+    localStorage.setItem(DISMISSED_KEY, "1");
+    setDismissed(true);
+  }
+
+  async function install() {
+    await triggerInstall();
+    localStorage.setItem(DISMISSED_KEY, "1");
+    setDismissed(true);
+  }
+
+  const showAndroid = canInstall && !isInstalled && !dismissed;
+  const showIos = isIos && !isInstalled && !dismissed;
+
+  if (!showAndroid && !showIos) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-0 inset-x-0 z-40 flex items-center justify-between gap-3 px-4 py-3 bg-primary text-primary-foreground text-sm shadow-lg"
+    >
+      {showAndroid && (
+        <>
+          <div className="flex items-center gap-2 min-w-0">
+            <Download className="w-4 h-4 shrink-0" aria-hidden="true" />
+            <span>Install SSI Scoreboard for quick courtside access.</span>
+          </div>
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              type="button"
+              onClick={() => void install()}
+              className="px-3 py-1 rounded-full bg-primary-foreground/15 hover:bg-primary-foreground/25 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-primary"
+            >
+              Install
+            </button>
+            <button
+              type="button"
+              aria-label="Dismiss install prompt"
+              onClick={dismiss}
+              className="flex items-center justify-center min-w-[44px] min-h-[44px] opacity-70 hover:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-primary"
+            >
+              <X className="w-4 h-4" aria-hidden="true" />
+            </button>
+          </div>
+        </>
+      )}
+
+      {showIos && (
+        <>
+          <div className="flex items-center gap-2 min-w-0">
+            <Share className="w-4 h-4 shrink-0" aria-hidden="true" />
+            <span>
+              Tap the{" "}
+              <Share
+                className="inline w-3.5 h-3.5 align-text-bottom mx-0.5"
+                aria-label="Share"
+              />{" "}
+              button, then <strong>Add to Home Screen</strong>.
+            </span>
+          </div>
+          <button
+            type="button"
+            aria-label="Dismiss install instructions"
+            onClick={dismiss}
+            className="flex items-center justify-center min-w-[44px] min-h-[44px] shrink-0 opacity-70 hover:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-primary"
+          >
+            <X className="w-4 h-4" aria-hidden="true" />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/install-instructions.tsx
+++ b/components/install-instructions.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { CheckCircle, Download, Share, Monitor } from "lucide-react";
+import { usePWAInstall } from "@/lib/pwa-install";
+
+export function InstallInstructions() {
+  const { canInstall, isIos, isInstalled, triggerInstall } = usePWAInstall();
+
+  if (isInstalled) {
+    return (
+      <div className="flex items-center gap-3 p-4 rounded-lg border border-border bg-accent/30 text-sm text-muted-foreground">
+        <CheckCircle className="w-5 h-5 shrink-0 text-green-600 dark:text-green-400" aria-hidden="true" />
+        <span>SSI Scoreboard is already installed on this device.</span>
+      </div>
+    );
+  }
+
+  if (canInstall) {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Your browser supports one-tap install — no app store needed.
+        </p>
+        <button
+          type="button"
+          onClick={() => void triggerInstall()}
+          className="flex items-center gap-3 w-full p-4 rounded-lg border border-border hover:bg-accent hover:text-accent-foreground transition-colors text-left"
+        >
+          <Download className="w-5 h-5 shrink-0" aria-hidden="true" />
+          <div>
+            <p className="font-medium text-sm">Install SSI Scoreboard</p>
+            <p className="text-xs text-muted-foreground">
+              Runs fullscreen, no browser chrome, fast to open
+            </p>
+          </div>
+        </button>
+      </div>
+    );
+  }
+
+  if (isIos) {
+    return (
+      <div className="space-y-3 text-sm text-muted-foreground">
+        <p>To install on iOS:</p>
+        <ol className="space-y-2 list-decimal list-inside leading-relaxed">
+          <li>
+            Open this page in <strong className="text-foreground">Safari</strong>
+          </li>
+          <li>
+            Tap the{" "}
+            <Share
+              className="inline w-4 h-4 align-text-bottom mx-0.5"
+              aria-label="Share"
+            />{" "}
+            <strong className="text-foreground">Share</strong> button in the
+            toolbar
+          </li>
+          <li>
+            Scroll down and tap{" "}
+            <strong className="text-foreground">Add to Home Screen</strong>
+          </li>
+          <li>
+            Tap <strong className="text-foreground">Add</strong> — done!
+          </li>
+        </ol>
+        <p className="text-xs">
+          The app will appear on your home screen and open fullscreen, just like
+          a native app.
+        </p>
+      </div>
+    );
+  }
+
+  // Desktop or browser without install prompt (Firefox, Safari desktop, etc.)
+  return (
+    <div className="space-y-3 text-sm text-muted-foreground">
+      <div className="flex items-start gap-3 p-4 rounded-lg border border-border">
+        <Monitor className="w-5 h-5 shrink-0 mt-0.5" aria-hidden="true" />
+        <div className="space-y-1">
+          <p className="font-medium text-foreground">Chrome or Edge (desktop)</p>
+          <p>
+            Look for the install icon{" "}
+            <span aria-hidden="true">⊕</span> in the address bar, or open the
+            browser menu and choose <strong className="text-foreground">Install SSI Scoreboard</strong>.
+          </p>
+        </div>
+      </div>
+      <div className="flex items-start gap-3 p-4 rounded-lg border border-border">
+        <Share className="w-5 h-5 shrink-0 mt-0.5" aria-hidden="true" />
+        <div className="space-y-1">
+          <p className="font-medium text-foreground">iPhone / iPad (Safari)</p>
+          <p>
+            Tap{" "}
+            <Share
+              className="inline w-3.5 h-3.5 align-text-bottom mx-0.5"
+              aria-label="Share"
+            />{" "}
+            Share → <strong className="text-foreground">Add to Home Screen</strong>.
+          </p>
+        </div>
+      </div>
+      <div className="flex items-start gap-3 p-4 rounded-lg border border-border">
+        <Download className="w-5 h-5 shrink-0 mt-0.5" aria-hidden="true" />
+        <div className="space-y-1">
+          <p className="font-medium text-foreground">Android (Chrome)</p>
+          <p>
+            Tap the browser menu → <strong className="text-foreground">Add to Home Screen</strong>{" "}
+            or <strong className="text-foreground">Install app</strong>.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { PWAInstallProvider } from "@/lib/pwa-install";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -21,7 +22,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
       <QueryClientProvider client={queryClient}>
-        <TooltipProvider>{children}</TooltipProvider>
+        <TooltipProvider>
+          <PWAInstallProvider>{children}</PWAInstallProvider>
+        </TooltipProvider>
       </QueryClientProvider>
     </ThemeProvider>
   );

--- a/lib/pwa-install.tsx
+++ b/lib/pwa-install.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+// Non-standard browser API — not in the TypeScript DOM lib
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  readonly userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+interface PWAInstallContextValue {
+  /** True when the browser has fired beforeinstallprompt (Chrome / Edge / Android) */
+  canInstall: boolean;
+  /** True when running on iOS Safari — requires manual share-sheet flow */
+  isIos: boolean;
+  /** True when already running as an installed PWA */
+  isInstalled: boolean;
+  /** Trigger the native install prompt (no-op if canInstall is false) */
+  triggerInstall(): Promise<void>;
+}
+
+const PWAInstallContext = createContext<PWAInstallContextValue>({
+  canInstall: false,
+  isIos: false,
+  isInstalled: false,
+  triggerInstall: async () => {},
+});
+
+function readIsInstalled() {
+  if (typeof window === "undefined") return false;
+  return (
+    window.matchMedia("(display-mode: standalone)").matches ||
+    (navigator as Navigator & { standalone?: boolean }).standalone === true
+  );
+}
+
+function readIsIos() {
+  if (typeof window === "undefined") return false;
+  return /iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+export function PWAInstallProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Lazy initialisers read browser state once on first client render — no effect needed
+  const [isInstalled] = useState(readIsInstalled);
+  const [isIos] = useState(readIsIos);
+  const [deferredPrompt, setDeferredPrompt] =
+    useState<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    // Already installed or iOS — no point listening for beforeinstallprompt
+    if (isInstalled || isIos) return;
+
+    function handleBeforeInstall(e: Event) {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+    }
+    window.addEventListener("beforeinstallprompt", handleBeforeInstall);
+    return () =>
+      window.removeEventListener("beforeinstallprompt", handleBeforeInstall);
+  }, [isInstalled, isIos]);
+
+  const triggerInstall = useCallback(async () => {
+    if (!deferredPrompt) return;
+    await deferredPrompt.prompt();
+    await deferredPrompt.userChoice;
+    setDeferredPrompt(null);
+  }, [deferredPrompt]);
+
+  return (
+    <PWAInstallContext.Provider
+      value={{
+        canInstall: !!deferredPrompt,
+        isIos,
+        isInstalled,
+        triggerInstall,
+      }}
+    >
+      {children}
+    </PWAInstallContext.Provider>
+  );
+}
+
+export function usePWAInstall() {
+  return useContext(PWAInstallContext);
+}

--- a/tests/e2e/pwa-install.spec.ts
+++ b/tests/e2e/pwa-install.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect } from "@playwright/test";
+
+// Simulate iPhone Safari user agent for iOS-branch tests
+const IOS_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) " +
+  "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+
+test.describe("PWA install — About page", () => {
+  test("about page has an install section", async ({ page }) => {
+    await page.goto("/about");
+    await expect(
+      page.getByRole("heading", { name: /install as an app/i })
+    ).toBeVisible();
+  });
+
+  test("about page install section renders instructions", async ({ page }) => {
+    await page.goto("/about");
+    // The fallback (generic instructions) is shown on desktop Chromium
+    // — verify the section has actionable content
+    const section = page.locator("#install");
+    await expect(section).toBeVisible();
+    await expect(section.getByText(/progressive web app/i)).toBeVisible();
+  });
+
+  test("about page shows 'already installed' when in standalone mode", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      // matches is a read-only getter — return a full mock object for standalone
+      const original = window.matchMedia.bind(window);
+      window.matchMedia = (query: string): MediaQueryList => {
+        if (query === "(display-mode: standalone)") {
+          return {
+            matches: true,
+            media: query,
+            onchange: null,
+            addListener: () => {},
+            removeListener: () => {},
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            dispatchEvent: () => false,
+          } as MediaQueryList;
+        }
+        return original(query);
+      };
+    });
+    await page.goto("/about");
+    await expect(page.getByText(/already installed/i)).toBeVisible();
+  });
+
+  test("about page shows iOS instructions when on iOS", async ({ page }) => {
+    await page.addInitScript((ua) => {
+      Object.defineProperty(navigator, "userAgent", {
+        value: ua,
+        configurable: true,
+      });
+    }, IOS_UA);
+    await page.goto("/about");
+    // iOS flow shows the numbered list with "Add to Home Screen"
+    await expect(
+      page.locator("#install").getByText(/add to home screen/i).first()
+    ).toBeVisible();
+  });
+});
+
+test.describe("PWA install — footer link", () => {
+  test("footer contains Install app link pointing to /about#install", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const link = page.getByRole("link", { name: /install app/i });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", "/about#install");
+  });
+});
+
+test.describe("PWA install — banner", () => {
+  test("iOS banner is visible on first visit (iOS UA, not standalone)", async ({
+    page,
+  }) => {
+    await page.addInitScript((ua) => {
+      Object.defineProperty(navigator, "userAgent", {
+        value: ua,
+        configurable: true,
+      });
+      // Ensure not standalone
+      Object.defineProperty(navigator, "standalone", {
+        value: false,
+        configurable: true,
+      });
+    }, IOS_UA);
+
+    await page.goto("/");
+    await expect(page.getByText(/add to home screen/i)).toBeVisible();
+  });
+
+  test("iOS banner is hidden when already dismissed", async ({ page }) => {
+    await page.addInitScript((ua) => {
+      Object.defineProperty(navigator, "userAgent", {
+        value: ua,
+        configurable: true,
+      });
+      localStorage.setItem("pwa-install-dismissed", "1");
+    }, IOS_UA);
+
+    await page.goto("/");
+    await expect(page.getByText(/add to home screen/i)).not.toBeVisible();
+  });
+
+  test("iOS banner is hidden when running in standalone mode", async ({
+    page,
+  }) => {
+    await page.addInitScript((ua) => {
+      Object.defineProperty(navigator, "userAgent", {
+        value: ua,
+        configurable: true,
+      });
+      // Simulate standalone (navigator.standalone = true is the iOS signal)
+      Object.defineProperty(navigator, "standalone", {
+        value: true,
+        configurable: true,
+      });
+    }, IOS_UA);
+
+    await page.goto("/");
+    await expect(page.getByText(/add to home screen/i)).not.toBeVisible();
+  });
+
+  test("dismissing iOS banner hides it immediately", async ({ page }) => {
+    await page.addInitScript((ua) => {
+      Object.defineProperty(navigator, "userAgent", {
+        value: ua,
+        configurable: true,
+      });
+    }, IOS_UA);
+
+    await page.goto("/");
+    await expect(page.getByText(/add to home screen/i)).toBeVisible();
+
+    await page
+      .getByRole("button", { name: /dismiss install instructions/i })
+      .click();
+    await expect(page.getByText(/add to home screen/i)).not.toBeVisible();
+  });
+
+  test("dismissed state persists across navigation", async ({ page }) => {
+    await page.addInitScript((ua) => {
+      Object.defineProperty(navigator, "userAgent", {
+        value: ua,
+        configurable: true,
+      });
+    }, IOS_UA);
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /dismiss install instructions/i })
+      .click();
+
+    // Navigate away and back — banner must stay hidden
+    await page.goto("/about");
+    await page.goto("/");
+    await expect(page.getByText(/add to home screen/i)).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a non-intrusive `InstallBanner` (fixed bottom strip) that shows a one-tap install CTA on Chrome/Edge/Android and share-sheet instructions on iOS; hidden when already installed or after dismissal (persisted in `localStorage`)
- Shared `PWAInstallProvider` context in `lib/pwa-install.tsx` captures `beforeinstallprompt` once at app level — both the banner and the About page draw from the same deferred prompt
- New "Install as an app" section on the About page (`/about#install`) with platform-aware instructions (one-tap install, iOS numbered steps, generic all-platform fallback, "already installed" confirmation)
- Permanent "Install app" footer link → `/about#install` so users who dismissed the banner can always find instructions

## Test plan

- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — 774 unit/component tests pass
- [x] `pnpm test:e2e` — 22 E2E tests pass (10 new: About page section, footer link, iOS banner visibility/dismissal/standalone guard, persistence across navigation)
- [ ] Manual: open on iOS Safari — verify banner appears on first visit, tapping dismiss hides it, `/about#install` shows numbered iOS steps
- [ ] Manual: open on Chrome/Android or desktop Chrome — verify native install prompt fires on "Install" tap
- [ ] Manual: install the app, reload — verify banner and About page both show "already installed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)