### PR TITLE
Add MCP resources, prompts, and configurable base URL

### DIFF
--- a/lib/mcp-tools.ts
+++ b/lib/mcp-tools.ts
@@ -1,8 +1,151 @@
-// Server-only — registers MCP tools on a McpServer instance.
+// Server-only — registers MCP tools, resources, and prompts on a McpServer instance.
 // Called by both the HTTP route handler and the stdio server.
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { EventSummary, MatchResponse, CompareResponse, PopularMatch } from "./types";
+
+// ---------------------------------------------------------------------------
+// Static resource content
+// ---------------------------------------------------------------------------
+
+const GUIDE_TEXT = `\
+SSI Scoreboard MCP Server — Tool Guide
+=======================================
+
+This server provides read-only access to IPSC competition data from
+ShootNScoreIt (SSI) via the public scoreboard at https://scoreboard.urdr.dev.
+
+TYPICAL WORKFLOWS
+-----------------
+
+1. Analyse one competitor's performance:
+   search_events(query="<match name>")
+   → get_match(ct, id)
+   → compare_competitors(ct, id, [competitor_id])
+
+2. Compare a squad head-to-head:
+   search_events(...)
+   → get_match(...)         ← use squads[n].competitorIds to find IDs
+   → compare_competitors(ct, id, ids)
+
+3. Browse currently popular / active matches:
+   get_popular_matches()    ← returns [] when cache cold
+   → (if empty) search_events(starts_after="<today>")
+
+TOOL SUMMARY
+------------
+
+search_events
+  Find events by name, country, date range, or competition level.
+  • min_level defaults to "l2plus" (Regional and above).
+    Use "all" only when the user explicitly asks for Level I club matches.
+  • With a query param, past events are included — no date filter needed.
+  • Without a query, returns events within ~3 months of today.
+
+get_match
+  Load full competitor list, stage list, and squads for one match.
+  • Always call this before compare_competitors to resolve names → numeric IDs.
+  • squads[n].competitorIds lists every approved competitor in that squad.
+  • scoring_completed (0–100 %) shows how much of the match has been scored.
+
+compare_competitors
+  Deep stage-by-stage analysis for 1–12 competitors.
+  • Pass a single ID for solo analysis; multiple IDs for head-to-head.
+  • Returns: scores, hit factors, penalties, efficiency, consistency,
+    what-if rank simulations, and style fingerprints.
+  • competitor_ids are numeric — always resolve names via get_match first.
+
+get_popular_matches
+  Returns recently-viewed matches from the server cache.
+  • Call first when the user has not named a specific match.
+  • Falls back to search_events when the cache is cold (returns []).
+
+DATA QUALITY NOTES
+------------------
+• During active matches some stages may not yet be scored
+  (incomplete=true, hit_factor=null).
+• Competitors with dnf=true or dq=true should be noted in summaries.
+• division values are lowercase strings (e.g. "production", "open").
+• All percentages in compare_competitors are relative to the selected
+  group leader unless the field includes "div_" or "overall_" prefix.
+`;
+
+const IPSC_REFERENCE_TEXT = `\
+IPSC Reference — Divisions, Levels, and Scoring
+================================================
+
+HANDGUN DIVISIONS
+-----------------
+Production        Standard factory pistol, box-standard sights, 10-round limit
+Production Optics Production-legal pistol with red dot sight
+Standard          Modified pistol, open sights or red dot, 15-round limit
+Open              Race guns, compensators, optical sights, extended magazines
+Classic           1911-style single-stack pistols, 8-round limit
+Revolver          Double-action revolvers, 6-round capacity
+
+PCC DIVISIONS
+-------------
+PCC Optics        Pistol-calibre carbine with red dot or scope
+PCC Iron          Pistol-calibre carbine with iron sights
+
+MATCH LEVELS
+------------
+Level I   (L1)  Club match — local, unofficial, not in world rankings
+Level II  (L2)  Regional championship
+Level III (L3)  National championship
+Level IV  (L4)  Continental championship (European, Pan-American, etc.)
+Level V   (L5)  World Shoot — IPSC world championship
+
+MATCH STATUS CODES (from search_events / get_match)
+----------------------------------------------------
+on    Ongoing / in progress
+cp    Complete (results published)
+dr    Draft
+cs    Cancelled or suspended
+pr    Pre-match (registration open, not yet running)
+ol    Offline
+
+SCORING ZONES
+-------------
+A   5 points   (Alpha — centre zone; hardest to hit)
+C   3 points   (Charlie — outer scoring zone; B-zone combined here)
+D   1 point    (Delta — edge of cardboard target)
+M  −10 points  Miss (no valid zone hit on a required target)
+NS −10 points  No-Shoot (hit on a non-threat / hostage target)
+PE −10 points  Procedural error (per infraction)
+
+HIT FACTOR FORMULA
+------------------
+  HF = total_points / total_time_in_seconds
+
+Stage score % = (competitor_HF / stage_winner_HF) × 100
+
+Match result = average stage % across all stages (equally weighted).
+A 100 % on every stage is a perfect match.
+
+ACCURACY vs. SPEED TRADE-OFF
+-----------------------------
+A-ratio = total_A / (total_A + total_C + total_D)
+  • 0.80+ is excellent accuracy; typical club shooters are 0.55–0.70.
+  • Shooting faster almost always produces more C/D hits, but the HF
+    improves when the time savings exceed the point cost.
+
+HIT LOSS     Points left on the table from non-A hits (C/D/miss)
+             relative to a perfect alpha run.
+PENALTY LOSS Points lost to M/NS/PE penalties.
+PENALTY COST % = hypothetical penalty-free avg % − actual avg %.
+
+SHOOTER ARCHETYPES (style fingerprint)
+---------------------------------------
+Gunslinger   High speed, lower accuracy — wins on time
+Surgeon      High accuracy (A-ratio), slower — wins on points quality
+Speed Demon  Fast and penalised — speed without discipline
+Grinder      Steady, consistent performer near field median
+`;
+
+// ---------------------------------------------------------------------------
+// Tool, resource, and prompt registration
+// ---------------------------------------------------------------------------
 
 async function apiFetch<T>(baseUrl: string, path: string): Promise<T> {
   const res = await fetch(`${baseUrl}${path}`);
@@ -93,5 +236,143 @@ export function registerMcpTools(server: McpServer, baseUrl: string): void {
       const data = await apiFetch<PopularMatch[]>(baseUrl, "/api/popular-matches");
       return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
     },
+  );
+
+  // -------------------------------------------------------------------------
+  // Resources — static reference documents readable by MCP clients
+  // -------------------------------------------------------------------------
+
+  server.resource(
+    "guide",
+    "ssi://guide",
+    { description: "How to use the SSI Scoreboard MCP tools, including workflows and data quality notes", mimeType: "text/plain" },
+    async (uri) => ({
+      contents: [{ uri: uri.href, mimeType: "text/plain", text: GUIDE_TEXT }],
+    }),
+  );
+
+  server.resource(
+    "ipsc-reference",
+    "ssi://ipsc-reference",
+    { description: "IPSC reference: divisions, match levels, status codes, scoring zones, hit factor formula, and shooter archetypes", mimeType: "text/plain" },
+    async (uri) => ({
+      contents: [{ uri: uri.href, mimeType: "text/plain", text: IPSC_REFERENCE_TEXT }],
+    }),
+  );
+
+  // -------------------------------------------------------------------------
+  // Prompts — workflow starters that guide an AI through common tasks
+  // -------------------------------------------------------------------------
+
+  server.prompt(
+    "analyze_performance",
+    "Analyse a competitor's stage-by-stage performance at an IPSC match and produce coaching feedback",
+    {
+      match_name: z.string().describe("Name of the IPSC match (partial name is fine)"),
+      competitor_name: z.string().describe("Full or partial name of the competitor to analyse"),
+    },
+    ({ match_name, competitor_name }) => ({
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text:
+              `Please analyse ${competitor_name}'s performance at "${match_name}".\n\n` +
+              `Steps:\n` +
+              `1. Use search_events with query="${match_name}" to find the match.\n` +
+              `2. Use get_match with the ct and id from that result to load competitors and stages.\n` +
+              `3. Find ${competitor_name} in the competitor list — match by name.\n` +
+              `4. Use compare_competitors with their numeric competitor ID.\n` +
+              `5. Present a coaching summary covering:\n` +
+              `   • Overall result, division rank, and overall rank\n` +
+              `   • Best and worst stages (by group %)\n` +
+              `   • Consistency score and what it means\n` +
+              `   • Hit quality vs speed trade-off (A-ratio, efficiency)\n` +
+              `   • Penalty analysis (cost in match % terms)\n` +
+              `   • What-if simulation: what rank would they have achieved with a better worst stage?\n` +
+              `   • 2–3 specific, actionable improvement tips`,
+          },
+        },
+      ],
+    }),
+  );
+
+  server.prompt(
+    "compare_squad",
+    "Compare all members of a squad (or a named group) head-to-head at an IPSC match",
+    {
+      match_name: z.string().describe("Name of the IPSC match"),
+      squad: z
+        .string()
+        .optional()
+        .describe(
+          "Squad name or number (e.g. 'Squad 3'). If omitted, list available squads and ask the user to choose.",
+        ),
+    },
+    ({ match_name, squad }) => ({
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text:
+              `Please compare the competitors in ${squad ? `"${squad}"` : "a squad"} at "${match_name}".\n\n` +
+              `Steps:\n` +
+              `1. Use search_events with query="${match_name}" to find the match.\n` +
+              `2. Use get_match to load the full competitor list and squads.\n` +
+              (squad
+                ? `3. Find "${squad}" in the squads list and collect all competitorIds.\n`
+                : `3. List the available squads and ask the user which one to compare.\n`) +
+              `4. Use compare_competitors with those competitor IDs (up to 12).\n` +
+              `5. Summarise:\n` +
+              `   • Head-to-head rankings within the squad\n` +
+              `   • Strongest stage performance(s) and who delivered them\n` +
+              `   • Who is the most consistent vs the most variable\n` +
+              `   • Any standout penalty issues\n` +
+              `   • A brief narrative on the overall squad dynamic`,
+          },
+        },
+      ],
+    }),
+  );
+
+  server.prompt(
+    "find_matches",
+    "Find upcoming or recent IPSC matches, optionally filtered by country, name, or competition level",
+    {
+      query: z.string().optional().describe("Match name or venue to search for"),
+      country: z
+        .string()
+        .optional()
+        .describe("ISO 3166-1 alpha-3 country code, e.g. SWE, NOR, FIN, GBR"),
+      level: z
+        .enum(["all", "l2plus", "l3plus", "l4plus"])
+        .optional()
+        .describe("Minimum match level filter. Defaults to l2plus (Regional and above)."),
+    },
+    ({ query, country, level }) => ({
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text:
+              `Please find IPSC matches` +
+              (query ? ` matching "${query}"` : "") +
+              (country ? ` in country ${country}` : "") +
+              (level && level !== "l2plus" ? ` at level ${level}` : "") +
+              `.\n\n` +
+              `Use search_events` +
+              (query ? ` with query="${query}"` : "") +
+              (country ? ` and country="${country}"` : "") +
+              (level ? ` and min_level="${level}"` : "") +
+              `.\n\n` +
+              `Summarise the results in a table or list with: name, date, venue, level, and status ` +
+              `(ongoing / complete / upcoming). Highlight any matches that are currently in progress.`,
+          },
+        },
+      ],
+    }),
   );
 }

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -7,18 +7,27 @@ import { registerMcpTools } from "../../lib/mcp-tools.ts";
 const PROD_URL = "https://scoreboard.urdr.dev";
 
 /**
- * Smithery configSchema — no user configuration needed.
- * The server connects directly to the public scoreboard API.
+ * Smithery configSchema.
+ * All fields are optional — the server connects to the public scoreboard API by
+ * default, but operators running a self-hosted instance can override the URL.
  */
