### PR TITLE
feat: use SSI results/status fields for caching and results disclaimer

### DIFF
--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -15,7 +15,7 @@ import { CacheInfoBadge } from "@/components/cache-info-badge";
 import { LoadingBar } from "@/components/loading-bar";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Loader2, AlertCircle, ArrowLeft, RefreshCw, ChevronDown, ChevronUp, HelpCircle } from "lucide-react";
+import { Loader2, AlertCircle, ArrowLeft, RefreshCw, ChevronDown, ChevronUp, HelpCircle, ExternalLink, Info } from "lucide-react";
 import {
   Popover,
   PopoverContent,
@@ -210,10 +210,14 @@ export default function MatchPageClient() {
 
   const match = matchQuery.data;
 
-  // Match is complete when scoring ≥ 95% OR the match date is >3 days ago.
   const matchDateMs = match.date ? new Date(match.date).getTime() : null;
-  const isMatchComplete = match.scoring_completed >= 95 ||
+  // results_status === "all" is the definitive "published" signal from SSI.
+  // Fall back to scoring % and age heuristics for matches that haven't published yet.
+  const isMatchComplete = match.results_status === "all" ||
+    match.scoring_completed >= 95 ||
     (matchDateMs != null && (mountMs - matchDateMs) / 86_400_000 > 3);
+  const resultsPublished = match.results_status === "all";
+  const matchCancelled = match.match_status === "cs";
   const aiAvailable = coachingAvailability.data?.available === true;
 
   // Pick the older (more stale) cachedAt between match and compare responses.
@@ -251,6 +255,38 @@ export default function MatchPageClient() {
 
       {/* Match header */}
       <MatchHeader match={match} />
+
+      {/* Results disclaimer — shown whenever SSI has not publicly published results */}
+      {!resultsPublished && (
+        <div
+          role="alert"
+          className="flex items-start gap-2.5 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3.5 py-3 text-sm text-amber-900 dark:text-amber-200"
+        >
+          <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+          <span>
+            {matchCancelled
+              ? "This match was cancelled."
+              : "Results are not yet officially published by the organizers — data shown here may change."
+            }
+            {match.ssi_url && !matchCancelled && (
+              <>
+                {" "}
+                <a
+                  href={match.ssi_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 font-medium underline underline-offset-2 hover:text-amber-800 dark:hover:text-amber-100"
+                >
+                  ShootNScoreIt is the source of truth
+                  <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                  <span className="sr-only">(opens in new tab)</span>
+                </a>
+                .
+              </>
+            )}
+          </span>
+        </div>
+      )}
 
       {/* Competitor picker */}
       <div className="space-y-1">

--- a/components/match-header.tsx
+++ b/components/match-header.tsx
@@ -32,7 +32,7 @@ export function MatchHeader({ match }: MatchHeaderProps) {
     : null;
 
   const pct = match.scoring_completed ?? 0;
-  const isComplete = pct >= 100;
+  const isComplete = match.results_status === "all" || pct >= 100;
 
   return (
     <div className="space-y-3">

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,5 +13,6 @@ export const MAX_COMPETITORS = 12;
  *   1 → initial (implicit, unversioned entries)
  *   2 → added squads[] to MatchResponse (squad picker feature)
  *   3 → added image { url width height } to IpscMatchNode in MATCH_QUERY (OG images)
+ *   4 → added match_status + results_status to MatchResponse (results published flag)
  */
-export const CACHE_SCHEMA_VERSION = 3;
+export const CACHE_SCHEMA_VERSION = 4;

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -93,6 +93,8 @@ export const MATCH_QUERY = `
       name
       venue
       starts
+      status
+      results
       scoring_completed
       ... on IpscMatchNode {
         region

--- a/lib/match-data.ts
+++ b/lib/match-data.ts
@@ -48,6 +48,8 @@ export interface RawMatchData {
     name: string;
     starts: string | null;
     venue?: string | null;
+    status?: string | null;
+    results?: string | null;
     scoring_completed?: string | number | null;
     region?: string | null;
     sub_rule?: string | null;
@@ -106,8 +108,13 @@ export async function fetchMatchData(
   const scoringPct = Math.round(parseFloat(String(ev.scoring_completed ?? 0)));
   const matchDate = ev.starts ? new Date(ev.starts) : null;
   const daysSince = matchDate ? (Date.now() - matchDate.getTime()) / 86_400_000 : 0;
-  const isComplete = scoringPct >= 95 || daysSince > 3;
-  const ttl = computeMatchTtl(scoringPct, daysSince, ev.starts ?? null);
+  const resultsPublished = ev.results === "all";
+  const cancelled = ev.status === "cs";
+  // results=all or cancelled are definitive — cache permanently regardless of scoring %.
+  const ttl = (resultsPublished || cancelled)
+    ? null
+    : computeMatchTtl(scoringPct, daysSince, ev.starts ?? null);
+  const isComplete = resultsPublished || scoringPct >= 95 || daysSince > 3;
 
   try {
     if (ttl === null) {
@@ -176,6 +183,8 @@ export async function fetchMatchData(
       ev.scoring_completed != null
         ? Math.round(parseFloat(String(ev.scoring_completed)))
         : 0,
+    match_status: ev.status ?? "on",
+    results_status: ev.results ?? "org",
     ssi_url: `https://shootnscoreit.com/event/${ct}/${id}/`,
     stages,
     competitors,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -41,6 +41,10 @@ export interface MatchResponse {
   stages_count: number;
   competitors_count: number;
   scoring_completed: number; // percentage 0-100
+  /** SSI match lifecycle status: "dr" Draft | "on" Active | "ol" Active/no-self-edit | "pr" Preliminary | "cp" Completed | "cs" Cancelled */
+  match_status: string;
+  /** SSI results visibility: "org" organizers-only | "stg" scores-public | "cmp" participants-only | "all" publicly published */
+  results_status: string;
   ssi_url: string | null;
   stages: StageInfo[];
   competitors: CompetitorInfo[];

--- a/tests/components/match-header.test.tsx
+++ b/tests/components/match-header.test.tsx
@@ -14,6 +14,8 @@ const baseMatch: MatchResponse = {
   stages_count: 8,
   competitors_count: 105,
   scoring_completed: 56,
+  match_status: "on",
+  results_status: "org",
   ssi_url: "https://shootnscoreit.com/event/22/123/",
   stages: [],
   competitors: [],

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -13,6 +13,8 @@ const MOCK_MATCH: MatchResponse = {
   stages_count: 3,
   competitors_count: 10,
   scoring_completed: 75,
+  match_status: "on",
+  results_status: "org",
   ssi_url: "https://shootnscoreit.com/event/22/99999999/",
   stages: [
     { id: 1, name: "Stage 1", stage_number: 1, max_points: 80, min_rounds: 16, paper_targets: 8, steel_targets: 0, ssi_url: "https://shootnscoreit.com/event/stage/24/1/" },


### PR DESCRIPTION
## Summary

- Explored the SSI GraphQL API (`EventInterface`) and found two authoritative match state fields: `results` (org/stg/cmp/**all**) and `status` (dr/on/ol/pr/cp/cs). `results === "all"` is SSI's "Published" flag — the organizer has officially published results publicly.
- `results=all` or `status=cs` (cancelled) now short-circuit to a permanent cache TTL before `computeMatchTtl()` is called. The existing scoring % and age heuristics remain intact as fallback for the majority of matches that never explicitly publish via SSI.
- An amber disclaimer banner is shown on every match page until results are officially published, with a direct link to ShootNScoreIt as the source of truth. Cancelled matches show a simplified "Match was cancelled" message.
- `CACHE_SCHEMA_VERSION` bumped to 4 — old entries self-heal on first request, no manual flush needed.

## Key finding

`scoring_completed` can return `"0"` even for `status="cp"` (Completed) matches when `results` is not `"all"` — SSI hides it from non-organizers. This made it an unreliable primary permanence signal. The new `results` field is definitive.

## Test plan

- [ ] Typecheck: `pnpm -w run typecheck` — zero errors
- [ ] Unit + component tests: `pnpm -w test` — 512 tests passing
- [ ] Lint: `pnpm -w run lint` — zero warnings
- [ ] Load a live active match — amber banner should appear with SSI link
- [ ] Load a match with published results (`results=all`) — no banner, progress bar shows "Complete"
- [ ] Load a cancelled match — banner shows "This match was cancelled."

🤖 Generated with [Claude Code](https://claude.com/claude-code)