### PR TITLE
fix(oauth): echo scope in authorize redirect and token response

### DIFF
--- a/app/oauth/authorize/route.ts
+++ b/app/oauth/authorize/route.ts
@@ -32,8 +32,12 @@ export async function GET(request: Request) {
   }
 
   // Auto-approve: generate a one-time code and redirect immediately.
+  // Echo scope back per RFC 6749 §4.1.2 so clients that validate granted
+  // scopes (e.g. claude.ai requires scope=claudeai) don't reject the grant.
   callbackUrl.searchParams.set("code", crypto.randomUUID());
   if (state) callbackUrl.searchParams.set("state", state);
+  const scope = searchParams.get("scope");
+  if (scope) callbackUrl.searchParams.set("scope", scope);
 
   return Response.redirect(callbackUrl.toString(), 302);
 }

--- a/app/oauth/token/route.ts
+++ b/app/oauth/token/route.ts
@@ -16,13 +16,30 @@ export async function OPTIONS() {
   return new Response(null, { status: 204, headers: CORS });
 }
 
-export async function POST() {
+export async function POST(request: Request) {
+  // Parse the requested scope from the token request body so we can echo it
+  // back. RFC 6749 §5.1 requires scope in the response if it differs from
+  // requested; echoing it avoids clients (e.g. claude.ai) treating a missing
+  // scope field as a grant failure.
+  let scope = "";
+  try {
+    const ct = request.headers.get("content-type") ?? "";
+    if (ct.includes("application/x-www-form-urlencoded")) {
+      const body = new URLSearchParams(await request.text());
+      scope = body.get("scope") ?? "";
+    } else {
+      const body = (await request.json()) as Record<string, unknown>;
+      scope = typeof body.scope === "string" ? body.scope : "";
+    }
+  } catch { /* ignore — scope is optional */ }
+
   return Response.json(
     {
       access_token: crypto.randomUUID(),
-      token_type: "bearer",
+      token_type: "Bearer",
       // 1-year expiry — avoids frequent re-auth prompts for a public API.
       expires_in: 365 * 24 * 3600,
+      ...(scope ? { scope } : {}),
     },
     { headers: CORS },
   );


### PR DESCRIPTION
## Summary

- `/authorize` now echoes back the `scope` param in the redirect callback (RFC 6749 §4.1.2). Claude.ai requires `scope=claudeai` to appear in the callback — without it the grant was silently treated as failed, which explains the persistent "Error connecting to the MCP server" even after the OAuth flow appeared to complete
- `/token` now reads the requested `scope` from the token exchange body and echoes it back in the response
- `token_type` changed from `"bearer"` to `"Bearer"` (RFC 6749 §7.1 canonical casing; some strict OAuth clients reject lowercase)

## Root cause

From the Cloudflare logs, the full OAuth flow was completing (all endpoints returning 200/201/302) but the MCP connection was never established in Claude Desktop/claude.ai. The authorize redirect and token response were both missing the `scope` field — claude.ai's OAuth client validates that the granted scope includes `claudeai` before marking the connection as authorized.

## Test plan

- [ ] After deploy, try reconnecting the MCP server in Claude Desktop / claude.ai
- [ ] Verify `GET /authorize?...&scope=claudeai` redirects with `scope=claudeai` in callback
- [ ] Verify `POST /token` response includes `scope: "claudeai"`
- [ ] `pnpm -w run typecheck && pnpm -w test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)