### PR TITLE
feat: stage archetype analysis (#176)

### DIFF
--- a/app/api/compare/logic.ts
+++ b/app/api/compare/logic.ts
@@ -12,9 +12,11 @@ import type {
   StyleFingerprintStats,
   FieldFingerprintPoint,
   ShooterArchetype,
+  StageArchetype,
   StageClassification,
   SimResult,
   WhatIfResult,
+  ArchetypePerformance,
 } from "@/lib/types";
 
 export interface RawScorecard {
@@ -1343,4 +1345,104 @@ export function computeStylePercentiles(
       : 50;
 
   return { composurePercentile, consistencyPercentile };
+}
+
+// ── Stage Archetype Classification ──────────────────────────────────────────
+
+// Minimum rounds threshold for "long course" classification (IPSC: ≥25 rounds).
+const LONG_COURSE_MIN_ROUNDS = 25;
+
+/**
+ * Classify a stage archetype based on target composition.
+ *
+ * Priority tiers:
+ *   1. paper + steel counts → steel ratio > 50% = speed; ≤ 30% AND long course = precision; else mixed
+ *   2. paper only (steel null/0) → long course = precision; else mixed
+ *   3. min_rounds only (no targets) → ≥ 25 = precision; else mixed
+ *   4. max_points only → implied rounds (max_points/5) ≥ 25 = precision; else null
+ *   5. nothing → null
+ */
+export function classifyStageArchetype(stage: {
+  paper_targets: number | null;
+  steel_targets: number | null;
+  min_rounds: number | null;
+  max_points: number;
+}): StageArchetype | null {
+  const { paper_targets, steel_targets, min_rounds, max_points } = stage;
+
+  const hasPaper = paper_targets != null && paper_targets > 0;
+  const hasSteel = steel_targets != null && steel_targets > 0;
+
+  // Priority 1: both paper and steel counts available
+  if (hasPaper || hasSteel) {
+    const totalTargets = (paper_targets ?? 0) + (steel_targets ?? 0);
+    if (totalTargets > 0) {
+      const steelRatio = (steel_targets ?? 0) / totalTargets;
+      if (steelRatio > 0.5) return "speed";
+      const isLong = min_rounds != null ? min_rounds >= LONG_COURSE_MIN_ROUNDS : false;
+      if (steelRatio <= 0.3 && isLong) return "precision";
+      return "mixed";
+    }
+  }
+
+  // Priority 2–3: min_rounds only
+  if (min_rounds != null && min_rounds > 0) {
+    return min_rounds >= LONG_COURSE_MIN_ROUNDS ? "precision" : "mixed";
+  }
+
+  // Priority 4: max_points fallback (5 pts per round in IPSC)
+  if (max_points > 0) {
+    const impliedRounds = max_points / 5;
+    return impliedRounds >= LONG_COURSE_MIN_ROUNDS ? "precision" : null;
+  }
+
+  // Priority 5: nothing
+  return null;
+}
+
+/**
+ * Compute per-archetype average performance for one competitor.
+ *
+ * Groups stages by archetype, computes avg group/div/overall % per bucket.
+ * Excludes DNF/DQ/zeroed stages. Returns only archetypes that have at least one stage.
+ */
+export function computeArchetypePerformance(
+  stages: StageComparison[],
+  competitorId: number
+): ArchetypePerformance[] {
+  const buckets = new Map<StageArchetype, { groupPcts: number[]; divPcts: number[]; overallPcts: number[] }>();
+
+  for (const stage of stages) {
+    if (!stage.stageArchetype) continue;
+    const sc = stage.competitors[competitorId];
+    if (!sc || sc.dnf || sc.dq || sc.zeroed) continue;
+
+    const bucket = buckets.get(stage.stageArchetype) ?? { groupPcts: [], divPcts: [], overallPcts: [] };
+    if (sc.group_percent != null) bucket.groupPcts.push(sc.group_percent);
+    if (sc.div_percent != null) bucket.divPcts.push(sc.div_percent);
+    if (sc.overall_percent != null) bucket.overallPcts.push(sc.overall_percent);
+    buckets.set(stage.stageArchetype, bucket);
+  }
+
+  const avg = (arr: number[]): number | null =>
+    arr.length > 0 ? arr.reduce((a, b) => a + b, 0) / arr.length : null;
+
+  // Return in consistent order: speed, precision, mixed
+  const order: StageArchetype[] = ["speed", "precision", "mixed"];
+  const result: ArchetypePerformance[] = [];
+  for (const archetype of order) {
+    const bucket = buckets.get(archetype);
+    if (!bucket) continue;
+    const stageCount = bucket.groupPcts.length || bucket.divPcts.length || bucket.overallPcts.length;
+    if (stageCount === 0) continue;
+    result.push({
+      archetype,
+      stageCount: Math.max(bucket.groupPcts.length, bucket.divPcts.length, bucket.overallPcts.length),
+      avgGroupPercent: avg(bucket.groupPcts),
+      avgDivPercent: avg(bucket.divPcts),
+      avgOverallPercent: avg(bucket.overallPcts),
+    });
+  }
+
+  return result;
 }

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -5,7 +5,7 @@ import cache from "@/lib/cache-impl";
 import { computeMatchTtl } from "@/lib/match-ttl";
 
 import { formatDivisionDisplay } from "@/lib/divisions";
-import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles } from "@/app/api/compare/logic";
+import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance } from "@/app/api/compare/logic";
 import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
 import type { CompareResponse, CompetitorInfo, StageComparison } from "@/lib/types";
 
