### PR TITLE
chore: rename middleware.ts → proxy.ts for Next.js 16 convention

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   // Generate a per-request cryptographic nonce (Web Crypto API — works in both
   // Node.js and Cloudflare Workers edge runtime).
   const nonce = btoa(crypto.randomUUID());


### PR DESCRIPTION
## Summary

- Renames `middleware.ts` → `proxy.ts` and updates the exported function name accordingly
- Silences the Next.js 16 build warning: _"The 'middleware' file convention is deprecated. Please use 'proxy' instead."_
- This commit was cherry-picked from `fix/wcag-contrast-improvements` which was merged without it

## Test plan

- [ ] Verify the build warning is gone after merge and staging redeploy