### PR TITLE
feat: stage degradation analysis in coaching mode

### DIFF
--- a/app/api/compare/logic.ts
+++ b/app/api/compare/logic.ts
@@ -21,6 +21,8 @@ import type {
   StageConstraints,
   CourseLengthPerformance,
   ConstraintPerformance,
+  StageDegradationData,
+  StageDegradationPoint,
 } from "@/lib/types";
 
 export interface RawScorecard {
@@ -1617,4 +1619,95 @@ export function computeConstraintPerformance(
     normal:      { stageCount: normalPcts.length, avgGroupPercent: avg(normalPcts) },
     constrained: { stageCount: constrainedPcts.length, avgGroupPercent: avg(constrainedPcts) },
   };
+}
+
+// ── Stage Degradation Analysis ────────────────────────────────────────────────
+
+/**
+ * Compute per-stage shooting order vs HF% for the full field.
+ *
+ * For each stage, competitors are ranked by their scorecard_created timestamp
+ * (i.e., the absolute time they shot that specific stage, not their own cross-stage
+ * sequence). This enables visualization of stage degradation: does performance
+ * correlate with being an early or late shooter on that stage?
+ *
+ * Excluded: DNF, DQ, zeroed, missing timestamp, non-positive HF.
+ * spearmanR is null when fewer than 4 valid data points exist for a stage.
+ */
+export function computeStageDegradationData(
+  allScorecards: RawScorecard[]
+): StageDegradationData[] {
+  const byStage = new Map<number, RawScorecard[]>();
+  for (const sc of allScorecards) {
+    const arr = byStage.get(sc.stage_id) ?? [];
+    arr.push(sc);
+    byStage.set(sc.stage_id, arr);
+  }
+
+  const result: StageDegradationData[] = [];
+
+  for (const [stageId, scorecards] of byStage) {
+    const first = scorecards[0];
+    const valid = scorecards.filter(
+      (sc) => !sc.dnf && !sc.dq && !sc.zeroed && sc.scorecard_created && (sc.hit_factor ?? 0) > 0
+    );
+
+    // Sort by timestamp to establish stage-level shooting position
+    const sorted = [...valid].sort((a, b) =>
+      a.scorecard_created!.localeCompare(b.scorecard_created!)
+    );
+
+    const maxHF = sorted.reduce((m, sc) => Math.max(m, sc.hit_factor ?? 0), 0);
+
+    if (maxHF <= 0 || sorted.length < 2) {
+      result.push({
+        stageId,
+        stageNum: first.stage_number,
+        stageName: first.stage_name,
+        points: [],
+        spearmanR: null,
+      });
+      continue;
+    }
+
+    const points: StageDegradationPoint[] = sorted.map((sc, i) => ({
+      competitorId: sc.competitor_id,
+      shootingPosition: i + 1,
+      hfPercent: ((sc.hit_factor ?? 0) / maxHF) * 100,
+    }));
+
+    result.push({
+      stageId,
+      stageNum: first.stage_number,
+      stageName: first.stage_name,
+      points,
+      spearmanR: points.length >= 4 ? spearmanR(points) : null,
+    });
+  }
+
+  result.sort((a, b) => a.stageNum - b.stageNum);
+  return result;
+}
+
+/**
+ * Spearman rank correlation between shooting position and HF%.
+ *
+ * Since shootingPosition is already a 1-based rank (1..N), only the HF%
+ * values need to be ranked. Ties in HF% receive sequential ranks (no average-
+ * rank adjustment) — close enough for the badge display given that identical
+ * HFs are rare in IPSC matches.
+ */
+function spearmanR(points: StageDegradationPoint[]): number {
+  const n = points.length;
+  // Rank HF% values ascending (1 = lowest HF%)
+  const sortedByHF = [...points].sort((a, b) => a.hfPercent - b.hfPercent);
+  const hfRankMap = new Map<number, number>();
+  sortedByHF.forEach((p, i) => hfRankMap.set(p.competitorId, i + 1));
+
+  let sumD2 = 0;
+  for (const p of points) {
+    const d = p.shootingPosition - hfRankMap.get(p.competitorId)!;
+    sumD2 += d * d;
+  }
+  return 1 - (6 * sumD2) / (n * (n * n - 1));
 }

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -5,7 +5,7 @@ import cache from "@/lib/cache-impl";
 import { computeMatchTtl } from "@/lib/match-ttl";
 
 import { formatDivisionDisplay } from "@/lib/divisions";
-import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance } from "@/app/api/compare/logic";
+import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance, computeStageDegradationData } from "@/app/api/compare/logic";
 import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
 import type { CompareMode, CompareResponse, CompetitorInfo, FieldFingerprintPoint, StageComparison } from "@/lib/types";
 