@@ -191,7 +191,19 @@ export async function GET(req: Request) {
   );
 
   let stages: StageComparison[] = computeGroupRankings(rawScorecards, requestedCompetitors).map(
-    (s) => ({ ...s, ...stageMetaMap.get(s.stage_id) })
+    (s) => {
+      const meta = stageMetaMap.get(s.stage_id);
+      return {
+        ...s,
+        ...meta,
+        stageArchetype: classifyStageArchetype({
+          paper_targets: meta?.paper_targets ?? null,
+          steel_targets: meta?.steel_targets ?? null,
+          min_rounds: meta?.min_rounds ?? null,
+          max_points: s.max_points,
+        }),
+      };
+    }
   );
 
   // Fallback for future matches: if no scorecards exist yet but stage metadata is
@@ -213,6 +225,7 @@ export async function GET(req: Request) {
         field_competitor_count: 0,
         stageDifficultyLevel: 3 as const,
         stageDifficultyLabel: "—",
+        stageArchetype: null,
         competitors: {},
         ...(meta ?? {}),
       } satisfies StageComparison;
@@ -242,6 +255,10 @@ export async function GET(req: Request) {
 
   const lossBreakdownStats = Object.fromEntries(
     requestedCompetitors.map((c) => [c.id, computeLossBreakdown(stages, c.id)])
+  );
+
+  const archetypePerformance = Object.fromEntries(
+    requestedCompetitors.map((c) => [c.id, computeArchetypePerformance(stages, c.id)])
   );
 
   const whatIfStats = simulateWithoutWorstStage(stages, requestedCompetitors, rawScorecards);
@@ -313,6 +330,7 @@ export async function GET(req: Request) {
     whatIfStats,
     styleFingerprintStats,
     fieldFingerprintPoints,
+    archetypePerformance,
     cacheInfo,
   };
 

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -60,6 +60,13 @@ const StyleFingerprintChart = dynamic(
     ),
   { ssr: false, loading: ChartSkeleton },
 );
