### PR TITLE
Add expand/collapse functionality to recent competitions list

### DIFF
--- a/components/recent-competitions.tsx
+++ b/components/recent-competitions.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { useRouter } from "next/navigation";
-import { X } from "lucide-react";
+import { ChevronDown, X } from "lucide-react";
 import { Progress } from "@/components/ui/progress";
 import {
   subscribeRecent,
@@ -82,8 +82,10 @@ export function CompetitionCard({
 }
 
 const EMPTY_COMPETITIONS: StoredCompetition[] = [];
+const INITIAL_VISIBLE = 8;
 
 export function RecentCompetitions() {
+  const [showAll, setShowAll] = useState(false);
   // useSyncExternalStore handles SSR safety: getServerSnapshot returns []
   // and the client snapshot reads from localStorage after hydration.
   const competitions = useSyncExternalStore(
@@ -106,6 +108,9 @@ export function RecentCompetitions() {
     // will cause useSyncExternalStore to re-render with updated data.
   }
 
+  const visible = showAll ? competitions : competitions.slice(0, INITIAL_VISIBLE);
+  const hiddenCount = competitions.length - INITIAL_VISIBLE;
+
   return (
     <section aria-labelledby="recent-heading" className="w-full max-w-2xl">
       <h2
@@ -115,7 +120,7 @@ export function RecentCompetitions() {
         My recents
       </h2>
       <div className="grid gap-3 sm:grid-cols-2">
-        {competitions.map((comp) => (
+        {visible.map((comp) => (
           <CompetitionCard
             key={`${comp.ct}-${comp.id}`}
             comp={comp}
@@ -123,6 +128,19 @@ export function RecentCompetitions() {
           />
         ))}
       </div>
+      {competitions.length > INITIAL_VISIBLE && (
+        <button
+          type="button"
+          onClick={() => setShowAll((prev) => !prev)}
+          aria-expanded={showAll}
+          className="mt-3 w-full py-2 flex items-center justify-center gap-1 text-sm text-muted-foreground"
+        >
+          {showAll ? "Show less" : `Show more (${hiddenCount})`}
+          <ChevronDown
+            className={`w-4 h-4 transition-transform${showAll ? " rotate-180" : ""}`}
+          />
+        </button>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
Added the ability to expand and collapse the recent competitions list, showing only the first 8 items by default with an option to view all competitions.

## Key Changes
- Added `useState` hook to manage the `showAll` state for toggling list expansion
- Imported `ChevronDown` icon from lucide-react for the expand/collapse button
- Introduced `INITIAL_VISIBLE` constant set to 8 to control the default number of displayed competitions
- Implemented filtering logic to show either all competitions or only the first 8 based on the `showAll` state
- Added a toggle button that appears when there are more than 8 competitions, displaying:
  - "Show more (X)" text when collapsed, showing the count of hidden items
  - "Show less" text when expanded
  - Animated chevron icon that rotates 180° when expanded
- Button includes proper accessibility attributes (`aria-expanded`) and semantic HTML (`type="button"`)

## Implementation Details
- The visible competitions are determined by `showAll ? competitions : competitions.slice(0, INITIAL_VISIBLE)`
- The hidden count is calculated as `competitions.length - INITIAL_VISIBLE`
- The toggle button only renders when there are more competitions than the initial visible count
- The chevron icon uses CSS transform for smooth rotation animation on state change

https://claude.ai/code/session_01BPK1VvywTw8T8PEWZrsvQ7