### PR TITLE
fix(events): use wide date window for text searches to include past matches

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -72,10 +72,20 @@ export async function GET(req: Request) {
   const country = searchParams.get("country");
   const minLevel = searchParams.get("minLevel") ?? "l2plus";
 
-  const startsAfter =
-    searchParams.get("starts_after") ?? defaultAfter.toISOString().slice(0, 10);
-  const startsBefore =
-    searchParams.get("starts_before") ?? defaultBefore.toISOString().slice(0, 10);
+  // When a text query is present the caller is searching for a specific event
+  // and we should not silently clip results to a narrow date window — use a
+  // wide fallback (5 years back / 2 years forward) so past matches are found.
+  // The narrow ±3-month default applies only to browse mode (no q) where we
+  // need the sub-window strategy to work around the SSI API result cap.
+  const wideAfter = new Date(now);
+  wideAfter.setFullYear(wideAfter.getFullYear() - 5);
+  const wideBefore = new Date(now);
+  wideBefore.setFullYear(wideBefore.getFullYear() + 2);
+
+  const startsAfter = searchParams.get("starts_after") ??
+    (q ? wideAfter.toISOString().slice(0, 10) : defaultAfter.toISOString().slice(0, 10));
+  const startsBefore = searchParams.get("starts_before") ??
+    (q ? wideBefore.toISOString().slice(0, 10) : defaultBefore.toISOString().slice(0, 10));
   const firearms = searchParams.get("firearms") ?? "hg";
 
   let rawEvents: RawEvent[];

--- a/lib/mcp-tools.ts
+++ b/lib/mcp-tools.ts
@@ -16,7 +16,9 @@ export function registerMcpTools(server: McpServer, baseUrl: string): void {
     "Search for IPSC competitions by name, country, date range, or level. " +
     "Use this to find a specific match the user has named, or to browse upcoming/recent events. " +
     "Each result contains `id` and `content_type` fields — pass both to get_match to load full details. " +
-    "Omit all filters to list upcoming events. " +
+    "When searching by name (query param), past events are included automatically — no date filter needed. " +
+    "When browsing without a query, only events within ~3 months of today are returned by default; " +
+    "pass explicit starts_after/starts_before to widen the window. " +
     "`min_level` defaults to l2plus which hides small club matches; pass 'all' only if the user explicitly wants club-level events.",
     {
       query: z.string().optional().describe("Free-text search by event name or venue"),


### PR DESCRIPTION
## Summary

- When a `q` (text search) param is present, the default date fallback is now ±5 years back / +2 years forward instead of ±3 months — named past events like "Tallmilan 2025" are now found without requiring explicit date filters from the caller
- Browse mode (no `q`) keeps the narrow ±3-month default, which is needed for the sub-window strategy that works around the SSI API result cap
- Updates the MCP `search_events` tool description to document the distinction so LLM callers know when to supply explicit date ranges

## Test plan

- [ ] Search for a past event by name (e.g. "Tallmilan 2025") — should return results without passing `starts_after`
- [ ] Browse events without a query — should still default to ±3 months
- [ ] Explicit `starts_after`/`starts_before` params still override the defaults in both modes
- [ ] `pnpm -w run typecheck && pnpm -w test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)