### PR TITLE
fix(mcp): OAuth discovery endpoint so Claude Desktop and ChatGPT just work

### DIFF
--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,28 @@
+/**
+ * OAuth 2.0 Protected Resource Metadata (RFC 9728).
+ *
+ * MCP clients implementing the June 2025 auth spec (Claude Desktop, ChatGPT)
+ * probe this endpoint before attempting the MCP handshake. A 404 here is
+ * treated as a connection/auth error by those clients.
+ *
+ * Returning an empty `authorization_servers` array explicitly signals that
+ * this is an authless server — no OAuth flow is required.
+ */
+export async function GET() {
+  const resource =
+    (process.env.NEXT_PUBLIC_APP_URL ?? "https://scoreboard.urdr.dev") + "/api/mcp";
+
+  return Response.json(
+    {
+      resource,
+      authorization_servers: [],
+      bearer_methods_supported: [],
+    },
+    {
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "public, max-age=3600",
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Problem

Claude Desktop and ChatGPT both implement the MCP June 2025 auth spec, which requires probing `/.well-known/oauth-protected-resource` before attempting the MCP handshake. When this endpoint returns 404 (as it did), both clients show a generic "error connecting to MCP server, please check auth" message and refuse to connect — even though the actual MCP protocol works fine.

## Fix

Add `app/.well-known/oauth-protected-resource/route.ts` that returns RFC 9728 Protected Resource Metadata with an empty `authorization_servers` array. This explicitly tells clients the server is authless — no OAuth flow is required.

```
GET /.well-known/oauth-protected-resource
→ 200 { "resource": "https://scoreboard.urdr.dev/api/mcp", "authorization_servers": [] }
```

## Test plan

- [ ] Deploy and add `https://scoreboard.urdr.dev/api/mcp` as a remote connector in Claude Desktop Settings → Connectors — should connect without error
- [ ] Same for ChatGPT Settings → Apps (Developer Mode)
- [ ] `curl https://scoreboard.urdr.dev/.well-known/oauth-protected-resource` returns JSON with empty `authorization_servers`
- [ ] `pnpm typecheck && pnpm test` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)