### PR TITLE
chore: exclude .claude/worktrees/ from git tracking and vitest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Thumbs.db
 
 # Claude Code
 .claude/settings.local.json
+.claude/worktrees/
 
 # Testing
 /coverage/

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./tests/setup.ts"],
-    exclude: ["**/node_modules/**", "**/tests/e2e/**"],
+    exclude: ["**/node_modules/**", "**/tests/e2e/**", "**/.claude/**"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- `.gitignore`: adds `.claude/worktrees/` — Claude Code worktrees are ephemeral scratch copies, not source files
- `vitest.config.ts`: adds `**/.claude/**` to `exclude` — previously vitest discovered test files inside active worktrees and ran every suite twice (780 tests → now correctly 390)

## Test plan

- [ ] `pnpm test` reports 18 files / 390 tests (not 36 / 780)
- [ ] `git status` no longer shows `.claude/worktrees/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)