### PR TITLE
feat: support Workers AI binding for cloudflare provider (no API key required)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ or any other type that is serialised into Redis via `cachedExecuteQuery`.
 | `NEXT_PUBLIC_APP_URL` | `app/api/mcp/route.ts`, `app/match/[ct]/[id]/layout.tsx` | Both | Base URL used by MCP tools and OG image meta tags. Defaults to `http://localhost:PORT`. Required for Cloudflare Pages (set to the external URL, e.g. `https://scoreboard.urdr.dev`). |
 | `AI_PROVIDER` | `lib/ai-provider.ts` (server-only) | Both | `"cloudflare"` or `"openai"`. Omit to disable AI coaching tips. Never `NEXT_PUBLIC_`. |
 | `AI_MODEL` | `lib/ai-provider.ts` (server-only) | Both | Model identifier, e.g. `"gpt-4o-mini"` or `"@cf/meta/llama-3.1-8b-instruct"`. Never `NEXT_PUBLIC_`. |
-| `AI_API_KEY` | `lib/ai-provider.ts` (server-only) | Both | API key/token for the AI provider. Never `NEXT_PUBLIC_`. |
+| `AI_API_KEY` | `lib/ai-provider.ts` (server-only) | Both | API key/token for the AI provider. **Optional for `cloudflare` provider** — omit to use the Workers AI binding (`env.AI`) instead of the REST API. Never `NEXT_PUBLIC_`. |
 | `AI_API_URL` | `lib/ai-provider.ts` (server-only) | Both | Base URL. Required for Cloudflare Workers AI. Defaults to `https://api.openai.com/v1` for `openai`. |
 | `SMITHERY_API_KEY` | `.github/workflows/smithery-publish.yml` | CI only | Smithery registry API key. Store as a GitHub `production` environment secret. Obtain from https://smithery.ai/account/api-keys. Never `NEXT_PUBLIC_`. |
 

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -14,7 +14,8 @@ export interface AIProvider {
 export interface AIProviderConfig {
   provider: string;
   model: string;
-  apiKey: string;
+  /** Not required for the cloudflare provider when using the Workers AI binding. */
+  apiKey?: string;
   apiUrl?: string;
 }
 
@@ -28,7 +29,10 @@ export function createAIProvider(): AIProvider | null {
   const apiKey = process.env.AI_API_KEY;
   const apiUrl = process.env.AI_API_URL;
 
-  if (!provider || !model || !apiKey) return null;
+  // For the cloudflare provider the API key is optional — the Workers AI
+  // binding (env.AI) is used when no key is supplied.
+  if (!provider || !model) return null;
+  if (provider !== "cloudflare" && !apiKey) return null;
 
   const config: AIProviderConfig = { provider, model, apiKey, apiUrl };
 
@@ -45,9 +49,10 @@ export function createAIProvider(): AIProvider | null {
 
 /** Check whether the AI coaching feature is configured (env vars present). */
 export function isAIConfigured(): boolean {
-  return Boolean(
-    process.env.AI_PROVIDER &&
-    process.env.AI_MODEL &&
-    process.env.AI_API_KEY,
-  );
+  const provider = process.env.AI_PROVIDER;
+  const model = process.env.AI_MODEL;
+  if (!provider || !model) return false;
+  // Cloudflare provider uses the Workers AI binding — no API key needed.
+  if (provider === "cloudflare") return true;
+  return Boolean(process.env.AI_API_KEY);
 }

--- a/lib/ai-providers/cloudflare-workers-ai.ts
+++ b/lib/ai-providers/cloudflare-workers-ai.ts
@@ -1,14 +1,78 @@
-// Cloudflare Workers AI REST API implementation.
-// POST https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run/{model}
-// AI_API_URL should be the full base URL including account ID, e.g.:
-//   https://api.cloudflare.com/client/v4/accounts/ACCT_ID/ai/run
+// Cloudflare Workers AI provider — two modes:
+//
+// 1. Binding (preferred for CF deployments, no API key required):
+//    Set AI_PROVIDER=cloudflare and AI_MODEL, leave AI_API_KEY unset.
+//    Requires [ai] binding in wrangler.toml (binding = "AI").
+//    Uses getCloudflareContext().env.AI.run() at request time.
+//
+// 2. REST API (useful outside CF Workers, e.g. local dev with a CF API token):
+//    Set AI_PROVIDER=cloudflare, AI_MODEL, AI_API_KEY (CF API token), and
+//    AI_API_URL = https://api.cloudflare.com/client/v4/accounts/<ACCT_ID>/ai/run
+//    Calls the external REST endpoint with Bearer auth.
 
+import { getCloudflareContext } from "@opennextjs/cloudflare";
 import type { AIProvider, AIProviderConfig } from "@/lib/ai-provider";
 
 const TIMEOUT_MS = 10_000;
-const SYSTEM_MESSAGE = "You are a concise IPSC shooting coach. Give specific, actionable advice in 1-2 sentences.";
+const SYSTEM_MESSAGE =
+  "You are a concise IPSC shooting coach. Give specific, actionable advice in 1-2 sentences.";
+
+// Minimal type for the Workers AI text-generation binding.
+// Augments CloudflareEnv (declared globally by @opennextjs/cloudflare) so that
+// env.AI is typed without requiring @cloudflare/workers-types as a direct dep.
+interface AiTextGenBinding {
+  run(
+    model: string,
+    inputs: {
+      messages?: Array<{ role: string; content: string }>;
+      max_tokens?: number;
+      temperature?: number;
+    },
+  ): Promise<{ response?: string }>;
+}
+
+declare global {
+  interface CloudflareEnv {
+    AI?: AiTextGenBinding;
+  }
+}
 
 export function createCloudflareProvider(config: AIProviderConfig): AIProvider {
+  return config.apiKey
+    ? createRestProvider(config)
+    : createBindingProvider(config);
+}
+
+// --- binding variant ---
+
+function createBindingProvider(config: AIProviderConfig): AIProvider {
+  return {
+    modelId: config.model,
+    async generateTip(prompt: string): Promise<string> {
+      const { env } = getCloudflareContext();
+      const ai = env.AI;
+      if (!ai) {
+        throw new Error(
+          'Workers AI binding not available. ' +
+            'Ensure [ai] binding = "AI" is set in wrangler.toml.',
+        );
+      }
+      const result = await ai.run(config.model, {
+        messages: [
+          { role: "system", content: SYSTEM_MESSAGE },
+          { role: "user", content: prompt },
+        ],
+        max_tokens: 150,
+        temperature: 0.7,
+      });
+      return result.response ?? "";
+    },
+  };
+}
+
+// --- REST API variant (original, requires AI_API_KEY + AI_API_URL) ---
+
+function createRestProvider(config: AIProviderConfig): AIProvider {
   const baseUrl = config.apiUrl ?? "";
 
   return {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -39,6 +39,9 @@ cpu_ms = 30000
 [placement]
 mode = "smart"
 
+[ai]
+binding = "AI"
+
 [assets]
 directory = ".open-next/assets"
 


### PR DESCRIPTION
The cloudflare AI provider previously only supported the REST API, which
requires AI_API_KEY and AI_API_URL. When running inside a Cloudflare Worker
the AI binding (env.AI) is available natively with no credentials needed.

- wrangler.toml: add [ai] binding = "AI"
- cloudflare-workers-ai.ts: split into createBindingProvider (no key →
  getCloudflareContext().env.AI.run()) and createRestProvider (key present →
  original fetch-based REST path); add minimal AiTextGenBinding type +
  CloudflareEnv augmentation so env.AI is typed without @cloudflare/workers-types
- ai-provider.ts: make apiKey optional in AIProviderConfig; relax
  createAIProvider() and isAIConfigured() so AI_API_KEY is not required when
  AI_PROVIDER=cloudflare
- CLAUDE.md: note that AI_API_KEY is optional for the cloudflare provider

https://claude.ai/code/session_01ReYEaVwzJfkmEbQsZUUByD