### PR TITLE
feat: what-if stage simulator — light scope (#153)

### DIFF
--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -19,6 +19,7 @@ import { SpeedAccuracyChart } from "@/components/scatter-chart";
 import { StageBalanceChart } from "@/components/radar-chart";
 import { StyleFingerprintChart } from "@/components/style-fingerprint-chart";
 import { ShooterStyleRadarChart } from "@/components/shooter-style-radar-chart";
+import { StageSimulator } from "@/components/stage-simulator";
 import { useMatchQuery, useCompareQuery } from "@/lib/queries";
 import { CacheInfoBadge } from "@/components/cache-info-badge";
 import { LoadingBar } from "@/components/loading-bar";
@@ -42,6 +43,7 @@ import {
 
 export default function MatchPageClient() {
   const [showCoachingView, setShowCoachingView] = useState(false);
+  const [showSimulator, setShowSimulator] = useState(false);
   const params = useParams<{ ct: string; id: string }>();
   const { ct, id } = params;
   const searchParams = useSearchParams();
@@ -436,6 +438,7 @@ export default function MatchPageClient() {
                     aria-labelledby="coaching-view-heading"
                     className="space-y-6 pt-2"
                   >
+
                     <div className="space-y-2">
                       <div className="flex items-center gap-1.5">
                         <h3 className="text-sm font-semibold">Shooter style fingerprint</h3>
@@ -497,6 +500,49 @@ export default function MatchPageClient() {
                   </section>
                 )}
               </div>
+
+              {/* Stage Simulator — collapsed by default, only ≥ 80% complete */}
+              {match.scoring_completed >= 80 && (
+                <div className="rounded-lg border p-4">
+                  <h2 className="font-semibold text-base m-0 leading-none">
+                    <button
+                      type="button"
+                      id="stage-simulator-heading"
+                      onClick={() => setShowSimulator((v) => !v)}
+                      className="flex w-full items-center justify-between text-left gap-2"
+                      aria-expanded={showSimulator}
+                      aria-controls="stage-simulator-panel"
+                    >
+                      <span>
+                        Stage Simulator
+                        <span className="block text-xs font-normal text-muted-foreground mt-0.5">
+                          Adjust time or hit outcomes to see rank impact.
+                        </span>
+                      </span>
+                      {showSimulator ? (
+                        <ChevronUp className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />
+                      ) : (
+                        <ChevronDown className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />
+                      )}
+                    </button>
+                  </h2>
+
+                  {showSimulator && (
+                    <section
+                      id="stage-simulator-panel"
+                      role="region"
+                      aria-labelledby="stage-simulator-heading"
+                      className="pt-4"
+                    >
+                      <StageSimulator
+                        data={compareQuery.data}
+                        competitors={compareQuery.data.competitors}
+                        scoringCompleted={match.scoring_completed}
+                      />
+                    </section>
+                  )}
+                </div>
+              )}
             </>
           )}
         </div>

--- a/components/stage-simulator.tsx
+++ b/components/stage-simulator.tsx
@@ -1,0 +1,431 @@
+"use client";
+
+import { useState, useId } from "react";
+import { Minus, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  isMajorPowerFactor,
+  simulateStageAdjustment,
+  simulateMatchImpact,
+} from "@/lib/what-if-calc";
+import type { CompareResponse, CompetitorInfo, StageSimulatorAdjustments } from "@/lib/types";
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function fmt(n: number | null, digits = 2): string {
+  if (n == null) return "—";
+  return n.toFixed(digits);
+}
+
+function fmtDelta(n: number | null, digits = 2, invert = false): string {
+  if (n == null || Math.abs(n) < 0.0001) return "";
+  const val = invert ? -n : n;
+  const sign = val > 0 ? "+" : "";
+  return `${sign}${val.toFixed(digits)}`;
+}
+
+function fmtRankDelta(delta: number | null): string {
+  if (delta == null || delta === 0) return "";
+  if (delta > 0) return `↑${delta}`;
+  return `↓${Math.abs(delta)}`;
+}
+
+function ordinal(n: number): string {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] ?? s[v] ?? s[0]);
+}
+
+interface StepperProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  onChange: (v: number) => void;
+  formatValue?: (v: number) => string;
+  decrementLabel?: string;
+  incrementLabel?: string;
+}
+
+function Stepper({
+  label,
+  value,
+  min,
+  max,
+  step = 1,
+  onChange,
+  formatValue = (v) => String(v),
+  decrementLabel,
+  incrementLabel,
+}: StepperProps) {
+  const id = useId();
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <label htmlFor={id} className="text-sm text-foreground flex-1 leading-tight">
+        {label}
+      </label>
+      <div className="flex items-center gap-1.5">
+        <button
+          type="button"
+          aria-label={decrementLabel ?? `Decrease ${label}`}
+          onClick={() => onChange(Math.max(min, parseFloat((value - step).toFixed(10))))}
+          disabled={value <= min}
+          className={cn(
+            "w-11 h-11 flex items-center justify-center rounded-md border",
+            "text-foreground hover:bg-muted/50 active:bg-muted transition-colors",
+            "disabled:opacity-40 disabled:pointer-events-none",
+            "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+          )}
+        >
+          <Minus className="w-4 h-4" aria-hidden="true" />
+        </button>
+        <span
+          id={id}
+          className="text-sm font-mono font-medium w-14 text-center tabular-nums"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {formatValue(value)}
+        </span>
+        <button
+          type="button"
+          aria-label={incrementLabel ?? `Increase ${label}`}
+          onClick={() => onChange(Math.min(max, parseFloat((value + step).toFixed(10))))}
+          disabled={value >= max}
+          className={cn(
+            "w-11 h-11 flex items-center justify-center rounded-md border",
+            "text-foreground hover:bg-muted/50 active:bg-muted transition-colors",
+            "disabled:opacity-40 disabled:pointer-events-none",
+            "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+          )}
+        >
+          <Plus className="w-4 h-4" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface ResultRowProps {
+  label: string;
+  current: string;
+  simulated: string;
+  delta: string;
+  deltaPositive?: boolean | null; // true = green, false = red, null = neutral
+}
+
+function ResultRow({ label, current, simulated, delta, deltaPositive }: ResultRowProps) {
+  return (
+    <div className="flex items-baseline justify-between gap-2 py-1 border-b border-border/40 last:border-0">
+      <span className="text-xs text-muted-foreground w-20 shrink-0">{label}</span>
+      <span className="text-sm font-mono tabular-nums text-muted-foreground">{current}</span>
+      <span className="text-muted-foreground text-xs">→</span>
+      <span className="text-sm font-mono tabular-nums font-medium">{simulated}</span>
+      {delta ? (
+        <span
+          className={cn(
+            "text-xs font-mono tabular-nums font-medium min-w-[3rem] text-right",
+            deltaPositive === true && "text-green-600 dark:text-green-400",
+            deltaPositive === false && "text-red-600 dark:text-red-400",
+            deltaPositive == null && "text-muted-foreground"
+          )}
+        >
+          ({delta})
+        </span>
+      ) : (
+        <span className="min-w-[3rem]" />
+      )}
+    </div>
+  );
+}
+
+// ─── main component ──────────────────────────────────────────────────────────
+
+interface StageSimulatorProps {
+  data: CompareResponse;
+  competitors: CompetitorInfo[];
+  scoringCompleted: number;
+}
+
+const ZERO_ADJ: StageSimulatorAdjustments = { timeDelta: 0, missToACount: 0, aToCCount: 0 };
+
+export function StageSimulator({ data, competitors, scoringCompleted }: StageSimulatorProps) {
+  // All hooks must be called unconditionally before any early return.
+  const [selectedCompetitorId, setSelectedCompetitorId] = useState<number>(
+    competitors[0]?.id ?? 0
+  );
+  const [selectedStageId, setSelectedStageId] = useState<number>(
+    data.stages[0]?.stage_id ?? 0
+  );
+  const [adj, setAdj] = useState<StageSimulatorAdjustments>(ZERO_ADJ);
+  const liveRegionId = useId();
+
+  if (scoringCompleted < 80) return null;
+
+  const selectedComp = competitors.find((c) => c.id === selectedCompetitorId) ?? competitors[0];
+  const selectedStage = data.stages.find((s) => s.stage_id === selectedStageId) ?? data.stages[0];
+
+  if (!selectedComp || !selectedStage) return null;
+
+  const compSummary = selectedStage.competitors[selectedComp.id];
+  const isMajor = isMajorPowerFactor(selectedComp.division);
+
+  // Current stats for selected competitor on selected stage
+  const currentTime = compSummary?.time ?? null;
+  const currentPoints = compSummary?.points ?? null;
+  const currentHF = compSummary?.hit_factor ?? null;
+  const currentGroupPct = compSummary?.group_percent ?? null;
+  const currentMisses = compSummary?.miss_count ?? 0;
+  const currentAHits = compSummary?.a_hits ?? 0;
+  const stageUnavailable =
+    !compSummary || compSummary.dnf || compSummary.dq || compSummary.zeroed;
+
+  // Constrain adjustments when stage/competitor changes
+  const maxMissToA = currentMisses;
+  const maxAToC = Math.max(0, currentAHits - adj.missToACount);
+
+  const safeAdj: StageSimulatorAdjustments = {
+    timeDelta: adj.timeDelta,
+    missToACount: Math.min(adj.missToACount, maxMissToA),
+    aToCCount: Math.min(adj.aToCCount, maxAToC),
+  };
+
+  // Simulation — pure functions, synchronous, negligible cost (≤20 stages × 12 competitors)
+  const simStage =
+    !stageUnavailable && compSummary
+      ? simulateStageAdjustment(compSummary, selectedStage, safeAdj, isMajor)
+      : null;
+
+  const simMatch = simStage
+    ? simulateMatchImpact(
+        data.stages,
+        selectedComp.id,
+        competitors.map((c) => c.id),
+        simStage
+      )
+    : null;
+
+  // Current match avg % and group rank — computed inline (data is tiny)
+  function computeMatchAvg(compId: number): number | null {
+    let sum = 0;
+    let count = 0;
+    for (const stage of data.stages) {
+      const sc = stage.competitors[compId];
+      if (!sc || sc.dnf || sc.dq || sc.zeroed || sc.group_percent == null) continue;
+      sum += sc.group_percent;
+      count++;
+    }
+    return count > 0 ? sum / count : null;
+  }
+
+  const currentMatchPct = computeMatchAvg(selectedComp.id);
+
+  const avgs = competitors
+    .map((c) => ({ id: c.id, avg: computeMatchAvg(c.id) }))
+    .filter((x): x is { id: number; avg: number } => x.avg != null);
+  avgs.sort((a, b) => b.avg - a.avg);
+  const currentGroupRankIdx = avgs.findIndex((x) => x.id === selectedComp.id);
+  const currentGroupRank = currentGroupRankIdx >= 0 ? currentGroupRankIdx + 1 : null;
+
+  const hasChanges =
+    safeAdj.timeDelta !== 0 ||
+    safeAdj.missToACount !== 0 ||
+    safeAdj.aToCCount !== 0;
+
+  function resetAdj() {
+    setAdj(ZERO_ADJ);
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Competitor + stage selectors */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {competitors.length > 1 && (
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-muted-foreground" htmlFor="sim-competitor-select">
+              Competitor
+            </label>
+            <select
+              id="sim-competitor-select"
+              value={selectedCompetitorId}
+              onChange={(e) => {
+                setSelectedCompetitorId(Number(e.target.value));
+                setAdj(ZERO_ADJ);
+              }}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+            >
+              {competitors.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                  {c.division ? ` (${c.division})` : ""}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-muted-foreground" htmlFor="sim-stage-select">
+            Stage
+          </label>
+          <select
+            id="sim-stage-select"
+            value={selectedStageId}
+            onChange={(e) => {
+              setSelectedStageId(Number(e.target.value));
+              setAdj(ZERO_ADJ);
+            }}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+          >
+            {data.stages.map((s) => (
+              <option key={s.stage_id} value={s.stage_id}>
+                {s.stage_num} — {s.stage_name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {stageUnavailable ? (
+        <p className="text-sm text-muted-foreground">
+          No scorecard data for this stage and competitor.
+        </p>
+      ) : (
+        <>
+          {/* Current stage stats */}
+          <div className="rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground space-y-0.5">
+            <p>
+              <span className="font-medium text-foreground">
+                {fmt(currentPoints, 0)} pts · {fmt(currentTime)}s · HF {fmt(currentHF)}
+              </span>
+            </p>
+            <p>
+              {currentAHits}A · {compSummary?.c_hits ?? 0}C · {compSummary?.d_hits ?? 0}D ·{" "}
+              {currentMisses}M · {compSummary?.no_shoots ?? 0}NS ·{" "}
+              {compSummary?.procedurals ?? 0}P
+            </p>
+          </div>
+
+          {/* Adjustment controls */}
+          <div className="space-y-2 border rounded-md px-3 py-3">
+            <Stepper
+              label="Time (s)"
+              value={parseFloat((currentTime! + safeAdj.timeDelta).toFixed(10))}
+              min={0.1}
+              max={(currentTime ?? 999) + 60}
+              step={0.5}
+              onChange={(newTime) =>
+                setAdj((a) => ({ ...a, timeDelta: parseFloat((newTime - currentTime!).toFixed(10)) }))
+              }
+              formatValue={(v) => v.toFixed(1)}
+              decrementLabel="Decrease time by 0.5 seconds (shoot faster)"
+              incrementLabel="Increase time by 0.5 seconds (shoot slower)"
+            />
+            {currentMisses > 0 && (
+              <Stepper
+                label="Misses → A"
+                value={safeAdj.missToACount}
+                min={0}
+                max={maxMissToA}
+                onChange={(v) => setAdj((a) => ({ ...a, missToACount: v }))}
+                decrementLabel="Convert one fewer miss to A-hit"
+                incrementLabel="Convert one miss to A-hit (+15 pts)"
+              />
+            )}
+            {currentAHits > 0 && (
+              <Stepper
+                label="A → C"
+                value={safeAdj.aToCCount}
+                min={0}
+                max={maxAToC}
+                onChange={(v) => setAdj((a) => ({ ...a, aToCCount: v }))}
+                decrementLabel="Swap one fewer A-hit to C-hit"
+                incrementLabel={`Swap one A-hit to C-hit (${isMajor ? "−1 pt major" : "−2 pts minor"})`}
+              />
+            )}
+          </div>
+
+          {/* Live result */}
+          <div
+            id={liveRegionId}
+            aria-live="polite"
+            aria-atomic="true"
+            aria-label="Simulated result"
+          >
+            <div className="rounded-md border px-3 py-3 space-y-0.5">
+              <p className="text-xs font-medium text-muted-foreground mb-2">Simulated result</p>
+              <ResultRow
+                label="Points"
+                current={fmt(currentPoints, 0)}
+                simulated={fmt(simStage?.newPoints ?? currentPoints, 0)}
+                delta={fmtDelta(simStage?.pointDelta ?? null, 0)}
+                deltaPositive={simStage ? simStage.pointDelta > 0 : null}
+              />
+              <ResultRow
+                label="HF"
+                current={fmt(currentHF)}
+                simulated={fmt(simStage?.newHF ?? currentHF)}
+                delta={fmtDelta(simStage?.hfDelta ?? null)}
+                deltaPositive={simStage ? simStage.hfDelta > 0 : null}
+              />
+              <ResultRow
+                label="Stage %"
+                current={fmt(currentGroupPct, 1)}
+                simulated={fmt(simStage?.newGroupPct ?? currentGroupPct, 1)}
+                delta={fmtDelta(simStage?.groupPctDelta ?? null, 1)}
+                deltaPositive={simStage ? (simStage.groupPctDelta ?? 0) > 0 : null}
+              />
+              {competitors.length > 1 && (
+                <>
+                  <ResultRow
+                    label="Match avg"
+                    current={fmt(currentMatchPct, 1)}
+                    simulated={fmt(simMatch?.newMatchPct ?? currentMatchPct, 1)}
+                    delta={fmtDelta(simMatch?.matchPctDelta ?? null, 1)}
+                    deltaPositive={simMatch ? (simMatch.matchPctDelta ?? 0) > 0 : null}
+                  />
+                  <ResultRow
+                    label="Group rank"
+                    current={currentGroupRank != null ? ordinal(currentGroupRank) : "—"}
+                    simulated={
+                      simMatch?.newGroupRank != null
+                        ? ordinal(simMatch.newGroupRank)
+                        : currentGroupRank != null
+                        ? ordinal(currentGroupRank)
+                        : "—"
+                    }
+                    delta={fmtRankDelta(simMatch?.groupRankDelta ?? null)}
+                    deltaPositive={simMatch ? (simMatch.groupRankDelta ?? 0) > 0 : null}
+                  />
+                </>
+              )}
+              {competitors.length === 1 && (
+                <ResultRow
+                  label="Match avg"
+                  current={fmt(currentMatchPct, 1)}
+                  simulated={fmt(simMatch?.newMatchPct ?? currentMatchPct, 1)}
+                  delta={fmtDelta(simMatch?.matchPctDelta ?? null, 1)}
+                  deltaPositive={simMatch ? (simMatch.matchPctDelta ?? 0) > 0 : null}
+                />
+              )}
+            </div>
+          </div>
+
+          {/* Reset */}
+          {hasChanges && (
+            <button
+              type="button"
+              onClick={resetAdj}
+              className={cn(
+                "text-xs text-muted-foreground hover:text-foreground underline underline-offset-2",
+                "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring rounded"
+              )}
+            >
+              Reset
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -11,11 +11,25 @@ import type { Release } from "@/lib/types";
  * differs from the value stored in localStorage("whats-new-seen-id").
  */
 /** The `id` of the newest release. Used by e2e tests to suppress the What's New dialog. */
-export const LATEST_RELEASE_ID = "2026-02-27b";
+export const LATEST_RELEASE_ID = "2026-02-27c";
 
 export const RELEASES: Release[] = [
   {
     id: LATEST_RELEASE_ID,
+    date: "February 27, 2026",
+    title: "Stage Simulator",
+    sections: [
+      {
+        heading: "New",
+        items: [
+          "Stage Simulator: adjust your time or hit outcomes on any stage and instantly see the impact on hit factor, stage %, match average, and group rank.",
+          "Available after 80% of scorecards are submitted. Find it below the Coaching analysis section on any match page.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "2026-02-27b",
     date: "February 27, 2026",
     title: "Benchmark Picker",
     sections: [

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -298,6 +298,36 @@ export interface EventSummary {
   level: string; // e.g. "Level II"
 }
 
+// ── Stage Simulator ──────────────────────────────────────────────────────────
+
+// User-driven adjustments for the what-if stage simulator.
+export interface StageSimulatorAdjustments {
+  timeDelta: number;    // seconds added to current time (negative = faster)
+  missToACount: number; // misses converted to A-hits (0 ≤ n ≤ miss_count)
+  aToCCount: number;    // A-hits swapped to C-hits (0 ≤ n ≤ a_hits)
+}
+
+// Result of simulating a single stage after applying adjustments.
+export interface SimulatedStageResult {
+  stageId: number;
+  newPoints: number;
+  newTime: number;
+  newHF: number;
+  newGroupLeaderHF: number; // may equal newHF if competitor becomes leader
+  newGroupPct: number | null;
+  pointDelta: number;
+  hfDelta: number;
+  groupPctDelta: number | null;
+}
+
+// Match-level impact of a simulated stage adjustment.
+export interface SimulatedMatchResult {
+  newMatchPct: number | null;   // new avg group % across all valid stages
+  matchPctDelta: number | null; // positive = improvement
+  newGroupRank: number | null;  // rank among selected competitors
+  groupRankDelta: number | null; // positive = rank improved (moved up)
+}
+
 export interface ReleaseSection {
   heading: string;
   items: string[];

--- a/lib/what-if-calc.ts
+++ b/lib/what-if-calc.ts
@@ -1,0 +1,189 @@
+// Pure functions for the what-if stage simulator. No I/O, fully unit-tested.
+//
+// Scoring rules (IPSC Comstock):
+//   A = 5 pts (constant regardless of power factor)
+//   C = 4 pts major / 3 pts minor
+//   D = 2 pts major / 1 pt minor
+//   Miss = 0 pts + 10 pt penalty
+//
+// Point deltas for swaps:
+//   Miss → A: +15 pts (major and minor identical: +10 penalty removed + 5 hit)
+//   A → C: −1 pt major / −2 pts minor
+
+import type {
+  StageComparison,
+  CompetitorSummary,
+  StageSimulatorAdjustments,
+  SimulatedStageResult,
+  SimulatedMatchResult,
+} from "@/lib/types";
+
+/**
+ * Returns true when the competitor shoots major power factor.
+ * Detection is based on the formatted division string produced by
+ * `formatDivisionDisplay()` — divisions that compete at both power factors
+ * carry a " Major" or " Minor" suffix (e.g. "Open Major").
+ * Production and Production Optics have no suffix and are always minor.
+ */
+export function isMajorPowerFactor(division: string | null): boolean {
+  if (!division) return false;
+  return division.endsWith(" Major");
+}
+
+/**
+ * Computes the total point delta for a set of simulator adjustments.
+ * Does NOT account for time — time affects HF but not raw points.
+ */
+export function computePointDelta(
+  adjustments: StageSimulatorAdjustments,
+  isMajor: boolean
+): number {
+  const cDelta = isMajor ? -1 : -2;
+  return adjustments.missToACount * 15 + adjustments.aToCCount * cDelta;
+}
+
+/**
+ * Simulates a single stage result after applying the given adjustments.
+ *
+ * Handles group leader change: if the simulated HF exceeds the current group
+ * leader's HF, newGroupLeaderHF is updated to the simulated HF and
+ * newGroupPct is capped at 100%.
+ */
+export function simulateStageAdjustment(
+  competitor: CompetitorSummary,
+  stage: StageComparison,
+  adjustments: StageSimulatorAdjustments,
+  isMajor: boolean
+): SimulatedStageResult {
+  const currentPoints = competitor.points ?? 0;
+  const currentTime = competitor.time ?? 0;
+  const currentHF = competitor.hit_factor ?? 0;
+
+  const pointDelta = computePointDelta(adjustments, isMajor);
+  const newPoints = currentPoints + pointDelta;
+  const newTime = Math.max(0.001, currentTime + adjustments.timeDelta);
+  const newHF = newTime > 0 ? newPoints / newTime : 0;
+
+  // If simulated HF beats current group leader, the new leader HF is ours.
+  const currentLeaderHF = stage.group_leader_hf ?? 0;
+  const newGroupLeaderHF = Math.max(currentLeaderHF, newHF);
+
+  const newGroupPct =
+    newGroupLeaderHF > 0 ? (newHF / newGroupLeaderHF) * 100 : null;
+
+  const currentGroupPct = competitor.group_percent ?? null;
+  const groupPctDelta =
+    newGroupPct != null && currentGroupPct != null
+      ? newGroupPct - currentGroupPct
+      : null;
+
+  return {
+    stageId: stage.stage_id,
+    newPoints,
+    newTime,
+    newHF,
+    newGroupLeaderHF,
+    newGroupPct,
+    pointDelta,
+    hfDelta: newHF - currentHF,
+    groupPctDelta,
+  };
+}
+
+/**
+ * Computes the match-level impact of a simulated stage adjustment.
+ *
+ * For each selected competitor, recomputes their avg group % replacing the
+ * simulated stage's value. When the simulated competitor becomes the group
+ * leader for that stage, other competitors' stage % is scaled down accordingly.
+ *
+ * @param stages         All stages from CompareResponse
+ * @param competitorId   The competitor whose stage was adjusted
+ * @param allCompetitorIds All selected competitor IDs (used for group rank)
+ * @param simResult      Result from simulateStageAdjustment
+ */
+export function simulateMatchImpact(
+  stages: StageComparison[],
+  competitorId: number,
+  allCompetitorIds: number[],
+  simResult: SimulatedStageResult
+): SimulatedMatchResult {
+  const leaderChanged =
+    simResult.newGroupLeaderHF > (stages.find((s) => s.stage_id === simResult.stageId)?.group_leader_hf ?? 0);
+
+  /**
+   * Computes the avg group % for a competitor, optionally overriding the
+   * simulated stage. When the leader changed, other competitors' stage %
+   * on the simulated stage is scaled to the new leader HF.
+   */
+  function avgPct(compId: number, applySimulation: boolean): number | null {
+    let sum = 0;
+    let count = 0;
+
+    for (const stage of stages) {
+      const sc: CompetitorSummary | undefined = stage.competitors[compId];
+      if (!sc || sc.dnf || sc.dq || sc.zeroed) continue;
+
+      let groupPct: number | null;
+
+      if (applySimulation && stage.stage_id === simResult.stageId) {
+        if (compId === competitorId) {
+          groupPct = simResult.newGroupPct;
+        } else if (leaderChanged) {
+          // Scale down: other competitor keeps their HF but compares to new leader
+          const otherHF = sc.hit_factor ?? 0;
+          groupPct =
+            simResult.newGroupLeaderHF > 0
+              ? (otherHF / simResult.newGroupLeaderHF) * 100
+              : null;
+        } else {
+          groupPct = sc.group_percent ?? null;
+        }
+      } else {
+        groupPct = sc.group_percent ?? null;
+      }
+
+      if (groupPct != null) {
+        sum += groupPct;
+        count++;
+      }
+    }
+
+    return count > 0 ? sum / count : null;
+  }
+
+  const currentMatchPct = avgPct(competitorId, false);
+  const newMatchPct = avgPct(competitorId, true);
+
+  // Compute simulated averages for all selected competitors to determine group rank.
+  const simAvgs: { id: number; avg: number }[] = [];
+  const baseAvgs: { id: number; avg: number }[] = [];
+  for (const compId of allCompetitorIds) {
+    const simAvg = avgPct(compId, true);
+    const baseAvg = avgPct(compId, false);
+    if (simAvg != null) simAvgs.push({ id: compId, avg: simAvg });
+    if (baseAvg != null) baseAvgs.push({ id: compId, avg: baseAvg });
+  }
+
+  simAvgs.sort((a, b) => b.avg - a.avg);
+  baseAvgs.sort((a, b) => b.avg - a.avg);
+
+  const newRankIdx = simAvgs.findIndex((c) => c.id === competitorId);
+  const baseRankIdx = baseAvgs.findIndex((c) => c.id === competitorId);
+
+  const newGroupRank = newRankIdx >= 0 ? newRankIdx + 1 : null;
+  const baseGroupRank = baseRankIdx >= 0 ? baseRankIdx + 1 : null;
+
+  return {
+    newMatchPct,
+    matchPctDelta:
+      newMatchPct != null && currentMatchPct != null
+        ? newMatchPct - currentMatchPct
+        : null,
+    newGroupRank,
+    groupRankDelta:
+      newGroupRank != null && baseGroupRank != null
+        ? baseGroupRank - newGroupRank // positive = improved (lower rank number)
+        : null,
+  };
+}

--- a/tests/unit/what-if-calc.test.ts
+++ b/tests/unit/what-if-calc.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect } from "vitest";
+import {
+  isMajorPowerFactor,
+  computePointDelta,
+  simulateStageAdjustment,
+  simulateMatchImpact,
+} from "@/lib/what-if-calc";
+import type {
+  StageComparison,
+  CompetitorSummary,
+  StageSimulatorAdjustments,
+} from "@/lib/types";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeCompetitor(overrides: Partial<CompetitorSummary> = {}): CompetitorSummary {
+  return {
+    competitor_id: 1,
+    points: 72,
+    hit_factor: 5.81,
+    time: 12.4,
+    group_rank: 2,
+    group_percent: 87.2,
+    div_rank: null,
+    div_percent: null,
+    overall_rank: null,
+    overall_percent: null,
+    dq: false,
+    zeroed: false,
+    dnf: false,
+    incomplete: false,
+    a_hits: 12,
+    c_hits: 4,
+    d_hits: 0,
+    miss_count: 2,
+    no_shoots: 0,
+    procedurals: 0,
+    shooting_order: null,
+    overall_percentile: null,
+    stageClassification: null,
+    hitLossPoints: null,
+    penaltyLossPoints: 20,
+    ...overrides,
+  };
+}
+
+function makeStage(overrides: Partial<StageComparison> = {}): StageComparison {
+  const competitor = makeCompetitor();
+  return {
+    stage_id: 3,
+    stage_name: "The Maze",
+    stage_num: 3,
+    max_points: 96,
+    group_leader_hf: 6.67,
+    group_leader_points: null,
+    overall_leader_hf: 7.0,
+    field_median_hf: 4.5,
+    field_competitor_count: 20,
+    stageDifficultyLevel: 3,
+    stageDifficultyLabel: "hard",
+    competitors: { 1: competitor },
+    ...overrides,
+  };
+}
+
+const noAdj: StageSimulatorAdjustments = { timeDelta: 0, missToACount: 0, aToCCount: 0 };
+
+// ─── isMajorPowerFactor ──────────────────────────────────────────────────────
+
+describe("isMajorPowerFactor", () => {
+  it("returns true for divisions ending in ' Major'", () => {
+    expect(isMajorPowerFactor("Open Major")).toBe(true);
+    expect(isMajorPowerFactor("Standard Major")).toBe(true);
+  });
+
+  it("returns false for divisions ending in ' Minor'", () => {
+    expect(isMajorPowerFactor("Open Minor")).toBe(false);
+    expect(isMajorPowerFactor("Standard Minor")).toBe(false);
+  });
+
+  it("returns false for single-power-factor divisions", () => {
+    expect(isMajorPowerFactor("Production")).toBe(false);
+    expect(isMajorPowerFactor("Production Optics")).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isMajorPowerFactor(null)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isMajorPowerFactor("")).toBe(false);
+  });
+});
+
+// ─── computePointDelta ───────────────────────────────────────────────────────
+
+describe("computePointDelta", () => {
+  it("returns 0 with no adjustments", () => {
+    expect(computePointDelta(noAdj, true)).toBe(0);
+    expect(computePointDelta(noAdj, false)).toBe(0);
+  });
+
+  it("adds +15 pts per miss→A conversion (same for major and minor)", () => {
+    const adj: StageSimulatorAdjustments = { ...noAdj, missToACount: 2 };
+    expect(computePointDelta(adj, true)).toBe(30);
+    expect(computePointDelta(adj, false)).toBe(30);
+  });
+
+  it("applies -1 pt per A→C swap for major", () => {
+    const adj: StageSimulatorAdjustments = { ...noAdj, aToCCount: 3 };
+    expect(computePointDelta(adj, true)).toBe(-3);
+  });
+
+  it("applies -2 pts per A→C swap for minor", () => {
+    const adj: StageSimulatorAdjustments = { ...noAdj, aToCCount: 3 };
+    expect(computePointDelta(adj, false)).toBe(-6);
+  });
+
+  it("combines miss→A and A→C correctly (major)", () => {
+    // 1 miss→A: +15, 2 A→C: -2 → total +13
+    const adj: StageSimulatorAdjustments = { ...noAdj, missToACount: 1, aToCCount: 2 };
+    expect(computePointDelta(adj, true)).toBe(13);
+  });
+
+  it("combines miss→A and A→C correctly (minor)", () => {
+    // 1 miss→A: +15, 2 A→C: -4 → total +11
+    const adj: StageSimulatorAdjustments = { ...noAdj, missToACount: 1, aToCCount: 2 };
+    expect(computePointDelta(adj, false)).toBe(11);
+  });
+});
+
+// ─── simulateStageAdjustment ─────────────────────────────────────────────────
+
+describe("simulateStageAdjustment", () => {
+  it("returns current values with no adjustments", () => {
+    const comp = makeCompetitor();
+    const stage = makeStage();
+    const result = simulateStageAdjustment(comp, stage, noAdj, false);
+    expect(result.newPoints).toBeCloseTo(72, 5);
+    expect(result.newTime).toBeCloseTo(12.4, 5);
+    expect(result.newHF).toBeCloseTo(72 / 12.4, 5);
+    expect(result.pointDelta).toBe(0);
+  });
+
+  it("increases HF when time decreases", () => {
+    const comp = makeCompetitor();
+    const stage = makeStage();
+    const adj: StageSimulatorAdjustments = { timeDelta: -2, missToACount: 0, aToCCount: 0 };
+    const result = simulateStageAdjustment(comp, stage, adj, false);
+    expect(result.newTime).toBeCloseTo(10.4, 5);
+    expect(result.newHF).toBeCloseTo(72 / 10.4, 5);
+    expect(result.hfDelta).toBeGreaterThan(0);
+  });
+
+  it("time constrained to > 0", () => {
+    const comp = makeCompetitor({ time: 5 });
+    const stage = makeStage();
+    const adj: StageSimulatorAdjustments = { timeDelta: -100, missToACount: 0, aToCCount: 0 };
+    const result = simulateStageAdjustment(comp, stage, adj, false);
+    expect(result.newTime).toBeGreaterThan(0);
+  });
+
+  it("converting 2 misses to A adds +30 pts (minor)", () => {
+    const comp = makeCompetitor();
+    const stage = makeStage();
+    const adj: StageSimulatorAdjustments = { timeDelta: 0, missToACount: 2, aToCCount: 0 };
+    const result = simulateStageAdjustment(comp, stage, adj, false);
+    expect(result.newPoints).toBe(102);
+    expect(result.pointDelta).toBe(30);
+  });
+
+  it("group percent capped at 100 when competitor becomes group leader", () => {
+    // Comp currently at HF 5.81, leader is 6.67. Adjust time to beat the leader.
+    const comp = makeCompetitor({ hit_factor: 5.81, time: 12.4, points: 72 });
+    const stage = makeStage({ group_leader_hf: 6.67 });
+    // new HF = 72 / 8.0 = 9.0 → beats leader
+    const adj: StageSimulatorAdjustments = { timeDelta: -4.4, missToACount: 0, aToCCount: 0 };
+    const result = simulateStageAdjustment(comp, stage, adj, false);
+    expect(result.newHF).toBeGreaterThan(6.67);
+    expect(result.newGroupLeaderHF).toBeCloseTo(result.newHF, 5);
+    expect(result.newGroupPct).toBeCloseTo(100, 5);
+  });
+
+  it("group percent lower when group leader is higher than simulated HF", () => {
+    const comp = makeCompetitor({ hit_factor: 5.81, time: 12.4, points: 72 });
+    const stage = makeStage({ group_leader_hf: 6.67 });
+    const result = simulateStageAdjustment(comp, stage, noAdj, false);
+    expect(result.newGroupPct).not.toBeNull();
+    expect(result.newGroupPct!).toBeLessThan(100);
+  });
+
+  it("groupPctDelta is null when group_percent is null", () => {
+    const comp = makeCompetitor({ group_percent: null });
+    const stage = makeStage({ group_leader_hf: null });
+    const result = simulateStageAdjustment(comp, stage, noAdj, false);
+    expect(result.groupPctDelta).toBeNull();
+  });
+});
+
+// ─── simulateMatchImpact ─────────────────────────────────────────────────────
+
+function makeMultiStage(): { stages: StageComparison[]; comp1: CompetitorSummary; comp2: CompetitorSummary } {
+  // group_percent values are computed consistently: (hf / leaderHF) * 100
+  // stage1: leader 6.67 → comp1 = 6.0/6.67*100 ≈ 89.955, comp2 = 100
+  // stage2: leader 5.0  → comp1 = 4.25/5.0*100 = 85, comp2 = 4.0/5.0*100 = 80
+  const comp1s1 = makeCompetitor({ competitor_id: 1, group_percent: (6.0 / 6.67) * 100, hit_factor: 6.0, time: 10, points: 60 });
+  const comp2s1 = makeCompetitor({ competitor_id: 2, group_percent: 100, hit_factor: 6.67, time: 10, points: 66.7 });
+  const comp1s2 = makeCompetitor({ competitor_id: 1, group_percent: 85, hit_factor: 4.25, time: 20, points: 85 });
+  const comp2s2 = makeCompetitor({ competitor_id: 2, group_percent: 80, hit_factor: 4.0, time: 20, points: 80 });
+
+  const stage1: StageComparison = {
+    stage_id: 1, stage_name: "Stage 1", stage_num: 1, max_points: 80,
+    group_leader_hf: 6.67, group_leader_points: null,
+    overall_leader_hf: 6.67, field_median_hf: 5.0, field_competitor_count: 10,
+    stageDifficultyLevel: 3, stageDifficultyLabel: "hard",
+    competitors: { 1: comp1s1, 2: comp2s1 },
+  };
+  const stage2: StageComparison = {
+    stage_id: 2, stage_name: "Stage 2", stage_num: 2, max_points: 100,
+    group_leader_hf: 5.0, group_leader_points: null,
+    overall_leader_hf: 5.0, field_median_hf: 3.5, field_competitor_count: 10,
+    stageDifficultyLevel: 3, stageDifficultyLabel: "hard",
+    competitors: { 1: comp1s2, 2: comp2s2 },
+  };
+
+  return { stages: [stage1, stage2], comp1: comp1s1, comp2: comp2s1 };
+}
+
+describe("simulateMatchImpact", () => {
+  it("returns null deltas when no adjustment is made", () => {
+    const { stages, comp1 } = makeMultiStage();
+    const stage = stages[0];
+    const simResult = simulateStageAdjustment(comp1, stage, noAdj, false);
+    const impact = simulateMatchImpact(stages, 1, [1, 2], simResult);
+    // With no change, matchPctDelta should be ~0
+    expect(impact.matchPctDelta).toBeCloseTo(0, 4);
+    expect(impact.groupRankDelta).toBe(0);
+  });
+
+  it("improving stage 1 increases match average", () => {
+    const { stages, comp1 } = makeMultiStage();
+    const stage = stages[0];
+    // Convert 2 misses to A: +30 pts (minor)
+    const adj: StageSimulatorAdjustments = { timeDelta: -2, missToACount: 2, aToCCount: 0 };
+    const simResult = simulateStageAdjustment(comp1, stage, adj, false);
+    const impact = simulateMatchImpact(stages, 1, [1, 2], simResult);
+    expect(impact.matchPctDelta).not.toBeNull();
+    expect(impact.matchPctDelta!).toBeGreaterThan(0);
+  });
+
+  it("competitor rank improves when simulation beats group leader match avg", () => {
+    const { stages, comp1 } = makeMultiStage();
+    // comp2 has higher avg currently (90+80)/2=85 for comp1, (100+80)/2=90 for comp2
+    // Drastically improve comp1's stage 1 performance to beat comp2
+    const stage = stages[0];
+    const adj: StageSimulatorAdjustments = { timeDelta: -4, missToACount: 2, aToCCount: 0 };
+    const simResult = simulateStageAdjustment(comp1, stage, adj, false);
+    const impact = simulateMatchImpact(stages, 1, [1, 2], simResult);
+    // If match avg improved enough, rank should improve
+    if (impact.newMatchPct != null && impact.newMatchPct > 90) {
+      expect(impact.newGroupRank).toBe(1);
+    }
+  });
+
+  it("handles single competitor correctly", () => {
+    const { stages, comp1 } = makeMultiStage();
+    const stage = stages[0];
+    const adj: StageSimulatorAdjustments = { timeDelta: -1, missToACount: 0, aToCCount: 0 };
+    const simResult = simulateStageAdjustment(comp1, stage, adj, false);
+    const impact = simulateMatchImpact(stages, 1, [1], simResult);
+    expect(impact.newGroupRank).toBe(1);
+    expect(impact.groupRankDelta).toBe(0);
+  });
+
+  it("DNF stages are excluded from average computation", () => {
+    const { stages, comp1 } = makeMultiStage();
+    // Mark stage 2 as DNF for comp1
+    stages[1].competitors[1] = { ...stages[1].competitors[1], dnf: true, group_percent: null };
+    const stage = stages[0];
+    const simResult = simulateStageAdjustment(comp1, stage, noAdj, false);
+    const impact = simulateMatchImpact(stages, 1, [1, 2], simResult);
+    // Should still work (only stage 1 counts for comp1)
+    expect(impact.newMatchPct).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a **Stage Simulator** accordion to the match page (positioned after Coaching analysis, gated at ≥80% scoring completed)
- Competitor selects a stage, then adjusts time (±0.5s), converts misses to A-hits, or swaps A-hits to C-hits — results update instantly with no server roundtrip
- Shows live impact on points, HF, stage %, match average %, and group rank among compared competitors
- Handles group leader change: when simulated HF exceeds the current group leader, all competitors' stage percentages are scaled accordingly

## Test plan

- [x] `pnpm -w run typecheck` — zero errors
- [x] `pnpm -w run lint` — zero warnings
- [x] `pnpm -w test` — 449 tests pass (23 new unit tests in `tests/unit/what-if-calc.test.ts`)
- [ ] Manual: open a match with ≥80% scoring, expand Stage Simulator, verify stepper controls, check live result deltas
- [ ] Manual: verify at 390px width — no horizontal overflow, touch targets reachable
- [ ] Manual: keyboard-navigate the accordion, selects, and steppers; confirm `aria-live` region announces changes

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)