-export const configSchema = z.object({});
+export const configSchema = z.object({
+  baseUrl: z
+    .string()
+    .url()
+    .optional()
+    .describe(
+      "Base URL of the SSI Scoreboard instance. Defaults to https://scoreboard.urdr.dev",
+    ),
+});
 
 /**
  * Smithery entry point (runtime: typescript).
  * Called by Smithery's HTTP runtime on each request.
  */
-export default function createServer(_: { config: z.infer<typeof configSchema> }) {
+export default function createServer({ config }: { config: z.infer<typeof configSchema> }) {
   const server = new McpServer({ name: "ssi-scoreboard", version: "0.1.0" });
-  registerMcpTools(server, PROD_URL);
+  registerMcpTools(server, config.baseUrl ?? PROD_URL);
   return server.server;
 }
 


### PR DESCRIPTION
## Summary
This PR extends the SSI Scoreboard MCP server with static reference resources, workflow-guided prompts, and support for self-hosted instances via a configurable base URL.

## Key Changes

- **Static Resources**: Added two new MCP resources (`ssi://guide` and `ssi://ipsc-reference`) that provide comprehensive reference documentation:
  - `guide`: Tool usage workflows, typical analysis patterns, data quality notes, and tool summary
  - `ipsc-reference`: IPSC divisions, match levels, status codes, scoring zones, hit factor formula, and shooter archetypes

- **Workflow Prompts**: Registered three guided prompts that help AI assistants structure common tasks:
  - `analyze_performance`: Step-by-step coaching feedback for a single competitor
  - `compare_squad`: Head-to-head comparison of squad members
  - `find_matches`: Match discovery with optional filtering by name, country, or level

- **Configurable Base URL**: Updated the Smithery config schema to accept an optional `baseUrl` parameter, allowing operators to point the server at self-hosted SSI instances while defaulting to the public scoreboard at `https://scoreboard.urdr.dev`

- **Config Handling**: Modified the server factory function to use the provided config and pass the base URL (or default) to `registerMcpTools`

## Implementation Details

- Reference documents are embedded as constants and served as static text resources with appropriate MIME types
- Prompts use Zod schemas for parameter validation and include detailed step-by-step instructions for the AI to follow
- The base URL configuration is optional and backward-compatible; existing deployments require no changes

https://claude.ai/code/session_018FuFGJC4p951drTEkpHHyb