+const ArchetypePerformanceSummary = dynamic(
+  () =>
+    import("@/components/archetype-performance").then(
+      (m) => m.ArchetypePerformanceSummary,
+    ),
+  { ssr: false },
+);
 const ShooterStyleRadarChart = dynamic(
   () =>
     import("@/components/shooter-style-radar-chart").then(
@@ -526,6 +533,8 @@ export default function MatchPageClient() {
                     aria-labelledby="coaching-view-heading"
                     className="space-y-6 pt-2"
                   >
+
+                    <ArchetypePerformanceSummary data={compareQuery.data} />
 
                     <div className="space-y-2">
                       <div className="flex items-center gap-1.5">

--- a/components/archetype-performance.tsx
+++ b/components/archetype-performance.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+} from "@/components/ui/popover";
+import { Focus, HelpCircle, Layers, Timer } from "lucide-react";
+import { cn, formatPct } from "@/lib/utils";
+import { buildColorMap } from "@/lib/colors";
+import type { CompareResponse, StageArchetype } from "@/lib/types";
+
+const ARCHETYPE_DISPLAY: Record<StageArchetype, { icon: typeof Timer; label: string; shortLabel: string; color: string }> = {
+  speed: { icon: Timer, label: "Speed", shortLabel: "Speed", color: "text-blue-500" },
+  precision: { icon: Focus, label: "Precision", shortLabel: "Prec.", color: "text-purple-500" },
+  mixed: { icon: Layers, label: "Mixed", shortLabel: "Mixed", color: "text-muted-foreground" },
+};
+
+interface ArchetypePerformanceSummaryProps {
+  data: CompareResponse;
+}
+
+export function ArchetypePerformanceSummary({ data }: ArchetypePerformanceSummaryProps) {
+  const { competitors, archetypePerformance } = data;
+  if (!archetypePerformance) return null;
+
+  // Collect all unique archetypes across all competitors
+  const allArchetypes = new Set<StageArchetype>();
+  for (const compId of competitors.map((c) => c.id)) {
+    const perfs = archetypePerformance[compId];
+    if (perfs) {
+      for (const p of perfs) allArchetypes.add(p.archetype);
+    }
+  }
+
+  // Only render when ≥2 different archetypes exist (otherwise the split is meaningless)
+  if (allArchetypes.size < 2) return null;
+
+  const colorMap = buildColorMap(competitors.map((c) => c.id));
+  const archetypeOrder: StageArchetype[] = ["speed", "precision", "mixed"];
+  const visibleArchetypes = archetypeOrder.filter((a) => allArchetypes.has(a));
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-1.5">
+        <h3 className="text-sm font-semibold">Stage archetype breakdown</h3>
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+              aria-label="About stage archetypes"
+            >
+              <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-80" side="bottom" align="start">
+            <PopoverHeader>
+              <PopoverTitle>Stage archetype breakdown</PopoverTitle>
+              <PopoverDescription>Average performance grouped by stage type.</PopoverDescription>
+            </PopoverHeader>
+            <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
+              <p>Stages are classified based on target composition: <strong>Speed</strong> stages have &gt;50% steel targets, <strong>Precision</strong> stages are long courses (&ge;25 rounds) with &le;30% steel, and <strong>Mixed</strong> stages are everything in between.</p>
+              <p>Compare average group % across archetypes to spot if a shooter dominates one type but struggles on another. A large gap (&gt;5%) between archetypes suggests targeted practice opportunities.</p>
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm" role="table">
+          <thead>
+            <tr>
+              <th scope="col" className="text-left text-xs text-muted-foreground font-medium pr-3 pb-1">Type</th>
+              {competitors.map((comp) => (
+                <th
+                  key={comp.id}
+                  scope="col"
+                  className="text-center text-xs font-medium pb-1 px-2 truncate max-w-24"
+                  style={{ color: colorMap[comp.id] }}
+                >
+                  <span className="hidden sm:inline">{comp.name}</span>
+                  <span className="sm:hidden">{comp.name.split(" ")[0]}</span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {visibleArchetypes.map((archetype) => {
+              const { icon: Icon, label, shortLabel, color } = ARCHETYPE_DISPLAY[archetype];
+              // Find the stage count (same across competitors since it's stage-level)
+              const stageCount = competitors.reduce((max, c) => {
+                const perf = archetypePerformance[c.id]?.find((p) => p.archetype === archetype);
+                return Math.max(max, perf?.stageCount ?? 0);
+              }, 0);
+
+              return (
+                <tr key={archetype} className="border-t border-border/50">
+                  <td className="py-1.5 pr-3 whitespace-nowrap">
+                    <span className={cn("inline-flex items-center gap-1", color)}>
+                      <Icon className="w-3 h-3 flex-none" aria-hidden="true" />
+                      <span className="hidden sm:inline">{label}</span>
+                      <span className="sm:hidden">{shortLabel}</span>
+                      <span className="text-xs text-muted-foreground">({stageCount})</span>
+                    </span>
+                  </td>
+                  {competitors.map((comp) => {
+                    const perf = archetypePerformance[comp.id]?.find((p) => p.archetype === archetype);
+                    const pct = perf?.avgGroupPercent;
+                    return (
+                      <td key={comp.id} className="py-1.5 px-2 text-center tabular-nums text-sm">
+                        {pct != null ? formatPct(pct) : "—"}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <ArchetypeGapHighlight data={data} colorMap={colorMap} />
+    </div>
+  );
+}
+
+/** Highlights strongest vs weakest archetype gap per competitor. */
+function ArchetypeGapHighlight({ data, colorMap }: { data: CompareResponse; colorMap: Record<number, string> }) {
+  const { competitors, archetypePerformance } = data;
+
+  const highlights: { name: string; color: string; strongest: string; weakest: string; gap: number }[] = [];
+
+  for (const comp of competitors) {
+    const perfs = archetypePerformance[comp.id];
+    if (!perfs || perfs.length < 2) continue;
+
+    const withPct = perfs.filter((p) => p.avgGroupPercent != null);
+    if (withPct.length < 2) continue;
+
+    const sorted = [...withPct].sort((a, b) => (b.avgGroupPercent ?? 0) - (a.avgGroupPercent ?? 0));
+    const strongest = sorted[0];
+    const weakest = sorted[sorted.length - 1];
+    const gap = (strongest.avgGroupPercent ?? 0) - (weakest.avgGroupPercent ?? 0);
+
+    if (gap >= 3) {
+      highlights.push({
+        name: comp.name.split(" ")[0],
+        color: colorMap[comp.id],
+        strongest: ARCHETYPE_DISPLAY[strongest.archetype].label.toLowerCase(),
+        weakest: ARCHETYPE_DISPLAY[weakest.archetype].label.toLowerCase(),
+        gap,
+      });
+    }
+  }
+
+  if (highlights.length === 0) return null;
+
+  return (
+    <div className="text-xs text-muted-foreground space-y-0.5">
+      {highlights.map((h) => (
+        <p key={h.name}>
+          <span style={{ color: h.color }} className="font-medium">{h.name}</span>
+          {" "}strongest on {h.strongest}, weakest on {h.weakest} ({formatPct(h.gap)} gap)
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -12,14 +12,14 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { AlertTriangle, ArrowDown, ArrowRight, ArrowUp, CheckCircle2, ChevronDown, ChevronUp, Crosshair, ExternalLink, Flame, Gauge, HelpCircle, Info, Shield, Target, TrendingUp, X, Zap } from "lucide-react";
+import { AlertTriangle, ArrowDown, ArrowRight, ArrowUp, CheckCircle2, ChevronDown, ChevronUp, Crosshair, ExternalLink, Flame, Focus, Gauge, HelpCircle, Info, Layers, Shield, Target, Timer, TrendingUp, X, Zap } from "lucide-react";
 import { cn, formatHF, formatTime, formatPct, computePointsDelta, formatDelta } from "@/lib/utils";
 import { buildColorMap } from "@/lib/colors";
 import { HitZoneBar } from "@/components/hit-zone-bar";
 import { RankBadge, PenaltyBadge, ShootingOrderBadge, StageClassificationBadge, ordinal } from "@/components/stage-cell-parts";
 import { CellHelpModal } from "@/components/cell-help-modal";
 import { CoachingTip } from "@/components/coaching-tip";
-import type { CompareResponse, CompetitorInfo, CompetitorSummary, LossBreakdownStats, PctMode, ShooterArchetype, ViewMode, WhatIfResult } from "@/lib/types";
+import type { CompareResponse, CompetitorInfo, CompetitorSummary, LossBreakdownStats, PctMode, ShooterArchetype, StageArchetype, ViewMode, WhatIfResult } from "@/lib/types";
 
 interface ComparisonTableProps {
   data: CompareResponse;
@@ -150,6 +150,28 @@ function StageDifficultyIcon({
   );
 }
 
+
+const ARCHETYPE_CONFIG: Record<StageArchetype, { icon: typeof Timer; label: string; color: string }> = {
+  speed: { icon: Timer, label: "Speed stage", color: "text-blue-500" },
+  precision: { icon: Focus, label: "Precision stage", color: "text-purple-500" },
+  mixed: { icon: Layers, label: "Mixed stage", color: "text-muted-foreground" },
+};
+
+function StageArchetypeIcon({ archetype }: { archetype: StageArchetype }) {
+  const { icon: Icon, label, color } = ARCHETYPE_CONFIG[archetype];
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={cn("inline-flex cursor-help", color)} aria-label={label} role="img">
+          <Icon className="w-3 h-3" aria-hidden="true" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="text-xs">
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
 
 /**
  * Horizontal stacked bar showing: remaining points / hit-quality loss / penalty loss.
@@ -771,7 +793,15 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
                                 label={stage.stageDifficultyLabel}
                                 medianHF={stage.field_median_hf}
                               />
+                              {stage.stageArchetype && (
+                                <StageArchetypeIcon archetype={stage.stageArchetype} />
+                              )}
                             </div>
+                            {stage.stageArchetype && (
+                              <span className="text-xs text-muted-foreground">
+                                Type: {stage.stageArchetype.charAt(0).toUpperCase() + stage.stageArchetype.slice(1)}
+                              </span>
+                            )}
                             {(stage.min_rounds != null || stage.paper_targets != null ||
                               (stage.steel_targets != null && stage.steel_targets > 0)) && (
                               <span className="text-xs text-muted-foreground tabular-nums">
@@ -818,6 +848,9 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
                           label={stage.stageDifficultyLabel}
                           medianHF={stage.field_median_hf}
                         />
+                        {stage.stageArchetype && (
+                          <StageArchetypeIcon archetype={stage.stageArchetype} />
+                        )}
                       </div>
                       <span className="truncate max-w-32">{stage.stage_name}</span>
                       {(stage.min_rounds != null || stage.paper_targets != null ||

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -138,6 +138,7 @@ export interface StageComparison {
   field_competitor_count: number;     // count of valid field competitors contributing to the median
   stageDifficultyLevel: 1 | 2 | 3 | 4 | 5; // relative difficulty on a 1–5 scale (1=easy, 5=brutal)
   stageDifficultyLabel: string;       // human-readable label: easy/moderate/hard/very hard/brutal
+  stageArchetype?: StageArchetype | null; // speed / precision / mixed — null when target data is insufficient
   competitors: Record<number, CompetitorSummary>; // keyed by competitor_id
 }
 
@@ -188,6 +189,19 @@ export interface LossBreakdownStats {
   totalLoss: number;        // totalHitLoss + totalPenaltyLoss
   stagesFired: number;      // non-DNF, non-DQ, non-zeroed stages included in the breakdown
   hasHitZoneData: boolean;  // true if at least one stage had zone data (so hit loss is meaningful)
+}
+
+// Stage archetype based on target composition: speed (steel-heavy), precision
+// (paper-heavy long course), or mixed.
+export type StageArchetype = "speed" | "precision" | "mixed";
+
+// Per-archetype performance aggregate for one competitor.
+export interface ArchetypePerformance {
+  archetype: StageArchetype;
+  stageCount: number;
+  avgGroupPercent: number | null;
+  avgDivPercent: number | null;
+  avgOverallPercent: number | null;
 }
 
 export type ShooterArchetype = "Gunslinger" | "Surgeon" | "Speed Demon" | "Grinder";
@@ -276,6 +290,7 @@ export interface CompareResponse {
   whatIfStats: Record<number, WhatIfResult | null>;     // keyed by competitor_id; null = not enough stages
   styleFingerprintStats: Record<number, StyleFingerprintStats>; // keyed by competitor_id
   fieldFingerprintPoints: FieldFingerprintPoint[]; // all match competitors (for cohort cloud)
+  archetypePerformance: Record<number, ArchetypePerformance[]>; // keyed by competitor_id
   cacheInfo: CacheInfo;
 }
 

--- a/tests/components/comparison-chart.test.tsx
+++ b/tests/components/comparison-chart.test.tsx
@@ -75,6 +75,7 @@ const baseData: CompareResponse = {
   whatIfStats: {},
   styleFingerprintStats: {},
   fieldFingerprintPoints: [],
+  archetypePerformance: {},
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },

--- a/tests/components/comparison-table.test.tsx
+++ b/tests/components/comparison-table.test.tsx
@@ -24,6 +24,7 @@ const baseData: CompareResponse = {
   whatIfStats: {},
   styleFingerprintStats: {},
   fieldFingerprintPoints: [],
+  archetypePerformance: {},
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },

--- a/tests/components/radar-chart.test.tsx
+++ b/tests/components/radar-chart.test.tsx
@@ -15,6 +15,7 @@ const baseData: CompareResponse = {
   whatIfStats: {},
   styleFingerprintStats: {},
   fieldFingerprintPoints: [],
+  archetypePerformance: {},
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },

--- a/tests/components/scatter-chart.test.tsx
+++ b/tests/components/scatter-chart.test.tsx
@@ -15,6 +15,7 @@ const baseData: CompareResponse = {
   whatIfStats: {},
   styleFingerprintStats: {},
   fieldFingerprintPoints: [],
+  archetypePerformance: {},
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -63,6 +63,7 @@ const MOCK_COMPARE: CompareResponse = {
     300: { alphaRatio: null, pointsPerSecond: null, penaltyRate: null, totalA: 0, totalC: 0, totalD: 0, totalPoints: 0, totalTime: 0, totalPenalties: 0, totalRounds: 0, stagesFired: 0, accuracyPercentile: null, speedPercentile: null, archetype: null, composurePercentile: 50, consistencyPercentile: 50 },
   },
   fieldFingerprintPoints: [],
+  archetypePerformance: {},
   stages: [
     {
       stage_id: 1,

--- a/tests/unit/compare-logic.test.ts
+++ b/tests/unit/compare-logic.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { computeGroupRankings, computePenaltyStats, assignDifficulty, computePercentile, computePercentileRank, assignArchetype, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computeStylePercentiles, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
-import type { CompetitorInfo } from "@/lib/types";
+import { computeGroupRankings, computePenaltyStats, assignDifficulty, computePercentile, computePercentileRank, assignArchetype, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
+import type { CompetitorInfo, StageComparison } from "@/lib/types";
 
 const competitors: CompetitorInfo[] = [
   { id: 1, name: "Alice", competitor_number: "10", club: null, division: "hg1" },
@@ -2256,4 +2256,241 @@ describe("computeStylePercentiles", () => {
     expect(result.consistencyPercentile).toBe(50);
   });
 
+});
+
+// ── classifyStageArchetype ──────────────────────────────────────────────────
+
+describe("classifyStageArchetype", () => {
+  it("high steel ratio (> 50%) → speed", () => {
+    expect(classifyStageArchetype({
+      paper_targets: 3, steel_targets: 8, min_rounds: 12, max_points: 60,
+    })).toBe("speed");
+  });
+
+  it("steel exactly 50% → mixed (not speed, needs > 50%)", () => {
+    expect(classifyStageArchetype({
+      paper_targets: 5, steel_targets: 5, min_rounds: 12, max_points: 60,
+    })).toBe("mixed");
+  });
+
+  it("paper-heavy long course (steel ≤ 30%, ≥ 25 rounds) → precision", () => {
+    expect(classifyStageArchetype({
+      paper_targets: 10, steel_targets: 3, min_rounds: 28, max_points: 140,
+    })).toBe("precision");
+  });
+
+  it("paper-heavy short course (steel ≤ 30%, < 25 rounds) → mixed", () => {
+    expect(classifyStageArchetype({
+      paper_targets: 6, steel_targets: 1, min_rounds: 14, max_points: 70,
+    })).toBe("mixed");
+  });
+
+  it("balanced targets (steel 31–50%) → mixed regardless of length", () => {
+    expect(classifyStageArchetype({
+      paper_targets: 6, steel_targets: 4, min_rounds: 30, max_points: 150,
+    })).toBe("mixed");
+  });
+
+  it("paper only, no steel, long course → precision", () => {
+    expect(classifyStageArchetype({
+      paper_targets: 12, steel_targets: null, min_rounds: 26, max_points: 130,
+    })).toBe("precision");
+  });
+
+  it("paper only, no steel, short course → mixed", () => {
+    expect(classifyStageArchetype({
+      paper_targets: 6, steel_targets: null, min_rounds: 12, max_points: 60,
+    })).toBe("mixed");
+  });
+
+  it("min_rounds only (no targets), long → precision", () => {
+    expect(classifyStageArchetype({
+      paper_targets: null, steel_targets: null, min_rounds: 30, max_points: 150,
+    })).toBe("precision");
+  });
+
+  it("min_rounds only (no targets), short → mixed", () => {
+    expect(classifyStageArchetype({
+      paper_targets: null, steel_targets: null, min_rounds: 12, max_points: 60,
+    })).toBe("mixed");
+  });
+
+  it("max_points fallback, large (implied ≥ 25 rounds) → precision", () => {
+    expect(classifyStageArchetype({
+      paper_targets: null, steel_targets: null, min_rounds: null, max_points: 125,
+    })).toBe("precision");
+  });
+
+  it("max_points fallback, small (implied < 25 rounds) → null", () => {
+    expect(classifyStageArchetype({
+      paper_targets: null, steel_targets: null, min_rounds: null, max_points: 60,
+    })).toBeNull();
+  });
+
+  it("all null/zero metadata → null", () => {
+    expect(classifyStageArchetype({
+      paper_targets: null, steel_targets: null, min_rounds: null, max_points: 0,
+    })).toBeNull();
+  });
+
+  it("zero targets, zero rounds → null (falls through to max_points)", () => {
+    expect(classifyStageArchetype({
+      paper_targets: 0, steel_targets: 0, min_rounds: 0, max_points: 0,
+    })).toBeNull();
+  });
+
+  it("steel_targets=0, paper_targets > 0 with long course → precision", () => {
+    // hasPaper=true, hasSteel=false, but totalTargets > 0 so tier 1 applies
+    // steelRatio = 0/10 = 0 ≤ 0.3 AND min_rounds ≥ 25 → precision
+    expect(classifyStageArchetype({
+      paper_targets: 10, steel_targets: 0, min_rounds: 26, max_points: 130,
+    })).toBe("precision");
+  });
+
+  it("boundary: exactly 25 rounds → precision", () => {
+    expect(classifyStageArchetype({
+      paper_targets: null, steel_targets: null, min_rounds: 25, max_points: 125,
+    })).toBe("precision");
+  });
+
+  it("boundary: 24 rounds → mixed", () => {
+    expect(classifyStageArchetype({
+      paper_targets: null, steel_targets: null, min_rounds: 24, max_points: 120,
+    })).toBe("mixed");
+  });
+});
+
+// ── computeArchetypePerformance ─────────────────────────────────────────────
+
+describe("computeArchetypePerformance", () => {
+  // Helper to build a minimal StageComparison with archetype + competitor summary
+  function makeStageComp(
+    stageId: number,
+    archetype: "speed" | "precision" | "mixed" | null,
+    competitorSummaries: Record<number, { group_percent?: number | null; div_percent?: number | null; overall_percent?: number | null; dnf?: boolean; dq?: boolean; zeroed?: boolean }>
+  ): StageComparison {
+    const comps: Record<number, StageComparison["competitors"][number]> = {};
+    for (const [id, overrides] of Object.entries(competitorSummaries)) {
+      comps[Number(id)] = {
+        competitor_id: Number(id),
+        hit_factor: 4.0,
+        points: 80,
+        time: 20,
+        dq: overrides.dq ?? false,
+        zeroed: overrides.zeroed ?? false,
+        dnf: overrides.dnf ?? false,
+        incomplete: false,
+        a_hits: 10,
+        c_hits: 2,
+        d_hits: 0,
+        miss_count: 0,
+        no_shoots: 0,
+        procedurals: 0,
+        group_rank: 1,
+        group_percent: overrides.group_percent ?? 90,
+        div_rank: 1,
+        div_percent: overrides.div_percent ?? 85,
+        overall_rank: 1,
+        overall_percent: overrides.overall_percent ?? 80,
+        overall_percentile: 0.9,
+        stageClassification: null,
+        hitLossPoints: null,
+        penaltyLossPoints: 0,
+      };
+    }
+    return {
+      stage_id: stageId,
+      stage_name: `Stage ${stageId}`,
+      stage_num: stageId,
+      max_points: 100,
+      group_leader_hf: 5.0,
+      group_leader_points: 100,
+      overall_leader_hf: 5.5,
+      field_median_hf: 3.0,
+      field_competitor_count: 10,
+      stageDifficultyLevel: 3,
+      stageDifficultyLabel: "moderate",
+      stageArchetype: archetype,
+      competitors: comps,
+    };
+  }
+
+  it("computes correct avg group % per archetype bucket", () => {
+    const stages = [
+      makeStageComp(1, "speed", { 1: { group_percent: 90 } }),
+      makeStageComp(2, "speed", { 1: { group_percent: 80 } }),
+      makeStageComp(3, "precision", { 1: { group_percent: 70 } }),
+    ];
+    const result = computeArchetypePerformance(stages, 1);
+    expect(result).toHaveLength(2);
+    const speed = result.find((r) => r.archetype === "speed");
+    expect(speed).toBeDefined();
+    expect(speed!.stageCount).toBe(2);
+    expect(speed!.avgGroupPercent).toBeCloseTo(85, 5);
+    const precision = result.find((r) => r.archetype === "precision");
+    expect(precision).toBeDefined();
+    expect(precision!.stageCount).toBe(1);
+    expect(precision!.avgGroupPercent).toBeCloseTo(70, 5);
+  });
+
+  it("excludes DNF/DQ/zeroed stages", () => {
+    const stages = [
+      makeStageComp(1, "speed", { 1: { group_percent: 90 } }),
+      makeStageComp(2, "speed", { 1: { group_percent: 50, dnf: true } }),
+      makeStageComp(3, "speed", { 1: { group_percent: 0, dq: true } }),
+      makeStageComp(4, "speed", { 1: { group_percent: 0, zeroed: true } }),
+    ];
+    const result = computeArchetypePerformance(stages, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0].stageCount).toBe(1);
+    expect(result[0].avgGroupPercent).toBeCloseTo(90, 5);
+  });
+
+  it("returns only archetypes that have stages", () => {
+    const stages = [
+      makeStageComp(1, "mixed", { 1: { group_percent: 88 } }),
+    ];
+    const result = computeArchetypePerformance(stages, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0].archetype).toBe("mixed");
+  });
+
+  it("returns empty when no stages are classified (archetype=null)", () => {
+    const stages = [
+      makeStageComp(1, null, { 1: { group_percent: 90 } }),
+      makeStageComp(2, null, { 1: { group_percent: 80 } }),
+    ];
+    const result = computeArchetypePerformance(stages, 1);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty when competitor has no data on classified stages", () => {
+    const stages = [
+      makeStageComp(1, "speed", { 2: { group_percent: 90 } }), // competitor 2 only
+    ];
+    const result = computeArchetypePerformance(stages, 1); // ask for competitor 1
+    expect(result).toHaveLength(0);
+  });
+
+  it("computes avg div and overall % correctly", () => {
+    const stages = [
+      makeStageComp(1, "precision", { 1: { group_percent: 90, div_percent: 80, overall_percent: 70 } }),
+      makeStageComp(2, "precision", { 1: { group_percent: 70, div_percent: 60, overall_percent: 50 } }),
+    ];
+    const result = computeArchetypePerformance(stages, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0].avgGroupPercent).toBeCloseTo(80, 5);
+    expect(result[0].avgDivPercent).toBeCloseTo(70, 5);
+    expect(result[0].avgOverallPercent).toBeCloseTo(60, 5);
+  });
+
+  it("returns archetypes in consistent order: speed, precision, mixed", () => {
+    const stages = [
+      makeStageComp(1, "mixed", { 1: { group_percent: 80 } }),
+      makeStageComp(2, "speed", { 1: { group_percent: 90 } }),
+      makeStageComp(3, "precision", { 1: { group_percent: 70 } }),
+    ];
+    const result = computeArchetypePerformance(stages, 1);
+    expect(result.map((r) => r.archetype)).toEqual(["speed", "precision", "mixed"]);
+  });
 });


### PR DESCRIPTION
## Summary

- Classifies stages by target composition into **speed** (>50% steel), **precision** (paper-heavy long course ≥25 rounds, ≤30% steel), or **mixed** archetypes
- Adds archetype icon badges (Timer/Focus/Layers) next to difficulty bars in the comparison table — desktop inline, mobile in stage Info popover
- New `ArchetypePerformanceSummary` component in the Coaching analysis panel showing avg group % per archetype per competitor, with strongest-vs-weakest gap highlights
- Pure functions `classifyStageArchetype()` and `computeArchetypePerformance()` in `logic.ts` with tiered fallback classification and DNF/DQ/zeroed exclusion
- 22 new unit tests covering all classification tiers, edge cases, and aggregation logic

## Test plan

- [x] `pnpm -w run typecheck` — zero errors
- [x] `pnpm -w test` — 535 tests pass (22 new)
- [x] `pnpm -w run lint` — zero warnings
- [ ] `pnpm dev` → open a match with known target data → verify archetype badges on stages
- [ ] Open coaching panel → verify archetype breakdown table renders with ≥2 archetypes
- [ ] Verify mobile popover shows "Type: Speed/Precision/Mixed" text line
- [ ] Verify component hides when <2 archetypes exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)