### PR TITLE
fix(wrangler): set keep_names=false to prevent __name ReferenceError in browser

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -19,6 +19,13 @@ compatibility_flags = ["nodejs_compat"]
 main = ".open-next/worker.js"
 workers_dev = true
 preview_urls = false
+# Wrangler's esbuild defaults to keepNames=true, which transforms named function
+# bodies (e.g. inside next-themes' theme-init script) with __name() helpers.
+# Those helpers are not in scope when next-themes serialises the function via
+# .toString() and injects it as a browser-side <script> tag → ReferenceError.
+# Setting keep_names=false disables that transform without affecting behaviour,
+# since @opennextjs/cloudflare already bundles with minifyIdentifiers=false.
+keep_names = false
 
 [assets]
 directory = ".open-next/assets"


### PR DESCRIPTION
## Problem

Two production-only symptoms were traced to a single root cause:

1. **`Uncaught ReferenceError: __name is not defined`** in the browser console
2. **CLS 0.105** (just above the 0.1 "good" threshold) in Lighthouse

## Root cause

The `.open-next/worker.js` template produced by `@opennextjs/cloudflare` intentionally leaves its relative imports unresolved (they carry `// @ts-expect-error: Will be resolved by wrangler build` comments). `wrangler deploy` therefore runs a real esbuild bundling step on the worker.

Wrangler's esbuild defaults to `keepNames: true` (`config.keep_names ?? true` in wrangler's source). This transforms named function declarations **inside** `next-themes`'s theme-init function `I` — `function p(r)`, `function C(r)`, `function a()` — by adding `__name(p, "p")` wrapper calls.

At runtime in the Worker, `next-themes` serialises `I` via `I.toString()` and injects the result as a raw browser-side `<script>` tag:

```js
`(${I.toString()})(${p})`
```

The browser evaluates that string, finds `__name` not in scope, and throws. Because the theme-init script never completes, the `dark`/`light` class is not applied inline — `next-themes` falls back to applying it after React hydrates, which Lighthouse measures as a CLS event.

## Fix

Add `keep_names = false` to `wrangler.toml`. This is safe because `@opennextjs/cloudflare` already bundles with `minifyIdentifiers: false`, so all identifier names are preserved at the JS level. The `.name`-property preservation that `keepNames` provides is redundant and its side-effect on `Function.prototype.toString()` output is harmful here.

## Expected outcome

- No `__name` error in the browser console
- Theme applied correctly before first paint → CLS drops back below 0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)