### PR TITLE
Replace OG PNG logo with SVG target icon and add decorative background

### DIFF
--- a/app/api/og/match/[ct]/[id]/route.tsx
+++ b/app/api/og/match/[ct]/[id]/route.tsx
@@ -176,7 +176,7 @@ async function fetchOgCompareStatsImpl(
 
   try {
     const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
-    const { data, cachedAt } = await cachedExecuteQuery<RawOgScorecardsData>(
+    const { data } = await cachedExecuteQuery<RawOgScorecardsData>(
       scorecardsKey,
       SCORECARDS_QUERY,
       { ct: ctNum, id },
@@ -347,30 +347,19 @@ function archetypeIcon(archetype: string, size: number, color: string) {
 
 // ── Shared layout pieces ────────────────────────────────────────────────
 
-/**
- * Brand icon as a styled div — avoids PNG fetch subrequests on CF Workers.
- * Fetching external images inside Satori on CF Workers can fail with
- * "Unsupported image type: unknown" and contribute to CPU time overruns.
- */
+/** Brand icon — concentric-circles target using design system colors. */
 function brandIcon() {
   return (
-    <div
-      style={{
-        display: "flex",
-        width: 48,
-        height: 48,
-        borderRadius: "10px",
-        backgroundColor: C.accent,
-        alignItems: "center",
-        justifyContent: "center",
-        fontSize: "18px",
-        fontWeight: 700,
-        color: C.bg,
-        letterSpacing: "-0.03em",
-      }}
+    <svg
+      width={48}
+      height={48}
+      viewBox="0 0 100 100"
+      style={{ display: "flex" }}
     >
-      SSI
-    </div>
+      <circle cx="50" cy="50" r="44" fill="none" stroke={C.dim} strokeWidth="4" />
+      <circle cx="50" cy="50" r="28" fill="none" stroke={C.muted} strokeWidth="4" />
+      <circle cx="50" cy="50" r="12" fill="none" stroke={C.accent} strokeWidth="6" />
+    </svg>
   );
 }
 
@@ -534,7 +523,7 @@ function matchOverviewImage(match: OgMatchData) {
       }}
     >
       {/* Background image layers (below content) */}
-      {match.imageUrl ? matchImageBgLayers(match.imageUrl, match.imageWidth, match.imageHeight) : null}
+      {match.imageUrl ? matchImageBgLayers(match.imageUrl, match.imageWidth, match.imageHeight) : targetBgLayers()}
 
       {/* Content layer (above background) */}
       <div
@@ -719,6 +708,68 @@ function matchImageBgLayers(
   );
 }
 
+/**
+ * Decorative target background — shown when no match image is available.
+ * Positioned on the right third like match images, with left-to-right fade.
+ */
+function targetBgLayers() {
+  const displayW = Math.round(OG_W / 3);
+  const containerLeft = OG_W - displayW;
+  const targetSize = OG_H;
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: containerLeft,
+        top: 0,
+        width: displayW,
+        height: OG_H,
+        display: "flex",
+      }}
+    >
+      {/* Target — shifted right so only the left portion is visible */}
+      <div
+        style={{
+          position: "absolute",
+          left: displayW * 0.15,
+          top: 0,
+          width: targetSize,
+          height: targetSize,
+          display: "flex",
+          opacity: 0.1,
+        }}
+      >
+        <svg
+          width={targetSize}
+          height={targetSize}
+          viewBox="0 0 200 200"
+          style={{ display: "flex" }}
+        >
+          <circle cx="100" cy="100" r="96" fill="none" stroke={C.muted} strokeWidth="2" />
+          <circle cx="100" cy="100" r="72" fill="none" stroke={C.muted} strokeWidth="2" />
+          <circle cx="100" cy="100" r="48" fill="none" stroke={C.muted} strokeWidth="2" />
+          <circle cx="100" cy="100" r="24" fill="none" stroke={C.muted} strokeWidth="2" />
+          <line x1="100" y1="4" x2="100" y2="196" stroke={C.muted} strokeWidth="1" />
+          <line x1="4" y1="100" x2="196" y2="100" stroke={C.muted} strokeWidth="1" />
+        </svg>
+      </div>
+      {/* Gradient fade — same direction as match images */}
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          top: 0,
+          width: displayW,
+          height: OG_H,
+          backgroundImage: `linear-gradient(to right, ${C.bg}, transparent)`,
+          display: "flex",
+        }}
+      />
+    </div>
+  );
+}
+
 function singleCompetitorWithStats(
   match: OgMatchData,
   competitor: CompetitorInfo,
@@ -749,7 +800,7 @@ function singleCompetitorWithStats(
       }}
     >
       {/* Background image layers (below content) */}
-      {match.imageUrl ? matchImageBgLayers(match.imageUrl, match.imageWidth, match.imageHeight) : null}
+      {match.imageUrl ? matchImageBgLayers(match.imageUrl, match.imageWidth, match.imageHeight) : targetBgLayers()}
 
       {/* Content layer (above background) */}
       <div
