### PR TITLE
fix: declare edge runtime in proxy.ts for Cloudflare compatibility

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
+// Next.js 16 proxy files default to the Node.js runtime; Cloudflare Workers
+// require the Edge runtime. Declare it explicitly so @opennextjs/cloudflare
+// can bundle this file correctly.
+export const runtime = "edge";
+
 export function proxy(request: NextRequest) {
   // Generate a per-request cryptographic nonce (Web Crypto API — works in both
   // Node.js and Cloudflare Workers edge runtime).


### PR DESCRIPTION
## Summary

- Adds `export const runtime = "edge"` to `proxy.ts`
- Next.js 16's `proxy` file convention defaults to the **Node.js** runtime (unlike the old `middleware.ts` which was always edge-only)
- `@opennextjs/cloudflare` does not support Node.js-runtime middleware and was failing with: _"Node.js middleware is not currently supported. Consider switching to Edge Middleware."_
- This restores the previous edge-runtime behaviour and unblocks the Cloudflare staging deploy

## Root cause

The rename `middleware.ts → proxy.ts` (PR #166) was correct for silencing the Next.js 16 deprecation warning, but the new file convention carries a different default runtime, which broke the CF build.

## Test plan

- [ ] Staging deploy succeeds after merge (no "Node.js middleware is not currently supported" error)
- [ ] CSP nonce header (`x-nonce`) still flows through to server components