### PR TITLE
fix: aria-progressbar-name and HSTS header (Lighthouse quick wins)

### DIFF
--- a/components/match-header.tsx
+++ b/components/match-header.tsx
@@ -94,7 +94,11 @@ export function MatchHeader({ match }: MatchHeaderProps) {
             {isComplete ? "Complete" : `${Math.round(pct)}%`}
           </span>
         </div>
-        <Progress value={pct} className="h-2" />
+        <Progress
+          value={pct}
+          className="h-2"
+          aria-label={isComplete ? "Scoring complete" : `Scoring progress: ${Math.round(pct)}%`}
+        />
       </div>
     </div>
   );

--- a/next.config.ts
+++ b/next.config.ts
@@ -34,6 +34,12 @@ const nextConfig: NextConfig = {
             key: "Permissions-Policy",
             value: "camera=(), microphone=(), geolocation=()",
           },
+          // HSTS: ignored over HTTP, so safe to set unconditionally.
+          // 2-year max-age is the recommended value for preload-list eligibility.
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains",
+          },
         ],
       },
     ];


### PR DESCRIPTION
## Changes

### `components/match-header.tsx` — accessible progress bar name
Radix UI's `Progress` renders as `role="progressbar"`. Without `aria-label` the bar has no accessible name, which Lighthouse accessibility audit flags as a failure. Added a context-aware label:
- Active: `"Scoring progress: 42%"`
- Complete: `"Scoring complete"`

### `next.config.ts` — HSTS header
Added `Strict-Transport-Security: max-age=63072000; includeSubDomains`. HSTS is silently ignored over plain HTTP, so it is safe to set unconditionally in `next.config.ts` — it only activates in production where Cloudflare Workers always serves HTTPS.

## Not included

**CSP** is deliberately excluded — it requires nonce plumbing for `next-themes`' inline theme-detection script and Next.js' bootstrap scripts. Tracked in #149.

## Issues addressed
Closes part of the Lighthouse Best Practices and Accessibility findings from the Feb 27 2026 audit. Remaining complex items tracked in #147 (LCP), #148 (JS bundle / TBT), #149 (CSP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)