@@ -905,7 +956,7 @@ function singleCompetitorNoStats(
         color: C.text,
       }}
     >
-      {match.imageUrl ? matchImageBgLayers(match.imageUrl, match.imageWidth, match.imageHeight) : null}
+      {match.imageUrl ? matchImageBgLayers(match.imageUrl, match.imageWidth, match.imageHeight) : targetBgLayers()}
 
       <div
         style={{
@@ -1098,7 +1149,7 @@ function multiCompetitorWithStats(
         color: C.text,
       }}
     >
-      {match.imageUrl ? matchImageBgLayers(match.imageUrl, match.imageWidth, match.imageHeight) : null}
+      {match.imageUrl ? matchImageBgLayers(match.imageUrl, match.imageWidth, match.imageHeight) : targetBgLayers()}
 
       <div
         style={{
@@ -1240,7 +1291,7 @@ function multiCompetitorNoStats(
         color: C.text,
       }}
     >
-      {match.imageUrl ? matchImageBgLayers(match.imageUrl, match.imageWidth, match.imageHeight) : null}
+      {match.imageUrl ? matchImageBgLayers(match.imageUrl, match.imageWidth, match.imageHeight) : targetBgLayers()}
 
       <div
         style={{
@@ -1330,30 +1381,44 @@ function fallbackImage() {
   return (
     <div
       style={{
+        position: "relative",
         display: "flex",
-        flexDirection: "column",
         width: "100%",
         height: "100%",
         backgroundColor: C.bg,
         color: C.text,
       }}
     >
-      {topAccent()}
+      {targetBgLayers()}
 
       <div
         style={{
+          position: "absolute",
+          left: 0,
+          top: 0,
+          width: OG_W,
+          height: OG_H,
           display: "flex",
           flexDirection: "column",
-          flex: 1,
-          alignItems: "center",
-          justifyContent: "center",
-          gap: "20px",
         }}
       >
-        {brandIcon()}
-        <div style={{ fontSize: "40px", fontWeight: 700 }}>SSI Scoreboard</div>
-        <div style={{ fontSize: "22px", color: C.muted }}>
-          Live IPSC competitor comparison
+        {topAccent()}
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: 1,
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "20px",
+          }}
+        >
+          {brandIcon()}
+          <div style={{ fontSize: "40px", fontWeight: 700 }}>SSI Scoreboard</div>
+          <div style={{ fontSize: "22px", color: C.muted }}>
+            Live IPSC competitor comparison
+          </div>
         </div>
       </div>
     </div>

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -12,120 +12,194 @@ const C = {
   accent: "#f97316",
 } as const;
 
+const OG_W = 1200;
+const OG_H = 630;
+
 // ── Route handler ────────────────────────────────────────────────────────
 
-export async function GET(req: Request) {
-  const { origin } = new URL(req.url);
-  const logoUrl = `${origin}/icons/icon-192.png`;
-
+export async function GET() {
   return new ImageResponse(
     (
       <div
         style={{
+          position: "relative",
           display: "flex",
-          flexDirection: "column",
           width: "100%",
           height: "100%",
           backgroundColor: C.bg,
           color: C.text,
         }}
       >
-        {/* Top accent bar */}
-        <div
-          style={{
-            display: "flex",
-            width: "100%",
-            height: "4px",
-            backgroundColor: C.accent,
-          }}
-        />
+        {/* Faded target decoration on the right */}
+        {targetBgLayers()}
 
         <div
           style={{
+            position: "absolute",
+            left: 0,
+            top: 0,
+            width: OG_W,
+            height: OG_H,
             display: "flex",
             flexDirection: "column",
-            flex: 1,
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "28px",
-            padding: "40px 60px",
           }}
         >
-          {/* App icon */}
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={logoUrl}
-            width={96}
-            height={96}
-            alt="SSI Scoreboard"
-            style={{ borderRadius: "20px" }}
+          {/* Top accent bar */}
+          <div
+            style={{
+              display: "flex",
+              width: "100%",
+              height: "4px",
+              backgroundColor: C.accent,
+            }}
           />
 
-          {/* Title */}
           <div
             style={{
               display: "flex",
-              fontSize: "64px",
-              fontWeight: 700,
-              letterSpacing: "-0.02em",
+              flexDirection: "column",
+              flex: 1,
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "28px",
+              padding: "40px 60px",
             }}
           >
-            SSI Scoreboard
+            {/* App icon — concentric-circles target */}
+            <svg
+              width={96}
+              height={96}
+              viewBox="0 0 100 100"
+              style={{ display: "flex" }}
+            >
+              <circle cx="50" cy="50" r="44" fill="none" stroke={C.dim} strokeWidth="4" />
+              <circle cx="50" cy="50" r="28" fill="none" stroke={C.muted} strokeWidth="4" />
+              <circle cx="50" cy="50" r="12" fill="none" stroke={C.accent} strokeWidth="6" />
+            </svg>
+
+            {/* Title */}
+            <div
+              style={{
+                display: "flex",
+                fontSize: "64px",
+                fontWeight: 700,
+                letterSpacing: "-0.02em",
+              }}
+            >
+              SSI Scoreboard
+            </div>
+
+            {/* Tagline */}
+            <div
+              style={{
+                display: "flex",
+                fontSize: "28px",
+                color: C.muted,
+                textAlign: "center",
+              }}
+            >
+              Live stage-by-stage IPSC competitor comparison
+            </div>
+
+            {/* Feature pills */}
+            <div style={{ display: "flex", gap: "16px", marginTop: "8px" }}>
+              {["Side-by-side results", "Hit factor charts", "Coaching analysis"].map(
+                (label) => (
+                  <div
+                    key={label}
+                    style={{
+                      display: "flex",
+                      padding: "10px 24px",
+                      borderRadius: "24px",
+                      backgroundColor: C.cardBg,
+                      border: `1px solid ${C.border}`,
+                      fontSize: "22px",
+                      color: C.muted,
+                    }}
+                  >
+                    {label}
+                  </div>
+                ),
+              )}
+            </div>
           </div>
 
-          {/* Tagline */}
+          {/* Footer */}
           <div
             style={{
               display: "flex",
-              fontSize: "28px",
-              color: C.muted,
-              textAlign: "center",
+              justifyContent: "center",
+              paddingBottom: "32px",
+              fontSize: "22px",
+              color: C.dim,
             }}
           >
-            Live stage-by-stage IPSC competitor comparison
+            scoreboard.urdr.dev
           </div>
-
-          {/* Feature pills */}
-          <div style={{ display: "flex", gap: "16px", marginTop: "8px" }}>
-            {["Side-by-side results", "Hit factor charts", "Coaching analysis"].map(
-              (label) => (
-                <div
-                  key={label}
-                  style={{
-                    display: "flex",
-                    padding: "10px 24px",
-                    borderRadius: "24px",
-                    backgroundColor: C.cardBg,
-                    border: `1px solid ${C.border}`,
-                    fontSize: "22px",
-                    color: C.muted,
-                  }}
-                >
-                  {label}
-                </div>
-              ),
-            )}
-          </div>
-        </div>
-
-        {/* Footer */}
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "center",
-            paddingBottom: "32px",
-            fontSize: "22px",
-            color: C.dim,
-          }}
-        >
-          scoreboard.urdr.dev
         </div>
       </div>
     ),
     {
-      width: 1200,
-      height: 630,
+      width: OG_W,
+      height: OG_H,
       headers: { "Cache-Control": "public, max-age=86400, s-maxage=604800" },
     },
+  );
+}
+
+/** Decorative target background — faded half-target on the right side. */
+function targetBgLayers() {
+  const displayW = Math.round(OG_W / 3);
+  const containerLeft = OG_W - displayW;
+  const targetSize = OG_H;
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: containerLeft,
+        top: 0,
+        width: displayW,
+        height: OG_H,
+        display: "flex",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          left: displayW * 0.15,
+          top: 0,
+          width: targetSize,
+          height: targetSize,
+          display: "flex",
+          opacity: 0.1,
+        }}
+      >
+        <svg
+          width={targetSize}
+          height={targetSize}
+          viewBox="0 0 200 200"
+          style={{ display: "flex" }}
+        >
+          <circle cx="100" cy="100" r="96" fill="none" stroke={C.muted} strokeWidth="2" />
+          <circle cx="100" cy="100" r="72" fill="none" stroke={C.muted} strokeWidth="2" />
+          <circle cx="100" cy="100" r="48" fill="none" stroke={C.muted} strokeWidth="2" />
+          <circle cx="100" cy="100" r="24" fill="none" stroke={C.muted} strokeWidth="2" />
+          <line x1="100" y1="4" x2="100" y2="196" stroke={C.muted} strokeWidth="1" />
+          <line x1="4" y1="100" x2="196" y2="100" stroke={C.muted} strokeWidth="1" />
+        </svg>
+      </div>
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          top: 0,
+          width: displayW,
+          height: OG_H,
+          backgroundImage: `linear-gradient(to right, ${C.bg}, transparent)`,
+          display: "flex",
+        }}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Replaced the "SSI" text-box brand icon with a concentric-circles SVG target in both `/api/og` and `/api/og/match/[ct]/[id]` — avoids external PNG fetch subrequests that can fail on CF Workers
- Added a faded half-target background decoration on the right side for OG images when no match image is available (overview, single-competitor, multi-competitor, and fallback variants)
- Applied the same treatment to the site-level `/api/og` route, removing the PNG logo fetch entirely

## Test plan

- [ ] `open http://localhost:3000/api/og` — verify SVG target icon and faded background target render
- [ ] `open http://localhost:3000/api/og/match/22/{id}` — verify overview variant with and without match image
- [ ] `open http://localhost:3000/api/og/match/22/{id}?competitors=123` — verify single-competitor variant
- [ ] `open http://localhost:3000/api/og/match/22/{id}?competitors=123,456` — verify multi-competitor variant
- [ ] `pnpm -w run typecheck && pnpm -w run lint && pnpm -w test` all pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)