### PR TITLE
fix(mcp): implement auto-approving OAuth server for Claude Desktop + ChatGPT

### DIFF
--- a/app/.well-known/oauth-authorization-server/route.ts
+++ b/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,27 @@
+/**
+ * OAuth 2.0 Authorization Server Metadata (RFC 8414).
+ *
+ * MCP clients that found our oauth-protected-resource metadata follow up here
+ * to discover our authorization endpoints. We expose a minimal OAuth server
+ * that auto-approves all requests — this is a fully public read-only API with
+ * no user accounts or private data.
+ */
+const CORS = { "Access-Control-Allow-Origin": "*" };
+
+export async function GET() {
+  const base = process.env.NEXT_PUBLIC_APP_URL ?? "https://scoreboard.urdr.dev";
+  return Response.json(
+    {
+      issuer: base,
+      authorization_endpoint: `${base}/oauth/authorize`,
+      token_endpoint: `${base}/oauth/token`,
+      registration_endpoint: `${base}/register`,
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code"],
+      token_endpoint_auth_methods_supported: ["none"],
+      code_challenge_methods_supported: ["S256"],
+      scopes_supported: [],
+    },
+    { headers: CORS },
+  );
+}

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -2,21 +2,18 @@
  * OAuth 2.0 Protected Resource Metadata (RFC 9728).
  *
  * MCP clients implementing the June 2025 auth spec (Claude Desktop, ChatGPT)
- * probe this endpoint before attempting the MCP handshake. A 404 here is
- * treated as a connection/auth error by those clients.
- *
- * Returning an empty `authorization_servers` array explicitly signals that
- * this is an authless server — no OAuth flow is required.
+ * probe this endpoint before attempting the MCP handshake. We point them at
+ * our own OAuth server (same origin), which auto-approves all requests since
+ * this is a fully public read-only API.
  */
 export async function GET() {
-  const resource =
-    (process.env.NEXT_PUBLIC_APP_URL ?? "https://scoreboard.urdr.dev") + "/api/mcp";
-
+  const base = process.env.NEXT_PUBLIC_APP_URL ?? "https://scoreboard.urdr.dev";
   return Response.json(
     {
-      resource,
-      authorization_servers: [],
-      bearer_methods_supported: [],
+      resource: `${base}/api/mcp`,
+      // Points to our own authorization server — clients will follow up at
+      // /.well-known/oauth-authorization-server to get the OAuth endpoints.
+      authorization_servers: [base],
     },
     {
       headers: {

--- a/app/oauth/authorize/route.ts
+++ b/app/oauth/authorize/route.ts
@@ -1,0 +1,32 @@
+/**
+ * OAuth 2.0 Authorization Endpoint.
+ *
+ * Auto-approves all requests and redirects immediately — no user sign-in
+ * required because this is a fully public read-only API. The browser
+ * redirect will be nearly instant.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const redirectUri = searchParams.get("redirect_uri");
+  const state = searchParams.get("state");
+
+  if (!redirectUri) {
+    return new Response("Missing redirect_uri", { status: 400 });
+  }
+
+  // Basic open-redirect mitigation: only allow HTTPS callbacks.
+  // No user secrets are at stake (public server), but good practice.
+  let callbackUrl: URL;
+  try {
+    callbackUrl = new URL(redirectUri);
+    if (callbackUrl.protocol !== "https:") throw new Error("HTTPS only");
+  } catch {
+    return new Response("Invalid redirect_uri — must be an HTTPS URL", { status: 400 });
+  }
+
+  // Auto-approve: generate a one-time code and redirect immediately.
+  callbackUrl.searchParams.set("code", crypto.randomUUID());
+  if (state) callbackUrl.searchParams.set("state", state);
+
+  return Response.redirect(callbackUrl.toString(), 302);
+}

--- a/app/oauth/token/route.ts
+++ b/app/oauth/token/route.ts
@@ -1,0 +1,29 @@
+/**
+ * OAuth 2.0 Token Endpoint.
+ *
+ * Issues a long-lived bearer token for any valid-looking request.
+ * The MCP server at /api/mcp ignores the bearer token (no MCP_SECRET
+ * configured), so the token is effectively a formality — it just
+ * satisfies the client's OAuth flow requirement.
+ */
+const CORS: HeadersInit = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: CORS });
+}
+
+export async function POST() {
+  return Response.json(
+    {
+      access_token: crypto.randomUUID(),
+      token_type: "bearer",
+      // 1-year expiry — avoids frequent re-auth prompts for a public API.
+      expires_in: 365 * 24 * 3600,
+    },
+    { headers: CORS },
+  );
+}

--- a/app/register/route.ts
+++ b/app/register/route.ts
@@ -1,0 +1,39 @@
+/**
+ * OAuth 2.0 Dynamic Client Registration (RFC 7591).
+ *
+ * MCP clients (Claude Desktop, ChatGPT) register themselves here before
+ * starting the authorization flow. We accept all registrations and return
+ * a stable client_id — no real credentials are issued since the MCP server
+ * is fully public.
+ */
+const CORS: HeadersInit = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: CORS });
+}
+
+export async function POST(request: Request) {
+  let body: Record<string, unknown> = {};
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    /* ignore — all fields are optional */
+  }
+
+  return Response.json(
+    {
+      client_id: "public-mcp-client",
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+      client_name: body.client_name ?? "MCP Client",
+      redirect_uris: body.redirect_uris ?? [],
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    },
+    { status: 201, headers: CORS },
+  );
+}


### PR DESCRIPTION
## Root cause (from CF logs)

After our previous fix, Claude Desktop successfully fetched \`/.well-known/oauth-protected-resource\` (200), but then followed up at two more endpoints — both returning 404 — causing the error:

```
GET  /.well-known/oauth-protected-resource     → 200 ✅ (previous fix)
GET  /.well-known/oauth-authorization-server   → 404 ❌
POST /register                                 → 404 ❌
```

The \`authorization_servers: []\` response wasn't read as "no auth" — Claude used it as a cue to probe the same origin for an OAuth server.

## Fix

Implement a complete (but rubber-stamp) OAuth 2.0 server across four new routes:

| Endpoint | Purpose |
|---|---|
| \`GET /.well-known/oauth-authorization-server\` | RFC 8414 server metadata |
| \`POST /register\` | RFC 7591 Dynamic Client Registration |
| \`GET /oauth/authorize\` | Auto-approves, redirects immediately with a code |
| \`POST /oauth/token\` | Issues a 1-year bearer token |

Since this is a fully public read-only API (no user accounts, no write operations), auto-approving the OAuth flow is safe and appropriate. The MCP server ignores bearer tokens when \`MCP_SECRET\` is not set.

Also updates \`oauth-protected-resource\` to list our own server in \`authorization_servers\` so clients know where to find the OAuth metadata.

## Test plan

- [ ] Deploy and add \`https://scoreboard.urdr.dev/api/mcp\` in Claude Desktop Settings → Connectors — should connect without error (OAuth flow completes in background)
- [ ] Same for ChatGPT Settings → Apps (Developer Mode)
- [ ] \`curl https://scoreboard.urdr.dev/.well-known/oauth-authorization-server\` returns server metadata JSON
- [ ] \`curl -X POST https://scoreboard.urdr.dev/register -H "Content-Type: application/json" -d '{}'\` returns client registration
- [ ] \`pnpm typecheck && pnpm test\` — zero errors, 406 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)