### PR TITLE
fix: set AI_PROVIDER and AI_MODEL vars in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,6 +12,9 @@
 #                wrangler secret put UPSTASH_REDIS_REST_TOKEN --env staging
 #                wrangler secret put CACHE_PURGE_SECRET --env staging
 #                wrangler secret put CACHE_KEY_PREFIX --env staging   # value: "staging:"
+#
+# Non-secret vars (AI coaching feature) are committed here under [vars] /
+# [env.staging.vars] so they are version-controlled alongside the binding.
 
 name = "ssi-scoreboard"
 compatibility_date = "2024-09-23"
@@ -41,6 +44,14 @@ mode = "smart"
 
 [ai]
 binding = "AI"
+
+[vars]
+AI_PROVIDER = "cloudflare"
+AI_MODEL = "@cf/meta/llama-3.1-8b-instruct"
+
+[env.staging.vars]
+AI_PROVIDER = "cloudflare"
+AI_MODEL = "@cf/meta/llama-3.1-8b-instruct"
 
 [assets]
 directory = ".open-next/assets"


### PR DESCRIPTION
## Summary

- The `[ai]` binding grants Workers AI access but the app also checks `AI_PROVIDER` and `AI_MODEL` env vars to decide whether to expose the coaching feature
- Without those vars, `isAIConfigured()` returns `false` and the feature is invisible — even though the binding is present
- Adds `[vars]` (production) and `[env.staging.vars]` (staging) with `AI_PROVIDER=cloudflare` and `AI_MODEL=@cf/meta/llama-3.1-8b-instruct` so both workers activate the feature on deploy

## Test plan

- [ ] Deploy to staging (`pnpm cf:deploy:staging`) and verify `/api/coaching/availability` returns `{"available":true}`
- [ ] Verify a coaching tip loads for a competitor on the staging match page

🤖 Generated with [Claude Code](https://claude.com/claude-code)