@@ -283,6 +283,7 @@ export async function GET(req: Request) {
   let whatIfStats: CompareResponse["whatIfStats"] = null;
   let fieldFingerprintPoints: CompareResponse["fieldFingerprintPoints"] = null;
   let styleFingerprintStats: CompareResponse["styleFingerprintStats"] = null;
+  let stageDegradationData: CompareResponse["stageDegradationData"] = null;
 
   if (mode === "coaching") {
     archetypePerformance = Object.fromEntries(
@@ -298,6 +299,7 @@ export async function GET(req: Request) {
     );
 
     whatIfStats = simulateWithoutWorstStage(stages, requestedCompetitors, rawScorecards);
+    stageDegradationData = computeStageDegradationData(rawScorecards);
   }
 
   const tPerCompetitor = performance.now();
@@ -395,6 +397,7 @@ export async function GET(req: Request) {
     archetypePerformance,
     courseLengthPerformance,
     constraintPerformance,
+    stageDegradationData,
     cacheInfo,
   };
 

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -93,6 +93,13 @@ const ShooterStyleRadarChart = dynamic(
     ),
   { ssr: false, loading: ChartSkeleton },
 );
+const StageDegradationChart = dynamic(
+  () =>
+    import("@/components/stage-degradation-chart").then(
+      (m) => m.StageDegradationChart,
+    ),
+  { ssr: false, loading: ChartSkeleton },
+);
 const StageSimulator = dynamic(
   () => import("@/components/stage-simulator").then((m) => m.StageSimulator),
   { ssr: false, loading: () => <Skeleton className="h-48 w-full rounded-lg" /> },
@@ -707,6 +714,35 @@ export default function MatchPageClient() {
                             </Popover>
                           </div>
                           <ShooterStyleRadarChart data={compareQuery.data} />
+                        </div>
+
+                        <div className="space-y-2">
+                          <div className="flex items-center gap-1.5">
+                            <h3 className="text-sm font-semibold">Stage degradation</h3>
+                            <Popover>
+                              <PopoverTrigger asChild>
+                                <button
+                                  className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+                                  aria-label="About this chart"
+                                >
+                                  <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                                </button>
+                              </PopoverTrigger>
+                              <PopoverContent className="w-80" side="bottom" align="start">
+                                <PopoverHeader>
+                                  <PopoverTitle>Stage degradation</PopoverTitle>
+                                  <PopoverDescription>Does shooting position on a stage correlate with performance?</PopoverDescription>
+                                </PopoverHeader>
+                                <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
+                                  <p>X axis = the order in which each competitor shot this specific stage (1 = first to shoot, N = last). Derived from scorecard submission timestamps.</p>
+                                  <p>Y axis = HF as % of the stage overall leader (100% = best run). Faded dots = full field; colored dots = your selected competitors.</p>
+                                  <p>The dashed line is a linear trend. The Spearman r badge shows how strongly shooting position correlates with performance: negative r means earlier shooters scored higher (stage degraded over the day); positive r means later shooters benefited (e.g., learned from watching).</p>
+                                  <p>Values near 0 (|r| &lt; 0.1) mean no meaningful shooting-order effect on this stage.</p>
+                                </div>
+                              </PopoverContent>
+                            </Popover>
+                          </div>
+                          <StageDegradationChart data={compareQuery.data} />
                         </div>
                       </section>
                     )}

--- a/components/stage-degradation-chart.tsx
+++ b/components/stage-degradation-chart.tsx
@@ -1,0 +1,431 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  usePlotArea,
+  useXAxisDomain,
+  useYAxisDomain,
+} from "recharts";
+import { buildColorMap } from "@/lib/colors";
+import type { CompareResponse, CompetitorInfo, StageDegradationPoint } from "@/lib/types";
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+function linearRegression(
+  xs: number[],
+  ys: number[]
+): { slope: number; intercept: number } | null {
+  const n = xs.length;
+  if (n < 2) return null;
+  const sumX = xs.reduce((a, b) => a + b, 0);
+  const sumY = ys.reduce((a, b) => a + b, 0);
+  const sumXY = xs.reduce((acc, x, i) => acc + x * ys[i], 0);
+  const sumX2 = xs.reduce((acc, x) => acc + x * x, 0);
+  const denom = n * sumX2 - sumX * sumX;
+  if (denom === 0) return null;
+  const slope = (n * sumXY - sumX * sumY) / denom;
+  const intercept = (sumY - slope * sumX) / n;
+  return { slope, intercept };
+}
+
+function correlationLabel(r: number): string {
+  const abs = Math.abs(r);
+  const direction = r < 0 ? "early-squad advantage" : "late-squad advantage";
+  if (abs < 0.1) return "no clear shooting-order effect";
+  if (abs < 0.3) return `weak ${direction}`;
+  if (abs < 0.5) return `moderate ${direction}`;
+  return `strong ${direction}`;
+}
+
+// --------------------------------------------------------------------------
+// Trend line SVG overlay (must be a direct child of ScatterChart)
+// --------------------------------------------------------------------------
+
+function TrendLine({
+  regression,
+  xMin,
+  xMax,
+}: {
+  regression: { slope: number; intercept: number };
+  xMin: number;
+  xMax: number;
+}) {
+  const plotArea = usePlotArea();
+  const xDomain = useXAxisDomain();
+  const yDomain = useYAxisDomain();
+
+  if (!plotArea || !xDomain || !yDomain) return null;
+  if (xDomain.length < 2 || yDomain.length < 2) return null;
+
+  const dxMin = typeof xDomain[0] === "number" ? xDomain[0] : xMin;
+  const dxMax = typeof xDomain[1] === "number" ? xDomain[1] : xMax;
+  const dyMin = typeof yDomain[0] === "number" ? yDomain[0] : 0;
+  const dyMax = typeof yDomain[1] === "number" ? yDomain[1] : 100;
+
+  if (dxMax <= dxMin || dyMax <= dyMin) return null;
+
+  const toPixelX = (v: number) =>
+    plotArea.x + ((v - dxMin) / (dxMax - dxMin)) * plotArea.width;
+  const toPixelY = (v: number) =>
+    plotArea.y + ((dyMax - v) / (dyMax - dyMin)) * plotArea.height;
+
+  const clampY = (v: number) => Math.max(dyMin, Math.min(dyMax, v));
+
+  const y1 = regression.slope * dxMin + regression.intercept;
+  const y2 = regression.slope * dxMax + regression.intercept;
+
+  return (
+    <line
+      x1={toPixelX(dxMin)}
+      y1={toPixelY(clampY(y1))}
+      x2={toPixelX(dxMax)}
+      y2={toPixelY(clampY(y2))}
+      style={{
+        stroke: "var(--muted-foreground)",
+        strokeDasharray: "6 3",
+        strokeWidth: 1.5,
+        opacity: 0.6,
+      }}
+      aria-hidden="true"
+    />
+  );
+}
+
+// --------------------------------------------------------------------------
+// Custom dots
+// --------------------------------------------------------------------------
+
+interface FieldDotProps {
+  cx?: number;
+  cy?: number;
+}
+
+function FieldDot({ cx, cy }: FieldDotProps) {
+  if (cx === undefined || cy === undefined) return null;
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={3}
+      style={{ fill: "var(--muted-foreground)", opacity: 0.2 }}
+    />
+  );
+}
+
+interface SelectedDotProps {
+  cx?: number;
+  cy?: number;
+  fill?: string;
+}
+
+function SelectedDot({ cx, cy, fill }: SelectedDotProps) {
+  if (cx === undefined || cy === undefined) return null;
+  return (
+    <g>
+      {/* Enlarged touch target */}
+      <circle cx={cx} cy={cy} r={18} fill="transparent" />
+      <circle
+        cx={cx}
+        cy={cy}
+        r={7}
+        fill={fill}
+        style={{ stroke: "var(--background)" }}
+        strokeWidth={1.5}
+        opacity={0.9}
+      />
+    </g>
+  );
+}
+
+// --------------------------------------------------------------------------
+// Custom tooltip
+// --------------------------------------------------------------------------
+
+interface TooltipPoint {
+  competitorId: number;
+  competitorName: string;
+  shootingPosition: number;
+  hfPercent: number;
+}
+
+interface TooltipEntry {
+  payload: TooltipPoint;
+}
+
+function CustomTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: TooltipEntry[];
+}) {
+  if (!active || !payload?.length) return null;
+  const pt = payload[0].payload;
+  if (!pt.competitorName) return null;
+
+  return (
+    <div
+      style={{
+        backgroundColor: "var(--popover)",
+        color: "var(--popover-foreground)",
+        border: "1px solid var(--border)",
+        borderRadius: 6,
+        padding: "8px 10px",
+        fontSize: 12,
+        lineHeight: 1.6,
+        boxShadow: "0 4px 16px rgba(0,0,0,0.14), 0 1px 4px rgba(0,0,0,0.08)",
+      }}
+    >
+      <p style={{ fontWeight: 600, marginBottom: 4 }}>{pt.competitorName}</p>
+      <div
+        style={{ display: "grid", gridTemplateColumns: "auto auto", columnGap: 12 }}
+      >
+        <span style={{ color: "var(--muted-foreground)" }}>Shooting position</span>
+        <span>
+          {pt.shootingPosition}
+        </span>
+        <span style={{ color: "var(--muted-foreground)" }}>HF %</span>
+        <span>{pt.hfPercent.toFixed(1)}%</span>
+      </div>
+    </div>
+  );
+}
+
+// --------------------------------------------------------------------------
+// Main component
+// --------------------------------------------------------------------------
+
+interface StageDegradationChartProps {
+  data: CompareResponse;
+}
+
+export function StageDegradationChart({ data }: StageDegradationChartProps) {
+  const { competitors, stageDegradationData } = data;
+  const colorMap = buildColorMap(competitors.map((c) => c.id));
+  const selectedIds = useMemo(
+    () => new Set(competitors.map((c) => c.id)),
+    [competitors]
+  );
+
+  const stagesWithData = useMemo(
+    () => (stageDegradationData ?? []).filter((s) => s.points.length >= 2),
+    [stageDegradationData]
+  );
+
+  const [selectedStageId, setSelectedStageId] = useState<number | null>(
+    stagesWithData[0]?.stageId ?? null
+  );
+
+  // Keep selection valid if stagesWithData changes
+  const activeStageId =
+    selectedStageId !== null &&
+    stagesWithData.some((s) => s.stageId === selectedStageId)
+      ? selectedStageId
+      : (stagesWithData[0]?.stageId ?? null);
+
+  const stage = stagesWithData.find((s) => s.stageId === activeStageId) ?? null;
+
+  if (!stageDegradationData || stagesWithData.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No shooting-order data available — scorecard timestamps are required.
+      </p>
+    );
+  }
+
+  const formatLabel = (comp: CompetitorInfo) =>
+    `#${comp.competitor_number} ${comp.name.split(" ")[0]}`;
+
+  // Split this stage's points into field (faded) and selected (highlighted)
+  const allPoints = stage?.points ?? [];
+  const fieldPoints = allPoints.filter((p) => !selectedIds.has(p.competitorId));
+  const selectedPointsByComp: Record<number, StageDegradationPoint[]> = {};
+  for (const comp of competitors) {
+    const pts = allPoints.filter((p) => p.competitorId === comp.id);
+    if (pts.length > 0) selectedPointsByComp[comp.id] = pts;
+  }
+
+  // Build Tooltip-ready data for selected competitors (add name for tooltip)
+  function toTooltipPoints(compId: number, pts: StageDegradationPoint[]): TooltipPoint[] {
+    const comp = competitors.find((c) => c.id === compId);
+    return pts.map((p) => ({
+      ...p,
+      competitorName: comp ? formatLabel(comp) : String(compId),
+    }));
+  }
+
+  // Linear regression for trend line
+  const xs = allPoints.map((p) => p.shootingPosition);
+  const ys = allPoints.map((p) => p.hfPercent);
+  const regression = allPoints.length >= 4 ? linearRegression(xs, ys) : null;
+  const xMin = 1;
+  const xMax = allPoints.length;
+
+  return (
+    <div className="space-y-3">
+      {/* Stage selector */}
+      <div
+        role="group"
+        aria-label="Select stage for degradation view"
+        className="flex gap-1.5 flex-wrap"
+      >
+        {stagesWithData.map((s) => {
+          const active = s.stageId === activeStageId;
+          return (
+            <button
+              key={s.stageId}
+              type="button"
+              onClick={() => setSelectedStageId(s.stageId)}
+              aria-pressed={active}
+              className="rounded-full border px-3 py-0.5 text-xs transition-colors"
+              style={{
+                backgroundColor: active ? "var(--foreground)" : undefined,
+                color: active ? "var(--background)" : "var(--muted-foreground)",
+                borderColor: active ? "var(--foreground)" : "var(--border)",
+              }}
+            >
+              S{s.stageNum}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Correlation badge */}
+      {stage && stage.spearmanR !== null && (
+        <p className="text-xs" style={{ color: "var(--muted-foreground)" }}>
+          Spearman r ={" "}
+          <strong>
+            {stage.spearmanR > 0 ? "+" : ""}
+            {stage.spearmanR.toFixed(2)}
+          </strong>
+          {" · "}
+          {correlationLabel(stage.spearmanR)}
+        </p>
+      )}
+      {stage && stage.spearmanR === null && stage.points.length >= 2 && (
+        <p className="text-xs" style={{ color: "var(--muted-foreground)" }}>
+          {stage.points.length} shooter{stage.points.length !== 1 ? "s" : ""} — need ≥ 4 for
+          correlation.
+        </p>
+      )}
+
+      {/* Scatter chart */}
+      <ResponsiveContainer width="100%" height={300}>
+        <ScatterChart margin={{ top: 12, right: 16, left: 0, bottom: 28 }}>
+          <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+          <XAxis
+            type="number"
+            dataKey="shootingPosition"
+            name="Shooting position"
+            domain={[xMin, xMax]}
+            allowDataOverflow
+            tick={{ fontSize: 12 }}
+            className="fill-muted-foreground"
+            label={{
+              value: "Shooting position",
+              position: "insideBottom",
+              offset: -14,
+              style: { fontSize: 11, fill: "var(--muted-foreground)" },
+            }}
+          />
+          <YAxis
+            type="number"
+            dataKey="hfPercent"
+            name="HF %"
+            domain={[0, 100]}
+            ticks={[0, 25, 50, 75, 100]}
+            tick={{ fontSize: 12 }}
+            className="fill-muted-foreground"
+            label={{
+              value: "HF %",
+              angle: -90,
+              position: "insideLeft",
+              offset: 10,
+              style: { fontSize: 11, fill: "var(--muted-foreground)" },
+            }}
+          />
+          <Tooltip
+            content={<CustomTooltip />}
+            cursor={{ strokeDasharray: "3 3" }}
+          />
+
+          {/* Trend line overlay */}
+          {regression && (
+            <TrendLine regression={regression} xMin={xMin} xMax={xMax} />
+          )}
+
+          {/* Full-field background dots */}
+          {fieldPoints.length > 0 && (
+            <Scatter
+              name="Field"
+              data={fieldPoints}
+              shape={(props) => (
+                <FieldDot
+                  cx={(props as FieldDotProps).cx}
+                  cy={(props as FieldDotProps).cy}
+                />
+              )}
+              isAnimationActive={false}
+            />
+          )}
+
+          {/* Selected competitors */}
+          {competitors.map((comp) => {
+            const pts = selectedPointsByComp[comp.id];
+            if (!pts) return null;
+            return (
+              <Scatter
+                key={comp.id}
+                name={formatLabel(comp)}
+                data={toTooltipPoints(comp.id, pts)}
+                fill={colorMap[comp.id]}
+                shape={(props) => (
+                  <SelectedDot
+                    cx={(props as SelectedDotProps).cx}
+                    cy={(props as SelectedDotProps).cy}
+                    fill={colorMap[comp.id]}
+                  />
+                )}
+              />
+            );
+          })}
+        </ScatterChart>
+      </ResponsiveContainer>
+
+      {/* Competitor legend */}
+      <div className="flex flex-wrap justify-center gap-3">
+        {competitors.map((comp) => {
+          const pt = allPoints.find((p) => p.competitorId === comp.id);
+          return (
+            <div key={comp.id} className="flex items-center gap-1.5 text-xs">
+              <span
+                className="inline-block h-2.5 w-2.5 rounded-full flex-none"
+                style={{ backgroundColor: colorMap[comp.id] }}
+                aria-hidden="true"
+              />
+              <span>{formatLabel(comp)}</span>
+              {pt && (
+                <span style={{ color: "var(--muted-foreground)" }}>
+                  pos.{pt.shootingPosition}, {pt.hfPercent.toFixed(0)}%
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <p className="text-center text-xs" style={{ color: "var(--muted-foreground)" }}>
+        Faded dots = full field · dashed line = linear trend · position = order shot this stage
+      </p>
+    </div>
+  );
+}

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -11,11 +11,24 @@ import type { Release } from "@/lib/types";
  * differs from the value stored in localStorage("whats-new-seen-id").
  */
 /** The `id` of the newest release. Used by e2e tests to suppress the What's New dialog. */
-export const LATEST_RELEASE_ID = "2026-03-01";
+export const LATEST_RELEASE_ID = "2026-03-02";
 
 export const RELEASES: Release[] = [
   {
     id: LATEST_RELEASE_ID,
+    date: "March 2, 2026",
+    title: "Stage Degradation Analysis",
+    sections: [
+      {
+        heading: "New",
+        items: [
+          "Stage degradation chart (Coaching mode): see whether shooting early or late on a stage correlated with higher or lower performance across the full field. A Spearman r badge summarises the trend, and your selected competitors are highlighted against the field.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "2026-03-01",
     date: "March 1, 2026",
     title: "Live/Coaching Mode & Stage Analytics",
     sections: [

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -336,6 +336,27 @@ export interface WhatIfResult {
   secondWorstReplacement: SimResult;  // scenario 2: replace worst with second-worst (lower bound)
 }
 
+// One competitor's shooting position vs performance on a specific stage (full field).
+export interface StageDegradationPoint {
+  competitorId: number;
+  /** 1-based rank among all competitors who shot this stage, ordered by scorecard_created timestamp. */
+  shootingPosition: number;
+  /** HF as % of stage overall leader (0–100). */
+  hfPercent: number;
+}
+
+// Full-field shooting order vs performance data for one stage.
+// Used in the coaching analysis "Stage Degradation" chart.
+export interface StageDegradationData {
+  stageId: number;
+  stageNum: number;
+  stageName: string;
+  /** All field competitors with valid timestamps and positive HF, sorted by shooting position. */
+  points: StageDegradationPoint[];
+  /** Spearman rank correlation between shooting position and HF%; null when < 4 valid data points. */
+  spearmanR: number | null;
+}
+
 export interface CompareResponse {
   match_id: number;
   mode: CompareMode;
@@ -351,6 +372,7 @@ export interface CompareResponse {
   archetypePerformance: Record<number, ArchetypePerformance[]> | null; // null in live mode
   courseLengthPerformance: Record<number, CourseLengthPerformance[]> | null; // null in live mode
   constraintPerformance: Record<number, ConstraintPerformance> | null; // null in live mode
+  stageDegradationData: StageDegradationData[] | null; // null in live mode
   cacheInfo: CacheInfo;
 }
 

--- a/tests/components/comparison-chart.test.tsx
+++ b/tests/components/comparison-chart.test.tsx
@@ -79,6 +79,7 @@ const baseData: CompareResponse = {
   archetypePerformance: {},
   courseLengthPerformance: {},
   constraintPerformance: {},
+  stageDegradationData: null,
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },

--- a/tests/components/comparison-table.test.tsx
+++ b/tests/components/comparison-table.test.tsx
@@ -31,6 +31,7 @@ const baseData: CompareResponse = {
     1: { normal: { stageCount: 1, avgGroupPercent: 89.2 }, constrained: { stageCount: 0, avgGroupPercent: null } },
     2: { normal: { stageCount: 1, avgGroupPercent: 100 }, constrained: { stageCount: 0, avgGroupPercent: null } },
   },
+  stageDegradationData: null,
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },

--- a/tests/components/radar-chart.test.tsx
+++ b/tests/components/radar-chart.test.tsx
@@ -19,6 +19,7 @@ const baseData: CompareResponse = {
   archetypePerformance: {},
   courseLengthPerformance: {},
   constraintPerformance: {},
+  stageDegradationData: null,
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },

--- a/tests/components/scatter-chart.test.tsx
+++ b/tests/components/scatter-chart.test.tsx
@@ -19,6 +19,7 @@ const baseData: CompareResponse = {
   archetypePerformance: {},
   courseLengthPerformance: {},
   constraintPerformance: {},
+  stageDegradationData: null,
   consistencyStats: {
     1: { coefficientOfVariation: null, label: null, stagesFired: 1 },
     2: { coefficientOfVariation: null, label: null, stagesFired: 1 },

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -71,6 +71,7 @@ const MOCK_COMPARE: CompareResponse = {
     200: { normal: { stageCount: 2, avgGroupPercent: 99.15 }, constrained: { stageCount: 0, avgGroupPercent: null } },
     300: { normal: { stageCount: 2, avgGroupPercent: 93.55 }, constrained: { stageCount: 0, avgGroupPercent: null } },
   },
+  stageDegradationData: null,
   stages: [
     {
       stage_id: 1,

--- a/tests/unit/compare-logic.test.ts
+++ b/tests/unit/compare-logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeGroupRankings, computePenaltyStats, assignDifficulty, computePercentile, computePercentileRank, assignArchetype, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, computeQuartiles, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
+import { computeGroupRankings, computePenaltyStats, assignDifficulty, computePercentile, computePercentileRank, assignArchetype, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, computeQuartiles, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance, computeStageDegradationData, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
 import type { CompetitorInfo, StageComparison } from "@/lib/types";
 
 const competitors: CompetitorInfo[] = [
@@ -2885,5 +2885,146 @@ describe("computeConstraintPerformance", () => {
     const result = computeConstraintPerformance(stages, 1);
     expect(result.constrained.stageCount).toBe(1);
     expect(result.constrained.avgGroupPercent).toBeCloseTo(75, 5);
+  });
+});
+
+// ── computeStageDegradationData ───────────────────────────────────────────────
+
+describe("computeStageDegradationData", () => {
+  function makeTimedCard(
+    competitorId: number,
+    stageId: number,
+    stageNumber: number,
+    hitFactor: number,
+    createdIso: string,
+    overrides: Partial<RawScorecard> = {}
+  ): RawScorecard {
+    return {
+      competitor_id: competitorId,
+      competitor_division: null,
+      stage_id: stageId,
+      stage_number: stageNumber,
+      stage_name: `Stage ${stageNumber}`,
+      max_points: 100,
+      points: hitFactor * 10,
+      hit_factor: hitFactor,
+      time: 10,
+      dq: false,
+      zeroed: false,
+      dnf: false,
+      incomplete: false,
+      a_hits: 10,
+      c_hits: 0,
+      d_hits: 0,
+      miss_count: 0,
+      no_shoots: 0,
+      procedurals: 0,
+      scorecard_created: createdIso,
+      ...overrides,
+    };
+  }
+
+  it("assigns shooting positions in timestamp order", () => {
+    const cards = [
+      makeTimedCard(1, 10, 1, 5.0, "2024-01-01T09:00:00Z"),
+      makeTimedCard(2, 10, 1, 4.0, "2024-01-01T09:05:00Z"),
+      makeTimedCard(3, 10, 1, 3.0, "2024-01-01T09:10:00Z"),
+      makeTimedCard(4, 10, 1, 6.0, "2024-01-01T08:55:00Z"), // earliest
+    ];
+    const result = computeStageDegradationData(cards);
+    expect(result).toHaveLength(1);
+    const stage = result[0];
+    // Position 1 = earliest timestamp = competitor 4
+    expect(stage.points.find((p) => p.competitorId === 4)?.shootingPosition).toBe(1);
+    expect(stage.points.find((p) => p.competitorId === 1)?.shootingPosition).toBe(2);
+    expect(stage.points.find((p) => p.competitorId === 2)?.shootingPosition).toBe(3);
+    expect(stage.points.find((p) => p.competitorId === 3)?.shootingPosition).toBe(4);
+  });
+
+  it("computes hfPercent relative to stage max HF (100 = leader)", () => {
+    const cards = [
+      makeTimedCard(1, 10, 1, 8.0, "2024-01-01T09:00:00Z"), // leader
+      makeTimedCard(2, 10, 1, 4.0, "2024-01-01T09:05:00Z"), // 50% of leader
+    ];
+    const result = computeStageDegradationData(cards);
+    const stage = result[0];
+    expect(stage.points.find((p) => p.competitorId === 1)?.hfPercent).toBeCloseTo(100, 5);
+    expect(stage.points.find((p) => p.competitorId === 2)?.hfPercent).toBeCloseTo(50, 5);
+  });
+
+  it("excludes DNF, DQ, zeroed, and cards without timestamps", () => {
+    const cards = [
+      makeTimedCard(1, 10, 1, 5.0, "2024-01-01T09:00:00Z"), // valid
+      makeTimedCard(6, 10, 1, 4.5, "2024-01-01T09:03:00Z"), // valid — needed for ≥ 2 threshold
+      makeTimedCard(2, 10, 1, 4.0, "2024-01-01T09:05:00Z", { dnf: true }),
+      makeTimedCard(3, 10, 1, 3.0, "2024-01-01T09:10:00Z", { dq: true }),
+      makeTimedCard(4, 10, 1, 2.0, "2024-01-01T09:15:00Z", { zeroed: true }),
+      makeTimedCard(5, 10, 1, 6.0, "", { scorecard_created: null }),
+    ];
+    const result = computeStageDegradationData(cards);
+    const stage = result[0];
+    // Only competitors 1 and 6 survive all filters
+    expect(stage.points).toHaveLength(2);
+    const ids = stage.points.map((p) => p.competitorId);
+    expect(ids).toContain(1);
+    expect(ids).toContain(6);
+    expect(ids).not.toContain(2);
+    expect(ids).not.toContain(3);
+    expect(ids).not.toContain(4);
+    expect(ids).not.toContain(5);
+  });
+
+  it("returns empty points and null spearmanR when fewer than 2 valid entries", () => {
+    const cards = [makeTimedCard(1, 10, 1, 5.0, "2024-01-01T09:00:00Z")];
+    const result = computeStageDegradationData(cards);
+    expect(result[0].points).toHaveLength(0);
+    expect(result[0].spearmanR).toBeNull();
+  });
+
+  it("returns null spearmanR for 2–3 valid entries", () => {
+    const cards = [
+      makeTimedCard(1, 10, 1, 5.0, "2024-01-01T09:00:00Z"),
+      makeTimedCard(2, 10, 1, 4.0, "2024-01-01T09:05:00Z"),
+      makeTimedCard(3, 10, 1, 3.0, "2024-01-01T09:10:00Z"),
+    ];
+    const result = computeStageDegradationData(cards);
+    // 3 points < 4 → no correlation
+    expect(result[0].points).toHaveLength(3);
+    expect(result[0].spearmanR).toBeNull();
+  });
+
+  it("computes spearmanR = -1 for perfect inverse: earliest shooter always wins", () => {
+    // Perfect degradation: positions 1,2,3,4 map to HF% 100,75,50,25 (inverse)
+    const cards = [
+      makeTimedCard(1, 10, 1, 4.0, "2024-01-01T09:00:00Z"), // pos 1, max HF → 100%
+      makeTimedCard(2, 10, 1, 3.0, "2024-01-01T09:05:00Z"), // pos 2 → 75%
+      makeTimedCard(3, 10, 1, 2.0, "2024-01-01T09:10:00Z"), // pos 3 → 50%
+      makeTimedCard(4, 10, 1, 1.0, "2024-01-01T09:15:00Z"), // pos 4 → 25%
+    ];
+    const result = computeStageDegradationData(cards);
+    expect(result[0].spearmanR).toBeCloseTo(-1, 5);
+  });
+
+  it("computes spearmanR = +1 for perfect positive: latest shooter always wins", () => {
+    const cards = [
+      makeTimedCard(1, 10, 1, 1.0, "2024-01-01T09:00:00Z"), // pos 1 → 25%
+      makeTimedCard(2, 10, 1, 2.0, "2024-01-01T09:05:00Z"), // pos 2 → 50%
+      makeTimedCard(3, 10, 1, 3.0, "2024-01-01T09:10:00Z"), // pos 3 → 75%
+      makeTimedCard(4, 10, 1, 4.0, "2024-01-01T09:15:00Z"), // pos 4 → 100%
+    ];
+    const result = computeStageDegradationData(cards);
+    expect(result[0].spearmanR).toBeCloseTo(1, 5);
+  });
+
+  it("sorts output by stage number", () => {
+    const cards = [
+      makeTimedCard(1, 20, 2, 5.0, "2024-01-01T09:00:00Z"),
+      makeTimedCard(2, 20, 2, 4.0, "2024-01-01T09:05:00Z"),
+      makeTimedCard(1, 10, 1, 3.0, "2024-01-01T10:00:00Z"),
+      makeTimedCard(2, 10, 1, 2.0, "2024-01-01T10:05:00Z"),
+    ];
+    const result = computeStageDegradationData(cards);
+    expect(result[0].stageNum).toBe(1);
+    expect(result[1].stageNum).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a **Stage degradation** chart to the Coaching analysis section, showing whether shooting position on a stage (first vs. last to shoot) correlates with performance across the full field
- Per-stage scatter: X = shooting position (by timestamp), Y = HF% vs stage leader — full field as faded dots, selected competitors highlighted in their assigned colors
- Dashed linear trend line (least-squares regression) + Spearman r badge with plain-English interpretation ("early-squad advantage", "late-squad advantage", "no clear effect")
- Coaching mode only — zero overhead in live mode

## What changed

- `lib/types.ts` — new `StageDegradationPoint`, `StageDegradationData` interfaces; `stageDegradationData` field on `CompareResponse`
- `app/api/compare/logic.ts` — `computeStageDegradationData()` + internal `spearmanR()` helper
- `app/api/compare/route.ts` — calls new function in coaching mode block; adds field to response
- `components/stage-degradation-chart.tsx` — new chart component (stage selector, scatter, trend line, correlation badge, competitor legend)
- `app/match/[ct]/[id]/match-page-client.tsx` — dynamic import + section wired into coaching analysis collapsible with info popover
- `lib/releases.ts` — What's New entry for 2026-03-02, `LATEST_RELEASE_ID` bumped
- Test fixtures updated (`stageDegradationData: null`) across component + e2e suites
- 8 new unit tests in `tests/unit/compare-logic.test.ts`

## Test plan

- [ ] All 588 unit/component tests pass (`pnpm -w test`)
- [ ] Zero typecheck errors (`pnpm -w run typecheck`)
- [ ] Zero lint warnings (`pnpm -w run lint`)
- [ ] Open a completed match in Coaching mode → "Coaching analysis" collapsible → new "Stage degradation" section visible at the bottom
- [ ] Stage selector buttons switch between stages; scatter updates correctly
- [ ] Spearman r badge and trend line render and match the correlation direction
- [ ] Selected competitors appear as colored dots; unscored competitors show no dot on that stage
- [ ] Info popover (`?`) opens and contains correct explanation
- [ ] No stage degradation section visible in Live mode

Closes #175, closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)