### PR TITLE
fix: explicitly declare Workers AI binding for staging environment

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -52,3 +52,8 @@ enabled = true
 # Secrets set independently via: wrangler secret put <NAME> --env staging
 [env.staging]
 name = "ssi-scoreboard-staging"
+
+# The top-level [ai] binding is not automatically inherited by named environments
+# in Wrangler — declare it explicitly so the staging worker gets the AI binding.
+[env.staging.ai]
+binding = "AI"


### PR DESCRIPTION
## Summary

- Adds `[env.staging.ai] binding = "AI"` to `wrangler.toml`
- Wrangler does not automatically propagate top-level `[ai]` bindings to named `[env.*]` environments
- The staging worker was being deployed without the AI binding, causing it to be absent in the Cloudflare dashboard

## Test plan

- [ ] Redeploy staging — `ssi-scoreboard-staging` worker should show the AI binding in the Cloudflare dashboard
- [ ] AI coaching tips work on the staging deployment