### PR TITLE
feat(smithery): add Smithery registry integration

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -2,6 +2,7 @@
   "name": "ssi-scoreboard-mcp",
   "version": "0.1.0",
   "private": true,
+  "module": "./src/index.ts",
   "scripts": {
     "start": "tsx src/index.ts",
     "typecheck": "tsc --noEmit"

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,13 +1,40 @@
+import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
 import { registerMcpTools } from "../../lib/mcp-tools.ts";
 
-const baseUrl = process.env.SSI_SCOREBOARD_BASE_URL ?? "http://localhost:3000";
+const PROD_URL = "https://scoreboard.urdr.dev";
 
+/**
+ * Smithery configSchema — no user configuration needed.
+ * The server connects directly to the public scoreboard API.
+ */
+export const configSchema = z.object({});
+
+/**
+ * Smithery entry point (runtime: typescript).
+ * Called by Smithery's HTTP runtime on each request.
+ */
+export default function createServer(_: { config: z.infer<typeof configSchema> }) {
+  const server = new McpServer({ name: "ssi-scoreboard", version: "0.1.0" });
+  registerMcpTools(server, PROD_URL);
+  return server.server;
+}
+
+// ---------------------------------------------------------------------------
+// Stdio shim — used by the local .mcp.json entry and Claude Desktop.
+// Only runs when this file is the process entry point, not when imported
+// by Smithery's HTTP runtime bundler.
+// ---------------------------------------------------------------------------
 async function main() {
+  const baseUrl = process.env.SSI_SCOREBOARD_BASE_URL ?? PROD_URL;
   const server = new McpServer({ name: "ssi-scoreboard", version: "0.1.0" });
   registerMcpTools(server, baseUrl);
   await server.connect(new StdioServerTransport());
 }
 
-main().catch(console.error);
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  main().catch(console.error);
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,7 @@
+runtime: typescript
+build:
+  # The MCP server lives in the mcp/ subdirectory of this monorepo.
+  # Install from the root first so mcp/ can resolve shared deps (zod, MCP SDK)
+  # from the root node_modules, then build the Smithery bundle from mcp/.
+  installCommand: "npm install"
+  buildCommand: "cd mcp && npx @smithery/cli build"


### PR DESCRIPTION
## What

Adds the files needed to publish this MCP server to [Smithery](https://smithery.ai), so users can install it with one command instead of pasting a URL.

```bash
npx @smithery/cli install @mandakan/ssi-scoreboard --client claude
```

## Files changed

| File | Change |
|---|---|
| `smithery.yaml` | `runtime: typescript` + build commands pointing to `mcp/` subdirectory |
| `mcp/package.json` | Add `"module": "./src/index.ts"` so `@smithery/cli` finds the entry point |
| `mcp/src/index.ts` | Add `configSchema` + `createServer()` exports for Smithery's HTTP runtime; guard stdio `main()` with `isMain` check |

## Why the subpackage structure matters

The MCP server lives in `mcp/` (a sub-package of the main Next.js app). Putting `"module"` in the root `package.json` caused tsx to recurse (`mcp/mcp/src/index.ts`), so it lives in `mcp/package.json` instead. The `smithery.yaml` build command `cd mcp && npx @smithery/cli build` runs the Smithery bundler from there.

## No user config

`configSchema` is empty — the server connects directly to the public `https://scoreboard.urdr.dev` API, no API key or credentials needed.

## Smoke test

```bash
echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
  | node_modules/.bin/tsx mcp/src/index.ts
# → all 4 tools listed ✓
```

## Next step after merge

Go to smithery.ai/new → connect GitHub → select this repo → deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)