### PR TITLE
fix(mcp): serve resource metadata at RFC 9728 resource-specific path

### DIFF
--- a/app/.well-known/oauth-protected-resource/[...slug]/route.ts
+++ b/app/.well-known/oauth-protected-resource/[...slug]/route.ts
@@ -1,0 +1,27 @@
+/**
+ * OAuth 2.0 Protected Resource Metadata — resource-specific path (RFC 9728).
+ *
+ * Per RFC 9728 §3, clients SHOULD look up protected-resource metadata at
+ * /.well-known/oauth-protected-resource/{resource-path} before falling back
+ * to the bare /.well-known/oauth-protected-resource URL.
+ *
+ * For our MCP server at /api/mcp, Claude and other clients probe
+ * /.well-known/oauth-protected-resource/api/mcp first. This catch-all
+ * returns the same metadata as the parent route so the resource-specific
+ * lookup succeeds immediately (no 404 fallback needed).
+ */
+export async function GET() {
+  const base = process.env.NEXT_PUBLIC_APP_URL ?? "https://scoreboard.urdr.dev";
+  return Response.json(
+    {
+      resource: `${base}/api/mcp`,
+      authorization_servers: [base],
+    },
+    {
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "public, max-age=3600",
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Problem

Claude was hitting `/.well-known/oauth-protected-resource/api/mcp` first (RFC 9728 §3 — append the resource path) and getting a **404**. It fell back to `/.well-known/oauth-protected-resource` (200), ran the full OAuth flow, obtained a token — but then never made an authenticated `POST /api/mcp`. Result: "Error connecting to MCP server".

Log evidence:
```
GET /.well-known/oauth-protected-resource/api/mcp  → 404  ← problem
GET /.well-known/oauth-protected-resource           → 200  ← fallback worked
POST /register                                      → 201
GET  /authorize                                     → 302
POST /token                                         → 200
(no subsequent POST /api/mcp with Bearer token)
```

## Fix

Add `app/.well-known/oauth-protected-resource/[...slug]/route.ts` — a catch-all that returns the same protected-resource metadata for any subpath. Now the resource-specific URL `/.well-known/oauth-protected-resource/api/mcp` returns **200** on the first try.

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `curl https://scoreboard.urdr.dev/.well-known/oauth-protected-resource/api/mcp` returns 200 JSON with `resource` and `authorization_servers`
- [ ] Connect Claude Desktop to `https://scoreboard.urdr.dev/api/mcp` — no error dialog, tools listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)