### PR TITLE
fix: revert proxy.ts → middleware.ts for Cloudflare compatibility

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-// Next.js 16 proxy files default to the Node.js runtime; Cloudflare Workers
-// require the Edge runtime. Declare it explicitly so @opennextjs/cloudflare
-// can bundle this file correctly.
-export const runtime = "edge";
-
-export function proxy(request: NextRequest) {
+// NOTE: Next.js 16 renamed this file convention from "middleware" to "proxy",
+// but @opennextjs/cloudflare does not yet support the new Node.js-runtime proxy
+// convention. We keep the deprecated middleware.ts name so Cloudflare builds
+// continue to work. Revisit once @opennextjs/cloudflare adds proxy support.
+export function middleware(request: NextRequest) {
   // Generate a per-request cryptographic nonce (Web Crypto API — works in both
   // Node.js and Cloudflare Workers edge runtime).
   const nonce = btoa(crypto.randomUUID());


### PR DESCRIPTION
## Summary

- Renames `proxy.ts` back to `middleware.ts` and restores `export function middleware()`
- Reverts the changes from PRs #166 and #168 which broke the Cloudflare staging deploy

## Root cause

Next.js 16's `proxy` file convention **always runs on the Node.js runtime** — `export const runtime` is not allowed and throws a build error. `@opennextjs/cloudflare@1.17.1` (latest) does not support Node.js-runtime middleware and fails with:

> `Node.js middleware is not currently supported. Consider switching to Edge Middleware.`

The deprecated `middleware.ts` convention still works in Next.js 16 (just emits a warning, not a build error) and continues to run at the **edge runtime**, which `@opennextjs/cloudflare` handles correctly.

## Trade-off accepted

- The Next.js 16 deprecation warning will appear in every build — this is acceptable until `@opennextjs/cloudflare` adds support for the `proxy.ts` convention.
- When CF adapter support lands, we can do the rename properly.

## Test plan

- [ ] Staging deploy succeeds after merge (no middleware/proxy error)
- [ ] Build emits the deprecation warning but completes successfully