### PR TITLE
feat(smithery): add workflow_dispatch publish workflow

### DIFF
--- a/.github/workflows/smithery-publish.yml
+++ b/.github/workflows/smithery-publish.yml
@@ -1,0 +1,54 @@
+name: Publish to Smithery Registry
+
+on:
+  workflow_dispatch:
+    inputs:
+      server_url:
+        description: 'MCP server URL to publish'
+        required: true
+        default: 'https://scoreboard.urdr.dev/api/mcp'
+      dry_run:
+        description: 'Dry run — print command without executing'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Verify SMITHERY_API_KEY is set
+        run: |
+          if [ -z "$SMITHERY_API_KEY" ]; then
+            echo "ERROR: SMITHERY_API_KEY secret is not set in the production environment"
+            exit 1
+          fi
+        env:
+          SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
+
+      - name: Publish to Smithery (dry run)
+        if: ${{ inputs.dry_run == true }}
+        run: |
+          echo "DRY RUN — would execute:"
+          echo "npx @smithery/cli@latest mcp publish \"${{ inputs.server_url }}\" \\"
+          echo "  -n mandakan/ssi-scoreboard \\"
+          echo "  --config-schema mcp/smithery-config-schema.json"
+
+      - name: Publish to Smithery
+        if: ${{ inputs.dry_run != true }}
+        env:
+          SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
+        run: |
+          npx @smithery/cli@latest mcp publish "${{ inputs.server_url }}" \
+            -n mandakan/ssi-scoreboard \
+            --config-schema mcp/smithery-config-schema.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ or any other type that is serialised into Redis via `cachedExecuteQuery`.
 | `UPSTASH_REDIS_REST_TOKEN` | `lib/cache-edge.ts` | Cloudflare only | REST token from Upstash console. Set via `wrangler secret put` in production. |
 | `MCP_SECRET` | `app/api/mcp/route.ts` | Both | Optional. If set, `POST /api/mcp` requires `Authorization: Bearer <MCP_SECRET>`. Omit for public access. |
 | `NEXT_PUBLIC_APP_URL` | `app/api/mcp/route.ts` | Both | Base URL used by MCP tools for internal API calls. Defaults to `http://localhost:PORT`. Required for Cloudflare Pages (set to the external URL, e.g. `https://scoreboard.urdr.dev`). |
+| `SMITHERY_API_KEY` | `.github/workflows/smithery-publish.yml` | CI only | Smithery registry API key. Store as a GitHub `production` environment secret. Obtain from https://smithery.ai/account/api-keys. Never `NEXT_PUBLIC_`. |
 
 ## MCP Server
 
