### PR TITLE
fix(oauth): point well-known metadata at /oauth/authorize and /oauth/token

### DIFF
--- a/app/.well-known/oauth-authorization-server/route.ts
+++ b/app/.well-known/oauth-authorization-server/route.ts
@@ -13,14 +13,14 @@ export async function GET() {
   return Response.json(
     {
       issuer: base,
-      authorization_endpoint: `${base}/authorize`,
-      token_endpoint: `${base}/token`,
+      authorization_endpoint: `${base}/oauth/authorize`,
+      token_endpoint: `${base}/oauth/token`,
       registration_endpoint: `${base}/register`,
       response_types_supported: ["code"],
       grant_types_supported: ["authorization_code"],
       token_endpoint_auth_methods_supported: ["none"],
       code_challenge_methods_supported: ["S256"],
-      scopes_supported: [],
+      scopes_supported: ["claudeai"],
     },
     { headers: CORS },
   );


### PR DESCRIPTION
## Summary

- The `/.well-known/oauth-authorization-server` metadata was advertising `/authorize` and `/token`, but commit #127's scope-echoing and `Bearer` capitalisation fixes landed in `/oauth/authorize` and `/oauth/token` — so the actual OAuth flow used by Claude Desktop was still going through the old, broken endpoints.
- Claude Desktop requests `scope=claudeai`; without the scope being echoed back in the authorization callback and token response, claude.ai treats the grant as failed and shows "Error connecting to the MCP server".
- Also adds `claudeai` to `scopes_supported` so Claude Desktop doesn't reject the authorization server at metadata discovery.

## Test plan

- [ ] Connect the MCP server URL in Claude Desktop — OAuth flow should complete without the "Error connecting" message
- [ ] Verify `GET /.well-known/oauth-authorization-server` returns `/oauth/authorize` and `/oauth/token` endpoints
- [ ] `pnpm -w run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)