### PR TITLE
feat: live/coaching mode split for active vs post-match analysis

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -7,7 +7,7 @@ import { computeMatchTtl } from "@/lib/match-ttl";
 import { formatDivisionDisplay } from "@/lib/divisions";
 import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance } from "@/app/api/compare/logic";
 import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
-import type { CompareResponse, CompetitorInfo, StageComparison } from "@/lib/types";
+import type { CompareMode, CompareResponse, CompetitorInfo, StageComparison } from "@/lib/types";
 
 interface RawCompetitor {
   id: string;
@@ -76,6 +76,9 @@ export async function GET(req: Request) {
       { status: 400 }
     );
   }
+
+  const modeParam = searchParams.get("mode");
+  const mode: CompareMode = modeParam === "live" ? "live" : "coaching";
 
   // Step 1 — fetch match metadata to determine TTL for scorecards
   const matchKey = gqlCacheKey("GetMatch", { ct: ctNum, id });
@@ -264,60 +267,73 @@ export async function GET(req: Request) {
     requestedCompetitors.map((c) => [c.id, computeLossBreakdown(stages, c.id)])
   );
 
-  const archetypePerformance = Object.fromEntries(
-    requestedCompetitors.map((c) => [c.id, computeArchetypePerformance(stages, c.id)])
-  );
+  // Coaching-only computations — skipped in live mode for faster responses
+  let archetypePerformance: CompareResponse["archetypePerformance"] = null;
+  let courseLengthPerformance: CompareResponse["courseLengthPerformance"] = null;
+  let constraintPerformance: CompareResponse["constraintPerformance"] = null;
+  let whatIfStats: CompareResponse["whatIfStats"] = null;
+  let fieldFingerprintPoints: CompareResponse["fieldFingerprintPoints"] = null;
+  let styleFingerprintStats: CompareResponse["styleFingerprintStats"] = null;
 
-  const courseLengthPerformance = Object.fromEntries(
-    requestedCompetitors.map((c) => [c.id, computeCourseLengthPerformance(stages, c.id)])
-  );
+  if (mode === "coaching") {
+    archetypePerformance = Object.fromEntries(
+      requestedCompetitors.map((c) => [c.id, computeArchetypePerformance(stages, c.id)])
+    );
 
-  const constraintPerformance = Object.fromEntries(
-    requestedCompetitors.map((c) => [c.id, computeConstraintPerformance(stages, c.id)])
-  );
+    courseLengthPerformance = Object.fromEntries(
+      requestedCompetitors.map((c) => [c.id, computeCourseLengthPerformance(stages, c.id)])
+    );
 
-  const whatIfStats = simulateWithoutWorstStage(stages, requestedCompetitors, rawScorecards);
+    constraintPerformance = Object.fromEntries(
+      requestedCompetitors.map((c) => [c.id, computeConstraintPerformance(stages, c.id)])
+    );
+
+    whatIfStats = simulateWithoutWorstStage(stages, requestedCompetitors, rawScorecards);
+  }
 
   const tPerCompetitor = performance.now();
 