@@ -168,7 +169,7 @@ User-facing setup guide: `docs/mcp.md`.
 ### Smithery registry
 
 The server is published on [smithery.ai](https://smithery.ai) as an **external** server
-pointing at `https://scoreboard.urdr.dev/api/mcp`.
+pointing at `https://scoreboard.urdr.dev/api/mcp` (qualified name: `mandakan/ssi-scoreboard`).
 
 **Metadata set via the Smithery UI (registry listing page):**
 - Homepage → `https://scoreboard.urdr.dev`
@@ -177,14 +178,17 @@ pointing at `https://scoreboard.urdr.dev/api/mcp`.
 **Tool annotations** (`readOnlyHint: true`, `openWorldHint: true`) are declared inline in
 `lib/mcp-tools.ts` as the 4th argument to each `server.tool()` call.
 
-**`configSchema` for the external URL deployment** cannot be set through the Smithery UI.
-To update it after a schema change, republish via the CLI:
-```bash
-npx @smithery/cli@latest mcp publish "https://scoreboard.urdr.dev/api/mcp" \
-  -n mandakan/ssi-scoreboard \
-  --config-schema '{"type":"object","properties":{"baseUrl":{"type":"string","format":"uri","description":"Base URL of the SSI Scoreboard instance. Defaults to https://scoreboard.urdr.dev"}}}'
-```
-The `configSchema` block in `smithery.yaml` covers the hosted TypeScript runtime path only.
+**Publishing / updating the registry entry** — trigger the `Publish to Smithery Registry`
+workflow manually from the GitHub Actions tab (workflow_dispatch). This pushes the latest
+configSchema (`mcp/smithery-config-schema.json`) to the external deployment. The Smithery UI
+has no field for configSchema on external servers — the workflow is the only way to update it.
+
+Prerequisite: add `SMITHERY_API_KEY` as a secret in the GitHub repo's `production` environment
+(Settings → Environments → production → Add secret). Obtain the key from
+https://smithery.ai/account/api-keys.
+
+The `configSchema` block in `smithery.yaml` mirrors `mcp/smithery-config-schema.json` and
+covers the hosted TypeScript runtime path. Keep both in sync when changing the schema.
 
 ## Package Manager
 This project uses **pnpm@10.30.1**. Do not use npm or yarn. Use `pnpm add` / `pnpm add -D`.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 [![CI](https://github.com/mandakan/ssi-scoreboard/actions/workflows/ci.yml/badge.svg)](https://github.com/mandakan/ssi-scoreboard/actions/workflows/ci.yml)
 [![Live](https://img.shields.io/badge/Live-scoreboard.urdr.dev-4f46e5?logo=vercel&logoColor=white)](https://scoreboard.urdr.dev)
+[![smithery badge](https://smithery.ai/badge/mandakan/ssi-scoreboard)](https://smithery.ai/servers/mandakan/ssi-scoreboard)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Next.js 16](https://img.shields.io/badge/Next.js-16-black?logo=next.js&logoColor=white)](https://nextjs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
@@ -181,6 +182,9 @@ The `.mcp.json` at repo root registers two stdio servers:
 - **`ssi-scoreboard-local`** — calls `localhost:3000` (requires `pnpm dev` running)
 
 Claude Code picks up `.mcp.json` automatically when you open the repo.
+
+For client-specific setup (Claude Desktop, generic HTTP clients), example prompts, and
+troubleshooting, see **[docs/mcp.md](docs/mcp.md)**.
 
 ## Architecture
 ```

--- a/mcp/smithery-config-schema.json
+++ b/mcp/smithery-config-schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "baseUrl": {
+      "type": "string",
+      "format": "uri",
+      "description": "Base URL of the SSI Scoreboard instance. Defaults to https://scoreboard.urdr.dev"
+    }
+  },
+  "additionalProperties": false
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,10 +1,10 @@
 runtime: typescript
 
-# configSchema is used by Smithery's hosted TypeScript runtime to prompt users
-# for optional configuration values before launching the server.
-# For the external URL deployment (https://scoreboard.urdr.dev/api/mcp) this
-# must be provided separately via the Smithery CLI — see CLAUDE.md for the
-# republish command.
+# configSchema canonical source: mcp/smithery-config-schema.json
+# This inline copy is used by Smithery's hosted TypeScript runtime.
+# For the external URL deployment the schema is pushed via the
+# "Publish to Smithery Registry" GitHub Actions workflow (workflow_dispatch).
+# When changing the schema, update BOTH this block and mcp/smithery-config-schema.json.
 configSchema:
   type: object
   properties:


### PR DESCRIPTION
## Summary

- **`.github/workflows/smithery-publish.yml`** — manually triggered (`workflow_dispatch`) workflow that calls `smithery mcp publish` with the versioned config schema file. Inputs: `server_url` (defaults to prod) and `dry_run` (prints command without executing).
- **`mcp/smithery-config-schema.json`** — canonical JSON Schema for the Smithery configSchema; used by the workflow's `--config-schema` flag (avoids the shell newline/quoting issue we hit with inline JSON).
- **`smithery.yaml`** — updated comment to cross-reference the canonical JSON file.
- **`CLAUDE.md`** — adds `SMITHERY_API_KEY` to the env vars table; replaces the manual CLI command with a reference to the workflow.
- **`README.md`** — adds the Smithery registry badge.

## One-time setup required

Add `SMITHERY_API_KEY` as a secret in the GitHub repo:

> **Settings → Environments → production → Add secret**
> Name: `SMITHERY_API_KEY`
> Value: your key from https://smithery.ai/account/api-keys

## How to publish

1. Go to **Actions → Publish to Smithery Registry → Run workflow**
2. Accept the default server URL (or override for staging)
3. Optionally enable **dry run** first to preview the command

## Test plan

- [x] `pnpm -w run typecheck` — zero errors
- [x] `pnpm -w run lint` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)