### PR TITLE
fix(oauth): allow http://localhost redirect URIs for native MCP clients

### DIFF
--- a/app/oauth/authorize/route.ts
+++ b/app/oauth/authorize/route.ts
@@ -14,14 +14,21 @@ export async function GET(request: Request) {
     return new Response("Missing redirect_uri", { status: 400 });
   }
 
-  // Basic open-redirect mitigation: only allow HTTPS callbacks.
-  // No user secrets are at stake (public server), but good practice.
+  // Open-redirect mitigation: allow HTTPS callbacks for web clients, and
+  // http://localhost / http://127.0.0.1 for native/CLI MCP clients that spin
+  // up a local callback server (RFC 8252 §7.3). Block all other HTTP URLs.
   let callbackUrl: URL;
   try {
     callbackUrl = new URL(redirectUri);
-    if (callbackUrl.protocol !== "https:") throw new Error("HTTPS only");
+    const isHttps = callbackUrl.protocol === "https:";
+    const isLocalhost =
+      callbackUrl.protocol === "http:" &&
+      (callbackUrl.hostname === "localhost" || callbackUrl.hostname === "127.0.0.1");
+    if (!isHttps && !isLocalhost) throw new Error("HTTPS or localhost only");
   } catch {
-    return new Response("Invalid redirect_uri — must be an HTTPS URL", { status: 400 });
+    return new Response("Invalid redirect_uri — must be HTTPS or http://localhost", {
+      status: 400,
+    });
   }
 
   // Auto-approve: generate a one-time code and redirect immediately.


### PR DESCRIPTION
## Summary

- The `/authorize` endpoint was rejecting `http://localhost` and `http://127.0.0.1` redirect URIs with 400, breaking the OAuth PKCE flow for MCP native clients
- MCP clients (Claude Code, Claude Desktop) spin up a local HTTP callback server during authorization — this is the RFC 8252 §7.3 standard for native/CLI app OAuth
- HTTPS is still required for all non-localhost redirect URIs

## Root cause

Found by inspecting Cloudflare worker logs — the OAuth discovery endpoint (`/.well-known/oauth-protected-resource/api/mcp`) was the first thing Claude probed, and a prior deploy had that returning 404. That's now fixed. But the authorize endpoint's HTTPS-only check remained the active blocker for clients using localhost callbacks.

## Test plan

- [ ] `curl "https://scoreboard.urdr.dev/authorize?redirect_uri=http://localhost:3333/callback&..."` → 302 (was 400)
- [ ] `redirect_uri=http://evil.com` → still 400
- [ ] `redirect_uri=https://example.com/callback` → still 302
- [ ] `pnpm -w run typecheck && pnpm -w test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)