-  // Build division map for the full field (used by the fingerprint cohort cloud)
-  const divisionMap = new Map<number, string | null>(
-    allCompetitors.map((c) => [parseInt(c.id, 10), c.get_handgun_div_display ?? c.handgun_div ?? null])
-  );
-  // fieldFingerprintPoints includes percentile ranks so we compute it before enriching
-  // the selected competitors' stats.
-  const fieldFingerprintPoints = computeAllFingerprintPoints(rawScorecards, divisionMap);
+  if (mode === "coaching") {
+    // Build division map for the full field (used by the fingerprint cohort cloud)
+    const divisionMap = new Map<number, string | null>(
+      allCompetitors.map((c) => [parseInt(c.id, 10), c.get_handgun_div_display ?? c.handgun_div ?? null])
+    );
+    // fieldFingerprintPoints includes percentile ranks so we compute it before enriching
+    // the selected competitors' stats.
+    const ffp = computeAllFingerprintPoints(rawScorecards, divisionMap);
+    fieldFingerprintPoints = ffp;
 
-  const fieldAlphaRatios = fieldFingerprintPoints.map((p) => p.alphaRatio);
-  const fieldSpeeds = fieldFingerprintPoints.map((p) => p.pointsPerSecond);
+    const fieldAlphaRatios = ffp.map((p) => p.alphaRatio);
+    const fieldSpeeds = ffp.map((p) => p.pointsPerSecond);
 
-  const styleFingerprintStats = Object.fromEntries(
-    requestedCompetitors.map((c) => {
-      const base = computeStyleFingerprint(stages, c.id);
-      const accuracyPercentile =
-        base.alphaRatio != null
-          ? computePercentileRank(base.alphaRatio, fieldAlphaRatios)
-          : null;
-      const speedPercentile =
-        base.pointsPerSecond != null
-          ? computePercentileRank(base.pointsPerSecond, fieldSpeeds)
-          : null;
-      const fieldPoint = fieldFingerprintPoints.find((p) => p.competitorId === c.id);
-      const { composurePercentile, consistencyPercentile } =
-        computeStylePercentiles(base, fieldPoint?.cv ?? null, fieldFingerprintPoints);
-      return [
-        c.id,
-        {
-          ...base,
-          accuracyPercentile,
-          speedPercentile,
-          archetype: assignArchetype(accuracyPercentile, speedPercentile),
-          composurePercentile,
-          consistencyPercentile,
-        },
-      ];
-    })
-  );
+    styleFingerprintStats = Object.fromEntries(
+      requestedCompetitors.map((c) => {
+        const base = computeStyleFingerprint(stages, c.id);
+        const accuracyPercentile =
+          base.alphaRatio != null
+            ? computePercentileRank(base.alphaRatio, fieldAlphaRatios)
+            : null;
+        const speedPercentile =
+          base.pointsPerSecond != null
+            ? computePercentileRank(base.pointsPerSecond, fieldSpeeds)
+            : null;
+        const fieldPoint = ffp.find((p) => p.competitorId === c.id);
+        const { composurePercentile, consistencyPercentile } =
+          computeStylePercentiles(base, fieldPoint?.cv ?? null, ffp);
+        return [
+          c.id,
+          {
+            ...base,
+            accuracyPercentile,
+            speedPercentile,
+            archetype: assignArchetype(accuracyPercentile, speedPercentile),
+            composurePercentile,
+            consistencyPercentile,
+          },
+        ];
+      })
+    );
+  }
 
   const tFingerprint = performance.now();
   console.log(JSON.stringify({
@@ -326,6 +342,7 @@ export async function GET(req: Request) {
     match_id: id,
     competitor_ids: competitorIds,
     competitor_count: competitorIds.length,
+    mode,
     match_cache_hit: matchCachedAt !== null,
     scorecards_cache_hit: scorecardsCachedAt !== null,
     scorecard_count: rawScorecards.length,
@@ -336,6 +353,7 @@ export async function GET(req: Request) {
 
   const response: CompareResponse = {
     match_id: parseInt(id, 10),
+    mode,
     stages,
     competitors: requestedCompetitors,
     penaltyStats,
@@ -351,14 +369,17 @@ export async function GET(req: Request) {
     cacheInfo,
   };
 
-  const serverTiming = [
+  const timingParts = [
     `graphql;dur=${(tFetch - t0).toFixed(1)};desc="GraphQL fetch"`,
     `flatten;dur=${(tFlatten - tFetch).toFixed(1)};desc="Scorecard flatten"`,
     `rankings;dur=${(tRankings - tFlatten).toFixed(1)};desc="Group rankings"`,
     `per-competitor;dur=${(tPerCompetitor - tRankings).toFixed(1)};desc="Per-competitor stats"`,
-    `fingerprint;dur=${(tFingerprint - tPerCompetitor).toFixed(1)};desc="Fingerprint"`,
-    `total;dur=${(tFingerprint - t0).toFixed(1)};desc="Total"`,
-  ].join(", ");
+  ];
+  if (mode === "coaching") {
+    timingParts.push(`fingerprint;dur=${(tFingerprint - tPerCompetitor).toFixed(1)};desc="Fingerprint"`);
+  }
+  timingParts.push(`total;dur=${(tFingerprint - t0).toFixed(1)};desc="Total"`);
+  const serverTiming = timingParts.join(", ");
 
   return NextResponse.json(response, {
     headers: { "Server-Timing": serverTiming },

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -10,7 +10,9 @@ import { CompetitorPicker } from "@/components/competitor-picker";
 import { SquadPicker } from "@/components/squad-picker";
 import { BenchmarkPicker } from "@/components/benchmark-picker";
 import { ComparisonTable } from "@/components/comparison-table";
+import { ModeToggle } from "@/components/mode-toggle";
 import { useMatchQuery, useCompareQuery, useCoachingAvailability } from "@/lib/queries";
+import { detectMode } from "@/lib/mode";
 import { CacheInfoBadge } from "@/components/cache-info-badge";
 import { LoadingBar } from "@/components/loading-bar";
 import { Button } from "@/components/ui/button";
@@ -29,6 +31,9 @@ import {
   saveCompetitorSelection,
   getCompetitorSelectionSnapshot,
   SELECTION_CHANGED,
+  saveModeOverride,
+  getModeOverrideSnapshot,
+  subscribeMode,
 } from "@/lib/competition-store";
 
 // Stable empty array for useSyncExternalStore server snapshot — must be a
@@ -157,13 +162,30 @@ export default function MatchPageClient() {
     () => EMPTY_IDS
   );
 
+  // Mode override from localStorage (useSyncExternalStore for SSR safety).
+  const modeOverride = useSyncExternalStore(
+    subscribeMode,
+    useCallback(() => getModeOverrideSnapshot(ct, id), [ct, id]),
+    () => null,
+  );
+
   const matchQuery = useMatchQuery(ct, id);
-  const compareQuery = useCompareQuery(ct, id, selectedIds);
-  const coachingAvailability = useCoachingAvailability();
 
   // Capture mount timestamp once to avoid impure Date.now() in render path.
-  // useState initializer runs once on mount and is stable across re-renders.
   const [mountMs] = useState(() => Date.now());
+
+  // Compute auto mode from match data (defaults to "coaching" until loaded).
+  const matchDateMs = matchQuery.data?.date ? new Date(matchQuery.data.date).getTime() : null;
+  const autoMode = matchQuery.data
+    ? detectMode(
+        matchQuery.data.scoring_completed,
+        matchDateMs != null ? (mountMs - matchDateMs) / 86_400_000 : 0,
+      )
+    : "coaching";
+  const effectiveMode = modeOverride ?? autoMode;
+
+  const compareQuery = useCompareQuery(ct, id, selectedIds, effectiveMode);
+  const coachingAvailability = useCoachingAvailability();
 
   // Save match to recents whenever data loads/changes (localStorage write, no setState).
   useEffect(() => {
@@ -238,12 +260,8 @@ export default function MatchPageClient() {
 
   const match = matchQuery.data;
 
-  const matchDateMs = match.date ? new Date(match.date).getTime() : null;
   // results_status === "all" is the definitive "published" signal from SSI.
-  // Fall back to scoring % and age heuristics for matches that haven't published yet.
-  const isMatchComplete = match.results_status === "all" ||
-    match.scoring_completed >= 95 ||
-    (matchDateMs != null && (mountMs - matchDateMs) / 86_400_000 > 3);
+  const isMatchComplete = match.results_status === "all" || effectiveMode === "coaching";
   const resultsPublished = match.results_status === "all";
   const matchCancelled = match.match_status === "cs";
   const aiAvailable = coachingAvailability.data?.available === true;
@@ -315,6 +333,43 @@ export default function MatchPageClient() {
           </span>
         </div>
       )}
+
+      {/* Mode toggle */}
+      <div className="space-y-1">
+        <div className="flex items-center gap-1.5">
+          <ModeToggle
+            autoMode={autoMode}
+            effectiveMode={effectiveMode}
+            onModeChange={(mode) => saveModeOverride(ct, id, mode)}
+          />
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+                aria-label="About live and coaching modes"
+              >
+                <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent className="w-80" side="bottom" align="start">
+              <PopoverHeader>
+                <PopoverTitle>Live vs Coaching mode</PopoverTitle>
+                <PopoverDescription>The app picks a mode based on match state. You can override it.</PopoverDescription>
+              </PopoverHeader>
+              <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
+                <p><strong>Live</strong> — for active matches. Refreshes every 30 seconds. Shows stage results, charts, and core stats only. Skips heavy analytics to keep things fast courtside.</p>
+                <p><strong>Coaching</strong> — for completed matches. Full analysis: style fingerprints, archetype breakdown, course-length splits, constraint performance, and the stage simulator.</p>
+                <p>The mode is auto-detected: matches with ≥ 95% scored or older than 3 days default to Coaching. Tap the other mode to override, or tap the active mode to reset to auto.</p>
+              </div>
+            </PopoverContent>
+          </Popover>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {effectiveMode === "live"
+            ? "Fast refresh, stage-focused view. Coaching analytics hidden."
+            : "Full analysis with style fingerprints, breakdowns, and simulator."}
+        </p>
+      </div>
 
       {/* Competitor picker */}
       <div className="space-y-1">
@@ -554,177 +609,182 @@ export default function MatchPageClient() {
                 <StageBalanceChart data={compareQuery.data} />
               </div>
 
-              {/* Coaching / analysis view — hidden by default (not for courtside use) */}
-              <div className="rounded-lg border p-4 space-y-3">
-                {/* WAI-ARIA accordion pattern: heading wraps the disclosure button */}
-                <h2 className="font-semibold text-base m-0 leading-none">
-                  <button
-                    type="button"
-                    id="coaching-view-heading"
-                    onClick={() => setShowCoachingView((v) => !v)}
-                    className="flex w-full items-center justify-between text-left gap-2"
-                    aria-expanded={showCoachingView}
-                    aria-controls="coaching-view-panel"
-                  >
-                    <span>
-                      Coaching analysis
-                      <span className="block text-xs font-normal text-muted-foreground mt-0.5">
-                        Post-match aggregate view — not recommended during active shooting.
-                      </span>
-                    </span>
-                    {showCoachingView ? (
-                      <ChevronUp className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />
-                    ) : (
-                      <ChevronDown className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />
-                    )}
-                  </button>
-                </h2>
-
-                {showCoachingView && (
-                  <section
-                    id="coaching-view-panel"
-                    role="region"
-                    aria-labelledby="coaching-view-heading"
-                    className="space-y-6 pt-2"
-                  >
-
-                    <CourseLengthSummary data={compareQuery.data} />
-                    <ConstraintSummary data={compareQuery.data} />
-                    <ArchetypePerformanceSummary data={compareQuery.data} />
-
-                    <div className="space-y-2">
-                      <div className="flex items-center gap-1.5">
-                        <h3 className="text-sm font-semibold">Shooter style fingerprint</h3>
-                        <Popover>
-                          <PopoverTrigger asChild>
-                            <button
-                              className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
-                              aria-label="About this chart"
-                            >
-                              <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
-                            </button>
-                          </PopoverTrigger>
-                          <PopoverContent className="w-80" side="bottom" align="start">
-                            <PopoverHeader>
-                              <PopoverTitle>Shooter style fingerprint</PopoverTitle>
-                              <PopoverDescription>Match-wide accuracy vs. speed plotted for each competitor.</PopoverDescription>
-                            </PopoverHeader>
-                            <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
-                              <p>Both axes are <strong>field percentile ranks</strong> (0–100): X = accuracy rank (A-zone ratio vs. the full field), Y = speed rank (pts/s vs. the full field). A value of 50 means exactly field median.</p>
-                              <p>The dashed crosshair is always at (50, 50) — the field median — so each quadrant contains roughly 25 % of the field. Quadrant labels: <strong>Gunslinger</strong> (fast & accurate), <strong>Surgeon</strong> (accurate, leaving time on table), <strong>Speed Demon</strong> (fast, bleeding points), <strong>Grinder</strong> (room to grow).</p>
-                              <p>Each competitor gets an archetype badge based on their quadrant. Hover a dot or check the legend to see the archetype with raw values (α%, pts/s) and exact percentile.</p>
-                              <p>Faded background dots = field cohort cloud. Use the Field overlay toggle to show all competitors, same division, or none. Dot size ∝ penalty rate.</p>
-                            </div>
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-                      <StyleFingerprintChart data={compareQuery.data} />
-                    </div>
-
-                    <div className="space-y-2">
-                      <div className="flex items-center gap-1.5">
-                        <h3 className="text-sm font-semibold">Shooter style profile</h3>
-                        <Popover>
-                          <PopoverTrigger asChild>
-                            <button
-                              className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
-                              aria-label="About this chart"
-                            >
-                              <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
-                            </button>
-                          </PopoverTrigger>
-                          <PopoverContent className="w-80" side="bottom" align="start">
-                            <PopoverHeader>
-                              <PopoverTitle>Shooter style profile</PopoverTitle>
-                              <PopoverDescription>Four-axis radar showing where each competitor ranks across key shooting dimensions.</PopoverDescription>
-                            </PopoverHeader>
-                            <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
-                              <p><strong>Speed</strong> — points-per-second percentile rank. 100 = fastest scorer in the field.</p>
-                              <p><strong>Accuracy</strong> — A-zone ratio percentile rank. 100 = highest proportion of alpha hits.</p>
-                              <p><strong>Composure</strong> — inverse penalty-rate rank. 100 = fewest misses, no-shoots, and procedurals per round fired.</p>
-                              <p><strong>Consistency</strong> — inverse stage-to-stage hit-factor variability rank. 100 = most repeatable across stages. Shows 50 when only one stage is available.</p>
-                              <p>The dashed polygon marks the field median (50th percentile on all axes). A larger polygon means a stronger overall profile.</p>
-                            </div>
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-                      <ShooterStyleRadarChart data={compareQuery.data} />
-                    </div>
-                  </section>
-                )}
-              </div>
-
-              {/* Stage Simulator — collapsed by default, only ≥ 80% complete */}
-              {match.scoring_completed >= 80 && (
-                <div className="rounded-lg border p-4">
-                  <div className="flex items-start gap-2">
-                    <h2 className="flex-1 font-semibold text-base m-0 leading-none">
+              {/* Coaching sections — only rendered in coaching mode */}
+              {effectiveMode === "coaching" && (
+                <>
+                  {/* Coaching / analysis view — hidden by default */}
+                  <div className="rounded-lg border p-4 space-y-3">
+                    {/* WAI-ARIA accordion pattern: heading wraps the disclosure button */}
+                    <h2 className="font-semibold text-base m-0 leading-none">
                       <button
                         type="button"
-                        id="stage-simulator-heading"
-                        onClick={() => setShowSimulator((v) => !v)}
+                        id="coaching-view-heading"
+                        onClick={() => setShowCoachingView((v) => !v)}
                         className="flex w-full items-center justify-between text-left gap-2"
-                        aria-expanded={showSimulator}
-                        aria-controls="stage-simulator-panel"
+                        aria-expanded={showCoachingView}
+                        aria-controls="coaching-view-panel"
                       >
                         <span>
-                          Stage Simulator
+                          Coaching analysis
                           <span className="block text-xs font-normal text-muted-foreground mt-0.5">
-                            What-if sandbox — the comparison table above is not affected.
+                            Post-match aggregate view — not recommended during active shooting.
                           </span>
                         </span>
-                        {showSimulator ? (
+                        {showCoachingView ? (
                           <ChevronUp className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />
                         ) : (
                           <ChevronDown className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />
                         )}
                       </button>
                     </h2>
-                    {showSimulator && (
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <button
-                            className="flex-none text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
-                            aria-label="About the stage simulator"
-                          >
-                            <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
-                          </button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-80" side="bottom" align="end">
-                          <PopoverHeader>
-                            <PopoverTitle>Stage Simulator</PopoverTitle>
-                            <PopoverDescription>
-                              Adjust one stage at a time to see how a cleaner run would affect your hit factor, stage percentage, and match rank.
-                            </PopoverDescription>
-                          </PopoverHeader>
-                          <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
-                            <p>Pick a competitor and stage, then dial in adjustments — faster time, converting misses or no-shoots to A or C hits, upgrading C or D-hits to A-hits, or removing procedural penalties.</p>
-                            <p>Adjust multiple stages independently; the match avg and group rank rows show the cumulative impact across all modified stages.</p>
-                            <p>Division rank and overall rank (vs the full field) appear below the group rank after a short delay — they reflect the simulated scorecards server-side.</p>
-                            <p>Your adjustments are saved per-stage and restored if you refresh the page.</p>
+
+                    {showCoachingView && (
+                      <section
+                        id="coaching-view-panel"
+                        role="region"
+                        aria-labelledby="coaching-view-heading"
+                        className="space-y-6 pt-2"
+                      >
+
+                        <CourseLengthSummary data={compareQuery.data} />
+                        <ConstraintSummary data={compareQuery.data} />
+                        <ArchetypePerformanceSummary data={compareQuery.data} />
+
+                        <div className="space-y-2">
+                          <div className="flex items-center gap-1.5">
+                            <h3 className="text-sm font-semibold">Shooter style fingerprint</h3>
+                            <Popover>
+                              <PopoverTrigger asChild>
+                                <button
+                                  className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+                                  aria-label="About this chart"
+                                >
+                                  <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                                </button>
+                              </PopoverTrigger>
+                              <PopoverContent className="w-80" side="bottom" align="start">
+                                <PopoverHeader>
+                                  <PopoverTitle>Shooter style fingerprint</PopoverTitle>
+                                  <PopoverDescription>Match-wide accuracy vs. speed plotted for each competitor.</PopoverDescription>
+                                </PopoverHeader>
+                                <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
+                                  <p>Both axes are <strong>field percentile ranks</strong> (0–100): X = accuracy rank (A-zone ratio vs. the full field), Y = speed rank (pts/s vs. the full field). A value of 50 means exactly field median.</p>
+                                  <p>The dashed crosshair is always at (50, 50) — the field median — so each quadrant contains roughly 25 % of the field. Quadrant labels: <strong>Gunslinger</strong> (fast & accurate), <strong>Surgeon</strong> (accurate, leaving time on table), <strong>Speed Demon</strong> (fast, bleeding points), <strong>Grinder</strong> (room to grow).</p>
+                                  <p>Each competitor gets an archetype badge based on their quadrant. Hover a dot or check the legend to see the archetype with raw values (α%, pts/s) and exact percentile.</p>
+                                  <p>Faded background dots = field cohort cloud. Use the Field overlay toggle to show all competitors, same division, or none. Dot size ∝ penalty rate.</p>
+                                </div>
+                              </PopoverContent>
+                            </Popover>
                           </div>
-                        </PopoverContent>
-                      </Popover>
+                          <StyleFingerprintChart data={compareQuery.data} />
+                        </div>
+
+                        <div className="space-y-2">
+                          <div className="flex items-center gap-1.5">
+                            <h3 className="text-sm font-semibold">Shooter style profile</h3>
+                            <Popover>
+                              <PopoverTrigger asChild>
+                                <button
+                                  className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+                                  aria-label="About this chart"
+                                >
+                                  <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                                </button>
+                              </PopoverTrigger>
+                              <PopoverContent className="w-80" side="bottom" align="start">
+                                <PopoverHeader>
+                                  <PopoverTitle>Shooter style profile</PopoverTitle>
+                                  <PopoverDescription>Four-axis radar showing where each competitor ranks across key shooting dimensions.</PopoverDescription>
+                                </PopoverHeader>
+                                <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
+                                  <p><strong>Speed</strong> — points-per-second percentile rank. 100 = fastest scorer in the field.</p>
+                                  <p><strong>Accuracy</strong> — A-zone ratio percentile rank. 100 = highest proportion of alpha hits.</p>
+                                  <p><strong>Composure</strong> — inverse penalty-rate rank. 100 = fewest misses, no-shoots, and procedurals per round fired.</p>
+                                  <p><strong>Consistency</strong> — inverse stage-to-stage hit-factor variability rank. 100 = most repeatable across stages. Shows 50 when only one stage is available.</p>
+                                  <p>The dashed polygon marks the field median (50th percentile on all axes). A larger polygon means a stronger overall profile.</p>
+                                </div>
+                              </PopoverContent>
+                            </Popover>
+                          </div>
+                          <ShooterStyleRadarChart data={compareQuery.data} />
+                        </div>
+                      </section>
                     )}
                   </div>
 
-                  {showSimulator && (
-                    <section
-                      id="stage-simulator-panel"
-                      role="region"
-                      aria-labelledby="stage-simulator-heading"
-                      className="pt-4"
-                    >
-                      <StageSimulator
-                        ct={ct}
-                        id={id}
-                        data={compareQuery.data}
-                        competitors={compareQuery.data.competitors}
-                        scoringCompleted={match.scoring_completed}
-                      />
-                    </section>
+                  {/* Stage Simulator — collapsed by default, only ≥ 80% complete */}
+                  {match.scoring_completed >= 80 && (
+                    <div className="rounded-lg border p-4">
+                      <div className="flex items-start gap-2">
+                        <h2 className="flex-1 font-semibold text-base m-0 leading-none">
+                          <button
+                            type="button"
+                            id="stage-simulator-heading"
+                            onClick={() => setShowSimulator((v) => !v)}
+                            className="flex w-full items-center justify-between text-left gap-2"
+                            aria-expanded={showSimulator}
+                            aria-controls="stage-simulator-panel"
+                          >
+                            <span>
+                              Stage Simulator
+                              <span className="block text-xs font-normal text-muted-foreground mt-0.5">
+                                What-if sandbox — the comparison table above is not affected.
+                              </span>
+                            </span>
+                            {showSimulator ? (
+                              <ChevronUp className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />
+                            ) : (
+                              <ChevronDown className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />
+                            )}
+                          </button>
+                        </h2>
+                        {showSimulator && (
+                          <Popover>
+                            <PopoverTrigger asChild>
+                              <button
+                                className="flex-none text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+                                aria-label="About the stage simulator"
+                              >
+                                <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                              </button>
+                            </PopoverTrigger>
+                            <PopoverContent className="w-80" side="bottom" align="end">
+                              <PopoverHeader>
+                                <PopoverTitle>Stage Simulator</PopoverTitle>
+                                <PopoverDescription>
+                                  Adjust one stage at a time to see how a cleaner run would affect your hit factor, stage percentage, and match rank.
+                                </PopoverDescription>
+                              </PopoverHeader>
+                              <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
+                                <p>Pick a competitor and stage, then dial in adjustments — faster time, converting misses or no-shoots to A or C hits, upgrading C or D-hits to A-hits, or removing procedural penalties.</p>
+                                <p>Adjust multiple stages independently; the match avg and group rank rows show the cumulative impact across all modified stages.</p>
+                                <p>Division rank and overall rank (vs the full field) appear below the group rank after a short delay — they reflect the simulated scorecards server-side.</p>
+                                <p>Your adjustments are saved per-stage and restored if you refresh the page.</p>
+                              </div>
+                            </PopoverContent>
+                          </Popover>
+                        )}
+                      </div>
+
+                      {showSimulator && (
+                        <section
+                          id="stage-simulator-panel"
+                          role="region"
+                          aria-labelledby="stage-simulator-heading"
+                          className="pt-4"
+                        >
+                          <StageSimulator
+                            ct={ct}
+                            id={id}
+                            data={compareQuery.data}
+                            competitors={compareQuery.data.competitors}
+                            scoringCompleted={match.scoring_completed}
+                          />
+                        </section>
+                      )}
+                    </div>
                   )}
-                </div>
+                </>
               )}
             </>
           )}

--- a/components/archetype-performance.tsx
+++ b/components/archetype-performance.tsx
@@ -130,6 +130,7 @@ export function ArchetypePerformanceSummary({ data }: ArchetypePerformanceSummar
 /** Highlights strongest vs weakest archetype gap per competitor. */
 function ArchetypeGapHighlight({ data, colorMap }: { data: CompareResponse; colorMap: Record<number, string> }) {
   const { competitors, archetypePerformance } = data;
+  if (!archetypePerformance) return null;
 
   const highlights: { name: string; color: string; strongest: string; weakest: string; gap: number }[] = [];
 

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -547,7 +547,9 @@ function ArchetypePill({ archetype, color }: { archetype: ShooterArchetype; colo
 }
 
 export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable, isComplete, ct, matchId }: ComparisonTableProps) {
-  const { stages, competitors, penaltyStats, efficiencyStats, consistencyStats, lossBreakdownStats, whatIfStats, styleFingerprintStats } = data;
+  const { stages, competitors, penaltyStats, efficiencyStats, consistencyStats, lossBreakdownStats } = data;
+  const whatIfStats = data.whatIfStats;
+  const styleFingerprintStats = data.styleFingerprintStats;
   const [mode, setMode] = useState<PctMode>(
     competitors.length < 2 ? "division" : "group"
   );
@@ -774,7 +776,7 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
                         </Tooltip>
                       )}
                       {(() => {
-                        const archetype = styleFingerprintStats[comp.id]?.archetype;
+                        const archetype = styleFingerprintStats?.[comp.id]?.archetype;
                         return archetype ? (
                           <ArchetypePill archetype={archetype} color={colorMap[comp.id]} />
                         ) : null;
@@ -1200,7 +1202,7 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
       )}
 
       {/* What if? panel — only rendered when match is ≥ 80 % complete */}
-      {scoringCompleted >= 80 && competitors.some((c) => whatIfStats[c.id] != null) && (
+      {whatIfStats && scoringCompleted >= 80 && competitors.some((c) => whatIfStats[c.id] != null) && (
         <div className="rounded-lg border border-sky-200 dark:border-sky-900/50">
           <button
             id="whatif-heading"
@@ -1238,7 +1240,7 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
               </div>
               <div className="space-y-5">
                 {competitors.map((comp) => {
-                  const wi = whatIfStats[comp.id];
+                  const wi = whatIfStats?.[comp.id];
                   if (!wi) return null;
                   const stageName =
                     stages.find((s) => s.stage_num === wi.worstStageNum)?.stage_name ??

--- a/components/mode-toggle.tsx
+++ b/components/mode-toggle.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import type { CompareMode } from "@/lib/types";
+
+interface ModeToggleProps {
+  /** The mode the system would choose automatically. */
+  autoMode: CompareMode;
+  /** The mode currently in effect (override ?? autoMode). */
+  effectiveMode: CompareMode;
+  /** Called with a mode to set an override, or null to clear the override. */
+  onModeChange: (mode: CompareMode | null) => void;
+}
+
+const OPTIONS: { value: CompareMode; label: string }[] = [
+  { value: "live", label: "Live" },
+  { value: "coaching", label: "Coaching" },
+];
+
+export function ModeToggle({ autoMode, effectiveMode, onModeChange }: ModeToggleProps) {
+  const groupRef = useRef<HTMLDivElement>(null);
+
+  const handleClick = useCallback(
+    (value: CompareMode) => {
+      if (value === effectiveMode && value === autoMode) {
+        // Already on auto — no-op
+        return;
+      }
+      if (value === effectiveMode) {
+        // Tapping the active button when override is set → clear override
+        onModeChange(null);
+      } else {
+        onModeChange(value);
+      }
+    },
+    [effectiveMode, autoMode, onModeChange],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      let nextIdx = -1;
+      const currentIdx = OPTIONS.findIndex((o) => o.value === (e.currentTarget.dataset.value as CompareMode));
+      if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        nextIdx = (currentIdx + 1) % OPTIONS.length;
+      } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        nextIdx = (currentIdx - 1 + OPTIONS.length) % OPTIONS.length;
+      }
+      if (nextIdx >= 0) {
+        const next = OPTIONS[nextIdx];
+        handleClick(next.value);
+        const buttons = groupRef.current?.querySelectorAll<HTMLButtonElement>("[role=radio]");
+        buttons?.[nextIdx]?.focus();
+      }
+    },
+    [handleClick],
+  );
+
+  // Whether the user has an active override (effectiveMode !== autoMode)
+  const hasOverride = effectiveMode !== autoMode;
+
+  return (
+    <div
+      ref={groupRef}
+      role="radiogroup"
+      aria-label="Compare mode"
+      className="inline-flex rounded-lg border border-border bg-muted/50 p-0.5"
+    >
+      {OPTIONS.map((opt, i) => {
+        const isActive = opt.value === effectiveMode;
+        const showAuto = opt.value === autoMode && !hasOverride;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            data-value={opt.value}
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => handleClick(opt.value)}
+            onKeyDown={handleKeyDown}
+            className={[
+              "relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+              "min-h-[2.75rem] min-w-[5.5rem]",
+              "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+              isActive
+                ? "bg-primary text-primary-foreground shadow-sm"
+                : "bg-transparent text-muted-foreground hover:text-foreground",
+              i === 0 ? "rounded-r-md" : "rounded-l-md",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+          >
+            {opt.label}
+            {showAuto && (
+              <span className={isActive ? "text-primary-foreground/70" : "text-muted-foreground/70"}> (auto)</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/shooter-style-radar-chart.tsx
+++ b/components/shooter-style-radar-chart.tsx
@@ -107,6 +107,14 @@ export function ShooterStyleRadarChart({ data }: ShooterStyleRadarChartProps) {
   const colorMap = buildColorMap(competitors.map((c) => c.id));
   const [hiddenIds, setHiddenIds] = useState<Set<number>>(new Set());
 
+  if (!styleFingerprintStats) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Not enough scored stages to display the style profile.
+      </p>
+    );
+  }
+
   const radarData = AXES.map((axis) => {
     const row: Record<string, string | number> = { axis };
     for (const comp of competitors) {

--- a/components/stage-simulator.tsx
+++ b/components/stage-simulator.tsx
@@ -772,8 +772,8 @@ export function StageSimulator({ ct, id, data, competitors, scoringCompleted }: 
                   )}
                   {/* Div / overall rank — always shown; current from whatIfStats, simulated from server */}
                   {(() => {
-                    const currentDivRank = data.whatIfStats[selectedComp.id]?.actualDivRank ?? null;
-                    const currentOverallRank = data.whatIfStats[selectedComp.id]?.actualOverallRank ?? null;
+                    const currentDivRank = data.whatIfStats?.[selectedComp.id]?.actualDivRank ?? null;
+                    const currentOverallRank = data.whatIfStats?.[selectedComp.id]?.actualOverallRank ?? null;
                     const simDivRank = serverRank?.newDivRank ?? null;
                     const simOverallRank = serverRank?.newOverallRank ?? null;
                     const divRankDelta = simDivRank != null && currentDivRank != null ? currentDivRank - simDivRank : null;

--- a/components/style-fingerprint-chart.tsx
+++ b/components/style-fingerprint-chart.tsx
@@ -411,6 +411,15 @@ export function StyleFingerprintChart({ data }: StyleFingerprintChartProps) {
   const [hiddenIds, setHiddenIds] = useState<Set<number>>(new Set());
   const [cohortMode, setCohortMode] = useState<CohortMode>("all");
 
+  // Live mode returns null for these fields — early return.
+  if (!styleFingerprintStats || !fieldFingerprintPoints) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Not enough scored stages to display the style fingerprint.
+      </p>
+    );
+  }
+
   const selectedPoints = buildSelectedPoints(competitors, styleFingerprintStats);
   const selectedIds = new Set(competitors.map((c) => c.id));
 
@@ -447,7 +456,7 @@ export function StyleFingerprintChart({ data }: StyleFingerprintChartProps) {
     id: comp.id,
     label: formatLabel(comp),
     color: colorMap[comp.id],
-    archetype: styleFingerprintStats[comp.id]?.archetype ?? null,
+    archetype: styleFingerprintStats?.[comp.id]?.archetype ?? null,
   }));
 
   return (

--- a/lib/api-data.ts
+++ b/lib/api-data.ts
@@ -68,6 +68,7 @@ export async function compareCompetitors(
   p.set("ct", ct);
   p.set("id", id);
   p.set("competitor_ids", competitorIds.join(","));
+  p.set("mode", "coaching");
   const res = await compareGET(new Request(`http://localhost/api/compare?${p}`));
   return extractJson<CompareResponse>(res);
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,6 +2,7 @@
 // NOT the SSI API directly (which has no CORS headers).
 
 import type {
+  CompareMode,
   MatchResponse,
   CompareResponse,
   EventSummary,
@@ -51,7 +52,8 @@ export async function fetchPopularMatches(): Promise<PopularMatch[]> {
 export async function fetchCompare(
   ct: string,
   id: string,
-  competitorIds: number[]
+  competitorIds: number[],
+  mode: CompareMode = "coaching",
 ): Promise<CompareResponse> {
   if (competitorIds.length === 0) {
     throw new Error("No competitor IDs provided");
@@ -60,6 +62,7 @@ export async function fetchCompare(
     ct,
     id,
     competitor_ids: competitorIds.join(","),
+    mode,
   });
   const res = await fetch(`/api/compare?${params}`);
   if (!res.ok) {

--- a/lib/competition-store.ts
+++ b/lib/competition-store.ts
@@ -1,4 +1,4 @@
-import type { MatchResponse } from "@/lib/types";
+import type { CompareMode, MatchResponse } from "@/lib/types";
 
 export interface StoredCompetition {
   ct: string;
@@ -18,6 +18,9 @@ export const RECENTS_CHANGED = "ssi:recents_changed";
 
 /** Custom event dispatched (same-tab) whenever a competitor selection changes. */
 export const SELECTION_CHANGED = "ssi:selection_changed";
+
+/** Custom event dispatched (same-tab) whenever a mode override changes. */
+export const MODE_CHANGED = "ssi:mode_changed";
 
 function competitorKey(ct: string, id: string): string {
   return `ssi_competitors_${ct}_${id}`;
@@ -159,4 +162,55 @@ export function getCompetitorSelectionSnapshot(
   }
   _selCache.set(key, { json: raw ?? "", ids });
   return ids;
+}
+
+// ---------------------------------------------------------------------------
+// Mode override — helpers
+// ---------------------------------------------------------------------------
+
+function modeKey(ct: string, id: string): string {
+  return `ssi_mode_${ct}_${id}`;
+}
+
+/** Save a mode override for this match. Pass null to clear (revert to auto). */
+export function saveModeOverride(ct: string, id: string, mode: CompareMode | null): void {
+  if (typeof window === "undefined") return;
+  try {
+    const key = modeKey(ct, id);
+    if (mode === null) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, mode);
+    }
+    window.dispatchEvent(new Event(MODE_CHANGED));
+  } catch {
+    // ignore
+  }
+}
+
+/** Stable-reference snapshot cache for mode override. */
+const _modeCache = new Map<string, { raw: string | null; mode: CompareMode | null }>();
+
+export function getModeOverrideSnapshot(ct: string, id: string): CompareMode | null {
+  if (typeof window === "undefined") return null;
+  const key = modeKey(ct, id);
+  const raw = localStorage.getItem(key);
+  const cached = _modeCache.get(key);
+  if (cached && cached.raw === raw) return cached.mode;
+  const mode = raw === "live" || raw === "coaching" ? raw : null;
+  _modeCache.set(key, { raw, mode });
+  return mode;
+}
+
+/**
+ * Subscribe function for useSyncExternalStore — mode override.
+ * Listens for same-tab MODE_CHANGED and cross-tab storage events.
+ */
+export function subscribeMode(onChange: () => void): () => void {
+  window.addEventListener(MODE_CHANGED, onChange);
+  window.addEventListener("storage", onChange);
+  return () => {
+    window.removeEventListener(MODE_CHANGED, onChange);
+    window.removeEventListener("storage", onChange);
+  };
 }

--- a/lib/mcp-tools.ts
+++ b/lib/mcp-tools.ts
@@ -267,7 +267,7 @@ function createHttpProviders(baseUrl: string): DataProviders {
     },
     getMatch: (ct, id) => apiFetch<MatchResponse>(baseUrl, `/api/match/${ct}/${id}`),
     compareCompetitors: (ct, id, ids) => {
-      const p = new URLSearchParams({ ct, id, competitor_ids: ids.join(",") });
+      const p = new URLSearchParams({ ct, id, competitor_ids: ids.join(","), mode: "coaching" });
       return apiFetch<CompareResponse>(baseUrl, `/api/compare?${p}`);
     },
     getPopularMatches: () => apiFetch<PopularMatch[]>(baseUrl, "/api/popular-matches"),

--- a/lib/mode.ts
+++ b/lib/mode.ts
@@ -1,0 +1,11 @@
+import type { CompareMode } from "./types";
+
+/**
+ * Determine the default compare mode based on match state.
+ * "coaching" for completed matches (≥ 95% scored or > 3 days old).
+ * "live" for active matches where fast polling matters.
+ */
+export function detectMode(scoringPct: number, daysSinceMatch: number): CompareMode {
+  if (scoringPct >= 95 || daysSinceMatch > 3) return "coaching";
+  return "live";
+}

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { fetchMatch, fetchCompare, fetchEvents, fetchPopularMatches, fetchCoachingAvailability, fetchCoachingTip } from "@/lib/api";
-import type { MatchResponse, CompareResponse, EventSummary, PopularMatch, CoachingTipResponse, CoachingAvailability } from "@/lib/types";
+import type { CompareMode, MatchResponse, CompareResponse, EventSummary, PopularMatch, CoachingTipResponse, CoachingAvailability } from "@/lib/types";
 import { matchQueryKey, compareQueryKey, coachingAvailabilityKey, coachingTipQueryKey } from "@/lib/query-keys";
 
 // Re-export so existing imports from lib/queries keep working.
@@ -43,13 +43,14 @@ export function usePopularMatchesQuery() {
 export function useCompareQuery(
   ct: string,
   id: string,
-  competitorIds: number[]
+  competitorIds: number[],
+  mode: CompareMode = "coaching",
 ) {
   return useQuery<CompareResponse, Error>({
-    queryKey: compareQueryKey(ct, id, competitorIds),
-    queryFn: () => fetchCompare(ct, id, competitorIds),
-    staleTime: 30_000, // 30 seconds — aligned with server cache TTL
-    refetchInterval: 30_000, // poll every 30s while mounted
+    queryKey: compareQueryKey(ct, id, competitorIds, mode),
+    queryFn: () => fetchCompare(ct, id, competitorIds, mode),
+    staleTime: mode === "live" ? 30_000 : 300_000,
+    refetchInterval: mode === "live" ? 30_000 : false,
     enabled: Boolean(ct && id && competitorIds.length > 0),
   });
 }

--- a/lib/query-keys.ts
+++ b/lib/query-keys.ts
@@ -2,6 +2,8 @@
 // server-side prefetch calls (e.g. app/match/.../page.tsx).
 // This file has NO "use client" directive so it can be imported by both.
 
+import type { CompareMode } from "@/lib/types";
+
 export const matchQueryKey = (ct: string, id: string) =>
   ["match", ct, id] as const;
 
@@ -9,7 +11,8 @@ export const compareQueryKey = (
   ct: string,
   id: string,
   competitorIds: number[],
-) => ["compare", ct, id, competitorIds] as const;
+  mode: CompareMode = "coaching",
+) => ["compare", ct, id, competitorIds, mode] as const;
 
 export const coachingAvailabilityKey = () =>
   ["coaching-availability"] as const;

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -17,11 +17,13 @@ export const RELEASES: Release[] = [
   {
     id: LATEST_RELEASE_ID,
     date: "March 1, 2026",
-    title: "Stage Archetype Analysis, Division Position Chart & Constraint Analytics",
+    title: "Live/Coaching Mode & Stage Analytics",
     sections: [
       {
         heading: "New",
         items: [
+          "Live/Coaching mode: the app now auto-detects whether a match is active or complete. Live mode skips heavy analytics for fast 30s polling; Coaching mode loads the full analysis suite.",
+          "Mode toggle between the match header and competitor picker lets you override the auto-detected mode. Tap the active button to reset to auto.",
           "Stage archetype badges: stages are now classified as Speed, Precision, or Mixed based on target composition — look for the icon next to the difficulty bars.",
           "Archetype performance breakdown in the Coaching analysis panel: compare average group % across stage types to spot strengths and weaknesses.",
           "Division position chart: see where each competitor sits within their division's HF distribution per stage — the shaded band shows the middle 50% (Q1–Q3) of the division, with the median and minimum as reference lines.",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -181,6 +181,11 @@ export type StageClassification = "solid" | "conservative" | "over-push" | "melt
 // "overall"  — HF % relative to the overall stage winner (full field, all divisions)
 export type PctMode = "group" | "division" | "overall";
 
+// Whether the compare API returns full coaching analytics or just live stage data.
+// "live"     — active match; expensive analytics skipped for fast 30s polling
+// "coaching" — post-match; full fingerprint, archetype, what-if, etc.
+export type CompareMode = "live" | "coaching";
+
 // View mode for the comparison table.
 // "absolute" — shows raw hit factor, points, and percentage
 // "delta"    — shows gap to the group leader per stage (±X.X pts)
@@ -333,18 +338,19 @@ export interface WhatIfResult {
 
 export interface CompareResponse {
   match_id: number;
+  mode: CompareMode;
   stages: StageComparison[];
   competitors: CompetitorInfo[];
   penaltyStats: Record<number, CompetitorPenaltyStats>; // keyed by competitor_id
   efficiencyStats: Record<number, EfficiencyStats>;     // keyed by competitor_id
   consistencyStats: Record<number, ConsistencyStats>;   // keyed by competitor_id
   lossBreakdownStats: Record<number, LossBreakdownStats>; // keyed by competitor_id
-  whatIfStats: Record<number, WhatIfResult | null>;     // keyed by competitor_id; null = not enough stages
-  styleFingerprintStats: Record<number, StyleFingerprintStats>; // keyed by competitor_id
-  fieldFingerprintPoints: FieldFingerprintPoint[]; // all match competitors (for cohort cloud)
-  archetypePerformance: Record<number, ArchetypePerformance[]>; // keyed by competitor_id
-  courseLengthPerformance: Record<number, CourseLengthPerformance[]>; // keyed by competitor_id
-  constraintPerformance: Record<number, ConstraintPerformance>; // keyed by competitor_id
+  whatIfStats: Record<number, WhatIfResult | null> | null;     // null in live mode
+  styleFingerprintStats: Record<number, StyleFingerprintStats> | null; // null in live mode
+  fieldFingerprintPoints: FieldFingerprintPoint[] | null; // null in live mode
+  archetypePerformance: Record<number, ArchetypePerformance[]> | null; // null in live mode
+  courseLengthPerformance: Record<number, CourseLengthPerformance[]> | null; // null in live mode
+  constraintPerformance: Record<number, ConstraintPerformance> | null; // null in live mode
   cacheInfo: CacheInfo;
 }
 

--- a/tests/components/comparison-chart.test.tsx
+++ b/tests/components/comparison-chart.test.tsx
@@ -65,6 +65,7 @@ const baseStageCompetitors = {
 
 const baseData: CompareResponse = {
   match_id: 26547,
+  mode: "coaching",
   cacheInfo: { cachedAt: null },
   penaltyStats: {
     1: { totalPenalties: 0, penaltyCostPercent: 0, matchPctActual: 100, matchPctClean: 100, penaltiesPerStage: 0, penaltiesPer100Rounds: 0 },

--- a/tests/components/comparison-table.test.tsx
+++ b/tests/components/comparison-table.test.tsx
@@ -10,6 +10,7 @@ function renderWithProviders(ui: React.ReactElement) {
 
 const baseData: CompareResponse = {
   match_id: 26547,
+  mode: "coaching",
   cacheInfo: { cachedAt: null },
   competitors: [
     { id: 1, name: "Alice Smith", competitor_number: "35", club: null, division: "Open Major" },

--- a/tests/components/radar-chart.test.tsx
+++ b/tests/components/radar-chart.test.tsx
@@ -5,6 +5,7 @@ import type { CompareResponse } from "@/lib/types";
 
 const baseData: CompareResponse = {
   match_id: 26547,
+  mode: "coaching",
   cacheInfo: { cachedAt: null },
   penaltyStats: {
     1: { totalPenalties: 0, penaltyCostPercent: 0, matchPctActual: 100, matchPctClean: 100, penaltiesPerStage: 0, penaltiesPer100Rounds: 0 },

--- a/tests/components/scatter-chart.test.tsx
+++ b/tests/components/scatter-chart.test.tsx
@@ -5,6 +5,7 @@ import type { CompareResponse } from "@/lib/types";
 
 const baseData: CompareResponse = {
   match_id: 26547,
+  mode: "coaching",
   cacheInfo: { cachedAt: null },
   penaltyStats: {
     1: { totalPenalties: 0, penaltyCostPercent: 0, matchPctActual: 100, matchPctClean: 100, penaltiesPerStage: 0, penaltiesPer100Rounds: 0 },

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -34,6 +34,7 @@ const MOCK_MATCH: MatchResponse = {
 
 const MOCK_COMPARE: CompareResponse = {
   match_id: 99999999,
+  mode: "coaching",
   cacheInfo: { cachedAt: null },
   competitors: [
     MOCK_MATCH.competitors[0],

--- a/tests/unit/mode.test.ts
+++ b/tests/unit/mode.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { detectMode } from "@/lib/mode";
+
+describe("detectMode", () => {
+  it("returns 'live' for active match (0% scored, day 0)", () => {
+    expect(detectMode(0, 0)).toBe("live");
+  });
+
+  it("returns 'live' for active match (50% scored, day 1)", () => {
+    expect(detectMode(50, 1)).toBe("live");
+  });
+
+  it("returns 'live' just below threshold (94% scored, day 3)", () => {
+    expect(detectMode(94, 3)).toBe("live");
+  });
+
+  it("returns 'coaching' at 95% scored", () => {
+    expect(detectMode(95, 0)).toBe("coaching");
+  });
+
+  it("returns 'coaching' at 100% scored", () => {
+    expect(detectMode(100, 0)).toBe("coaching");
+  });
+
+  it("returns 'coaching' when > 3 days old even if 0% scored", () => {
+    expect(detectMode(0, 4)).toBe("coaching");
+  });
+
+  it("returns 'live' at exactly 3 days", () => {
+    expect(detectMode(0, 3)).toBe("live");
+  });
+
+  it("returns 'coaching' at 3.01 days", () => {
+    expect(detectMode(0, 3.01)).toBe("coaching");
+  });
+});


### PR DESCRIPTION
## Summary

- Auto-detects match status and splits into **Live** mode (fast 30s polling, stage-focused) and **Coaching** mode (full analytics, post-match)
- Adds a segmented toggle between the match header and competitor picker with `?` info popover explaining both modes and a dynamic description line
- Server skips 6 expensive computations in Live mode: style fingerprints, field fingerprint cloud, archetype/course-length/constraint breakdowns, and what-if simulation
- Coaching accordion and stage simulator are only rendered in Coaching mode
- Mode override persists in localStorage per match with cross-tab sync
- MCP providers always request coaching mode (AI agents need full data)
- All consuming components updated with null guards for the 6 now-nullable fields

### Key files
- `lib/mode.ts` — `detectMode()` pure function (≥95% scored or >3 days → coaching)
- `lib/competition-store.ts` — localStorage persistence for mode override
- `app/api/compare/route.ts` — server-side gating of coaching computations
- `components/mode-toggle.tsx` — accessible segmented control (radiogroup, roving tabindex, 44px touch targets)
- `app/match/[ct]/[id]/match-page-client.tsx` — integration: auto mode, override, toggle placement, section gating
- `lib/types.ts` — `CompareMode` type, `mode` on `CompareResponse`, 6 nullable fields

## Test plan
- [x] `pnpm -w run typecheck` — zero errors
- [x] `pnpm -w test` — 580 tests pass (including 8 new `detectMode` boundary tests)
- [x] `pnpm -w run lint` — zero warnings
- [ ] `pnpm dev` → open active match → verify Live mode auto-selected, coaching sections hidden, 30s polling
- [ ] `pnpm dev` → open completed match → verify Coaching mode auto-selected, all sections visible, no polling
- [ ] Toggle modes → verify localStorage persists, query refetches with correct mode param
- [ ] Check 390px viewport — toggle and description fit, touch targets adequate
- [ ] Verify `?` popover opens and explains both modes clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)