### PR TITLE
fix(pwa): rename short_name from SSI to Scoreboard

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "SSI Scoreboard",
-  "short_name": "SSI",
+  "short_name": "Scoreboard",
   "description": "Live stage-by-stage IPSC competitor comparison",
   "start_url": "/",
   "display": "standalone",


### PR DESCRIPTION
## Summary

- Changes PWA `short_name` from `"SSI"` to `"Scoreboard"` in `public/manifest.json`
- \"SSI\" is the ShootNScoreIt platform itself — using it as the home-screen label is confusing
- \"Scoreboard\" is clear and unambiguous as an installed app name

## Test plan

- [ ] Install the PWA on Android or iOS and verify the home-screen label reads \"Scoreboard\"
- [ ] Confirm no other manifest fields were changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)