### PR TITLE
fix(mcp): OAuth endpoints at /authorize and /token (Claude Desktop path fix)

### DIFF
--- a/app/.well-known/oauth-authorization-server/route.ts
+++ b/app/.well-known/oauth-authorization-server/route.ts
@@ -13,8 +13,8 @@ export async function GET() {
   return Response.json(
     {
       issuer: base,
-      authorization_endpoint: `${base}/oauth/authorize`,
-      token_endpoint: `${base}/oauth/token`,
+      authorization_endpoint: `${base}/authorize`,
+      token_endpoint: `${base}/token`,
       registration_endpoint: `${base}/register`,
       response_types_supported: ["code"],
       grant_types_supported: ["authorization_code"],

--- a/app/authorize/route.ts
+++ b/app/authorize/route.ts
@@ -1,0 +1,32 @@
+/**
+ * OAuth 2.0 Authorization Endpoint.
+ *
+ * Auto-approves all requests and redirects immediately — no user sign-in
+ * required because this is a fully public read-only API. The browser
+ * redirect will be nearly instant.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const redirectUri = searchParams.get("redirect_uri");
+  const state = searchParams.get("state");
+
+  if (!redirectUri) {
+    return new Response("Missing redirect_uri", { status: 400 });
+  }
+
+  // Basic open-redirect mitigation: only allow HTTPS callbacks.
+  // No user secrets are at stake (public server), but good practice.
+  let callbackUrl: URL;
+  try {
+    callbackUrl = new URL(redirectUri);
+    if (callbackUrl.protocol !== "https:") throw new Error("HTTPS only");
+  } catch {
+    return new Response("Invalid redirect_uri — must be an HTTPS URL", { status: 400 });
+  }
+
+  // Auto-approve: generate a one-time code and redirect immediately.
+  callbackUrl.searchParams.set("code", crypto.randomUUID());
+  if (state) callbackUrl.searchParams.set("state", state);
+
+  return Response.redirect(callbackUrl.toString(), 302);
+}

--- a/app/token/route.ts
+++ b/app/token/route.ts
@@ -1,0 +1,29 @@
+/**
+ * OAuth 2.0 Token Endpoint.
+ *
+ * Issues a long-lived bearer token for any valid-looking request.
+ * The MCP server at /api/mcp ignores the bearer token (no MCP_SECRET
+ * configured), so the token is effectively a formality — it just
+ * satisfies the client's OAuth flow requirement.
+ */
+const CORS: HeadersInit = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: CORS });
+}
+
+export async function POST() {
+  return Response.json(
+    {
+      access_token: crypto.randomUUID(),
+      token_type: "bearer",
+      // 1-year expiry — avoids frequent re-auth prompts for a public API.
+      expires_in: 365 * 24 * 3600,
+    },
+    { headers: CORS },
+  );
+}


### PR DESCRIPTION
## Problem

Claude Desktop requests `/authorize` but our route was at `/oauth/authorize`.
It either uses root-level paths as a convention, or falls back to them when
it can't read the metadata endpoint correctly.

## Fix

- Add `app/authorize/route.ts` (same handler as `/oauth/authorize`)
- Add `app/token/route.ts` (same handler as `/oauth/token`)
- Update `/.well-known/oauth-authorization-server` to advertise `/authorize` and `/token`
- Keep `/oauth/authorize` and `/oauth/token` as fallbacks

## Test plan

- [ ] Deploy and add `https://scoreboard.urdr.dev/api/mcp` in Claude Desktop Settings → Connectors
- [ ] `curl "https://scoreboard.urdr.dev/authorize?response_type=code&client_id=x&redirect_uri=https://claude.ai/api/mcp/auth_callback&state=test"` returns 302 redirect to callback
- [ ] `curl -X POST https://scoreboard.urdr.dev/token` returns `{ access_token, token_type, expires_in }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)