### PR TITLE
security: add nonce-based Content-Security-Policy header

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { headers } from "next/headers";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Providers } from "@/components/providers";
 import { InstallBanner } from "@/components/install-banner";
@@ -50,15 +51,17 @@ export const viewport: Viewport = {
   ],
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}>
-        <Providers>
+        <Providers nonce={nonce}>
           <InstallBanner />
           <UpdateBanner />
           {children}

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -7,7 +7,13 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { PWAInstallProvider } from "@/lib/pwa-install";
 import { WhatsNewProvider } from "@/components/whats-new-provider";
 
-export function Providers({ children }: { children: React.ReactNode }) {
+export function Providers({
+  children,
+  nonce,
+}: {
+  children: React.ReactNode;
+  nonce?: string;
+}) {
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -21,7 +27,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange nonce={nonce}>
       <QueryClientProvider client={queryClient}>
         <TooltipProvider>
           <PWAInstallProvider>

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  // Generate a per-request cryptographic nonce (Web Crypto API — works in both
+  // Node.js and Cloudflare Workers edge runtime).
+  const nonce = btoa(crypto.randomUUID());
+
+  const csp = [
+    "default-src 'self'",
+    // 'strict-dynamic' lets trusted nonce-carrying scripts (Next.js bootstrap,
+    // next-themes inline script) load additional chunks without per-chunk nonces.
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+    // Inline styles are required by Tailwind utility classes and component
+    // libraries that write style attributes at runtime.
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "font-src 'self'",
+    "connect-src 'self'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+  ].join("; ");
+
+  // Forward the nonce to server components via a request header so that
+  // layout.tsx can read it and pass it to ThemeProvider / next/script.
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+  response.headers.set("Content-Security-Policy", csp);
+
+  return response;
+}
+
+// Run on all routes except Next.js internals and static files.
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon\\.ico).*)"],
+};


### PR DESCRIPTION
Closes #149.

## Summary

- **`middleware.ts`** (new): generates a per-request cryptographic nonce via Web Crypto API (`btoa(crypto.randomUUID())`), sets `x-nonce` on the request headers so server components can read it, and sets the `Content-Security-Policy` response header
- **`app/layout.tsx`**: made `async`, reads the nonce from `headers()`, passes it to `<Providers>`
- **`components/providers.tsx`**: accepts `nonce?: string` and passes it to `ThemeProvider` so the inline theme-detection script carries the correct `nonce` attribute

### CSP directives

| Directive | Value | Why |
|---|---|---|
| `script-src` | `'self' 'nonce-{n}' 'strict-dynamic'` | Nonce covers Next.js bootstrap + next-themes; `strict-dynamic` lets those scripts load chunks |
| `style-src` | `'self' 'unsafe-inline'` | Tailwind and runtime inline styles |
| `img-src` | `'self' data: blob:` | OG images, data URIs |
| `connect-src` | `'self'` | All client fetches go to own routes |
| `frame-ancestors` | `'none'` | Matches existing `X-Frame-Options: DENY` |
| `object-src` | `'none'` | No plugin embeds |

### Turbopack note

The `missing` array filter in the middleware matcher is not yet supported by Turbopack in Next.js 16, so the matcher uses a plain string pattern. Setting CSP on prefetch responses is harmless.

## Test plan

- [x] `pnpm -w run typecheck` — zero errors
- [x] `pnpm -w run lint` — zero warnings
- [x] `pnpm -w test` — 426/426 passing
- [ ] Verify no CSP violations in browser console on a dev/production build
- [ ] Confirm next-themes dark/light/system toggle still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)