### PR TITLE
Disable Group pct mode for single competitor

### DIFF
--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -338,38 +338,49 @@ const MODE_TOOLTIPS: Record<PctMode, string> = {
 function ModeToggle({
   mode,
   onChange,
+  competitorCount,
 }: {
   mode: PctMode;
   onChange: (m: PctMode) => void;
+  competitorCount: number;
 }) {
+  const groupDisabled = competitorCount < 2;
   return (
     <div
       role="group"
       aria-label="Percentage reference"
       className="inline-flex rounded-md border text-xs"
     >
-      {(["group", "division", "overall"] as PctMode[]).map((m) => (
-        <Tooltip key={m}>
-          <TooltipTrigger asChild>
-            <button
-              onClick={() => onChange(m)}
-              aria-pressed={mode === m}
-              className={cn(
-                "px-2.5 py-1 first:rounded-l-md last:rounded-r-md transition-colors",
-                "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
-                mode === m
-                  ? "bg-foreground text-background font-medium"
-                  : "text-muted-foreground hover:bg-muted"
-              )}
-            >
-              {MODE_LABELS[m]}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top" className="max-w-56 text-center text-xs">
-            {MODE_TOOLTIPS[m]}
-          </TooltipContent>
-        </Tooltip>
-      ))}
+      {(["group", "division", "overall"] as PctMode[]).map((m) => {
+        const disabled = m === "group" && groupDisabled;
+        return (
+          <Tooltip key={m}>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => { if (!disabled) onChange(m); }}
+                aria-pressed={mode === m}
+                aria-disabled={disabled || undefined}
+                className={cn(
+                  "px-2.5 py-1 first:rounded-l-md last:rounded-r-md transition-colors",
+                  "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+                  disabled
+                    ? "opacity-40 cursor-default text-muted-foreground"
+                    : mode === m
+                      ? "bg-foreground text-background font-medium"
+                      : "text-muted-foreground hover:bg-muted"
+                )}
+              >
+                {MODE_LABELS[m]}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-56 text-center text-xs">
+              {disabled
+                ? "Select 2+ competitors to compare within the group"
+                : MODE_TOOLTIPS[m]}
+            </TooltipContent>
+          </Tooltip>
+        );
+      })}
     </div>
   );
 }
@@ -477,11 +488,22 @@ function ArchetypePill({ archetype, color }: { archetype: ShooterArchetype; colo
 
 export function ComparisonTable({ data, scoringCompleted, onRemove }: ComparisonTableProps) {
   const { stages, competitors, penaltyStats, efficiencyStats, consistencyStats, lossBreakdownStats, whatIfStats, styleFingerprintStats } = data;
-  const [mode, setMode] = useState<PctMode>("group");
+  const [mode, setMode] = useState<PctMode>(
+    competitors.length < 2 ? "division" : "group"
+  );
   const [viewMode, setViewMode] = useState<ViewMode>("absolute");
   const [showAnalysis, setShowAnalysis] = useState(false);
   const [showWhatIf, setShowWhatIf] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
+
+  useEffect(() => {
+    if (competitors.length < 2 && mode === "group") {
+      setMode("division");
+    } else if (competitors.length >= 2 && mode === "division") {
+      setMode("group");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only react to count changes
+  }, [competitors.length]);
 
   useEffect(() => {
     if (!localStorage.getItem("ssi-cell-help-seen")) {
@@ -600,7 +622,7 @@ export function ComparisonTable({ data, scoringCompleted, onRemove }: Comparison
       <div className="flex items-center gap-2">
         <ViewModeToggle viewMode={viewMode} onChange={setViewMode} />
         {viewMode === "absolute" && (
-          <ModeToggle mode={mode} onChange={setMode} />
+          <ModeToggle mode={mode} onChange={setMode} competitorCount={competitors.length} />
         )}
         <button
           onClick={() => setHelpOpen(true)}
@@ -1114,7 +1136,7 @@ export function ComparisonTable({ data, scoringCompleted, onRemove }: Comparison
             >
               <div className="flex items-center gap-2">
                 <span className="text-xs text-muted-foreground">Rank context:</span>
-                <ModeToggle mode={mode} onChange={setMode} />
+                <ModeToggle mode={mode} onChange={setMode} competitorCount={competitors.length} />
               </div>
               <div className="space-y-5">
                 {competitors.map((comp) => {

--- a/components/radar-chart.tsx
+++ b/components/radar-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   RadarChart,
   Radar,
@@ -33,7 +33,18 @@ export function StageBalanceChart({ data }: StageBalanceChartProps) {
   const { stages, competitors } = data;
   const colorMap = buildColorMap(competitors.map((c) => c.id));
   const [hiddenIds, setHiddenIds] = useState<Set<number>>(new Set());
-  const [pctMode, setPctMode] = useState<PctMode>("group");
+  const [pctMode, setPctMode] = useState<PctMode>(
+    competitors.length < 2 ? "overall" : "group"
+  );
+
+  useEffect(() => {
+    if (competitors.length < 2 && pctMode === "group") {
+      setPctMode("overall");
+    } else if (competitors.length >= 2 && pctMode === "overall") {
+      setPctMode("group");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only react to count changes
+  }, [competitors.length]);
 
   const radarData = stages.map((stage) => {
     const row: Record<string, string | number> = { stage: `S${stage.stage_num}` };
@@ -95,18 +106,22 @@ export function StageBalanceChart({ data }: StageBalanceChartProps) {
       >
         {PCT_MODES.map((mode) => {
           const active = pctMode === mode.value;
+          const disabled = mode.value === "group" && competitors.length < 2;
           return (
             <button
               key={mode.value}
               type="button"
-              onClick={() => setPctMode(mode.value)}
+              onClick={() => { if (!disabled) setPctMode(mode.value); }}
               aria-pressed={active}
-              title={mode.description}
+              aria-disabled={disabled || undefined}
+              title={disabled ? "Select 2+ competitors to compare within the group" : mode.description}
               className={[
                 "rounded-full border px-3 py-0.5 text-xs font-medium transition-colors",
-                active
-                  ? "bg-foreground text-background border-foreground"
-                  : "text-muted-foreground border-border hover:border-foreground hover:text-foreground",
+                disabled
+                  ? "opacity-40 cursor-default text-muted-foreground border-border"
+                  : active
+                    ? "bg-foreground text-background border-foreground"
+                    : "text-muted-foreground border-border hover:border-foreground hover:text-foreground",
               ].join(" ")}
             >
               {mode.label}


### PR DESCRIPTION
## Summary

- When only 1 competitor is selected, the "Group" percentage mode is meaningless (always 100%) — it is now visually greyed out (`opacity-40`, `aria-disabled`) with a tooltip explaining why
- Default mode switches to "Division" (comparison table) / "Overall" (radar chart) for single-competitor views
- Auto-switches to "Group" when a 2nd competitor is added, and back when reduced to 1

## Test plan

- [ ] Select 1 competitor → Group button is greyed out, mode defaults to Division (table) / Overall (radar)
- [ ] Add a 2nd competitor → Group button enables, mode auto-switches to Group
- [ ] Remove back to 1 competitor → mode auto-switches away, Group greys out again
- [ ] Verify radar chart follows the same behavior (Group/Overall toggle)
- [ ] `pnpm -w run typecheck && pnpm -w run lint && pnpm -w test` all pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)