### PR TITLE
feat: stage complexity metric (simple → intricate)

### DIFF
--- a/app/api/compare/logic.ts
+++ b/app/api/compare/logic.ts
@@ -1711,3 +1711,126 @@ function spearmanR(points: StageDegradationPoint[]): number {
   }
   return 1 - (6 * sumD2) / (n * (n * n - 1));
 }
+
+// ── Stage Complexity ─────────────────────────────────────────────────────────
+
+const COMPLEXITY_LABELS: Record<1 | 2 | 3 | 4 | 5, string> = {
+  1: "simple",
+  2: "structured",
+  3: "involved",
+  4: "complex",
+  5: "intricate",
+};
+
+export interface StageComplexityInput {
+  course_display?: string | null;
+  min_rounds?: number | null;
+  max_points: number;
+  paper_targets?: number | null;
+  steel_targets?: number | null;
+  constraints?: StageConstraints | null;
+}
+
+/** Per-match normalisation context, computed once across all stages. */
+interface ComplexityNormCtx {
+  minTargets: number;
+  maxTargets: number;
+}
+
+interface ComplexityFactor {
+  weight: number;
+  compute: (stage: StageComplexityInput, ctx: ComplexityNormCtx) => number; // returns 0–1
+}
+
+const COMPLEXITY_FACTORS: ComplexityFactor[] = [
+  // Factor 1: Course length (Short=0, Medium=0.5, Long=1.0; fallback via min_rounds heuristic)
+  {
+    weight: 0.35,
+    compute: (stage) => {
+      const display = stage.course_display;
+      if (display === "Short") return 0;
+      if (display === "Medium") return 0.5;
+      if (display === "Long") return 1.0;
+      // Fallback: use min_rounds heuristic
+      const r = stage.min_rounds;
+      if (r != null) {
+        if (r <= 8) return 0;
+        if (r <= 16) return 0.5;
+        return 1.0;
+      }
+      // Second fallback: max_points → implied rounds
+      if (stage.max_points > 0) {
+        const implied = stage.max_points / 5;
+        if (implied <= 8) return 0;
+        if (implied <= 16) return 0.5;
+        return 1.0;
+      }
+      return 0.5; // unknown → middle
+    },
+  },
+  // Factor 2: Target count (per-match normalisation)
+  {
+    weight: 0.25,
+    compute: (stage, ctx) => {
+      const paper = stage.paper_targets ?? 0;
+      const steel = stage.steel_targets ?? 0;
+      const total = paper + steel;
+      if (ctx.maxTargets === ctx.minTargets) return 0.5;
+      return (total - ctx.minTargets) / (ctx.maxTargets - ctx.minTargets);
+    },
+  },
+  // Factor 3: Constraint count (active constraints / 4)
+  {
+    weight: 0.25,
+    compute: (stage) => {
+      const c = stage.constraints;
+      if (!c) return 0;
+      const active = (c.strongHand ? 1 : 0) + (c.weakHand ? 1 : 0)
+        + (c.movingTargets ? 1 : 0) + (c.unloadedStart ? 1 : 0);
+      return active / 4;
+    },
+  },
+  // Factor 4: Target variety (1.0 if both paper AND steel present; 0.0 otherwise)
+  {
+    weight: 0.15,
+    compute: (stage) => {
+      const hasPaper = (stage.paper_targets ?? 0) > 0;
+      const hasSteel = (stage.steel_targets ?? 0) > 0;
+      return (hasPaper && hasSteel) ? 1.0 : 0.0;
+    },
+  },
+];
+
+/**
+ * Assign intrinsic complexity levels to a set of stages.
+ *
+ * Uses a weighted factor array pattern — each factor produces a [0,1] score,
+ * and the weighted sum is mapped to levels 1–5 via normalisedToLevel().
+ *
+ * This measures how much planning/memorisation a stage demands before any
+ * shots are fired, using only stage metadata. Complements the results-based
+ * difficulty metric.
+ */
+export function assignComplexity(
+  stages: StageComplexityInput[],
+): { level: 1 | 2 | 3 | 4 | 5; label: string }[] {
+  if (stages.length === 0) return [];
+
+  // Build normalisation context: min/max target counts across all stages
+  const targetCounts = stages.map((s) => (s.paper_targets ?? 0) + (s.steel_targets ?? 0));
+  const ctx: ComplexityNormCtx = {
+    minTargets: Math.min(...targetCounts),
+    maxTargets: Math.max(...targetCounts),
+  };
+
+  return stages.map((stage) => {
+    let score = 0;
+    for (const factor of COMPLEXITY_FACTORS) {
+      score += factor.weight * factor.compute(stage, ctx);
+    }
+    // Clamp to [0, 1] for safety
+    score = Math.max(0, Math.min(1, score));
+    const level = normalisedToLevel(score);
+    return { level, label: COMPLEXITY_LABELS[level] };
+  });
+}

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -5,7 +5,7 @@ import cache from "@/lib/cache-impl";
 import { computeMatchTtl } from "@/lib/match-ttl";
 
 import { formatDivisionDisplay } from "@/lib/divisions";
-import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance, computeStageDegradationData } from "@/app/api/compare/logic";
+import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance, computeStageDegradationData, assignComplexity } from "@/app/api/compare/logic";
 import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
 import type { CompareMode, CompareResponse, CompetitorInfo, FieldFingerprintPoint, StageComparison } from "@/lib/types";
 
@@ -224,11 +224,28 @@ export async function GET(req: Request) {
     }
   );
 
+  // Assign intrinsic complexity levels based on stage metadata
+  if (stages.length > 0) {
+    const complexities = assignComplexity(stages.map((s) => ({
+      course_display: s.course_display,
+      min_rounds: s.min_rounds,
+      max_points: s.max_points,
+      paper_targets: s.paper_targets,
+      steel_targets: s.steel_targets,
+      constraints: s.constraints,
+    })));
+    stages = stages.map((s, i) => ({
+      ...s,
+      stageComplexityLevel: complexities[i].level,
+      stageComplexityLabel: complexities[i].label,
+    }));
+  }
+
   // Fallback for future matches: if no scorecards exist yet but stage metadata is
   // available from the match query, build placeholder rows so the comparison table
   // shows stage names and metadata. Competitor cells render "—" for undefined entries.
   if (stages.length === 0 && stageMetaMap.size > 0) {
-    stages = (matchData.event.stages ?? []).map((s) => {
+    const fallbackStages = (matchData.event.stages ?? []).map((s) => {
       const stageId = parseInt(s.id, 10);
       const meta = stageMetaMap.get(stageId);
       return {
@@ -249,6 +266,20 @@ export async function GET(req: Request) {
         ...(meta ?? {}),
       } satisfies StageComparison;
     });
+    // Assign complexity to fallback stages too
+    const fallbackComplexities = assignComplexity(fallbackStages.map((s) => ({
+      course_display: s.course_display,
+      min_rounds: s.min_rounds,
+      max_points: s.max_points,
+      paper_targets: s.paper_targets,
+      steel_targets: s.steel_targets,
+      constraints: s.constraints,
+    })));
+    stages = fallbackStages.map((s, i) => ({
+      ...s,
+      stageComplexityLevel: fallbackComplexities[i].level,
+      stageComplexityLabel: fallbackComplexities[i].label,
+    }));
   }
 
   const tRankings = performance.now();

--- a/components/cell-help-modal.tsx
+++ b/components/cell-help-modal.tsx
@@ -17,7 +17,7 @@ import {
   ShootingOrderBadge,
   StageClassificationBadge,
 } from "@/components/stage-cell-parts";
-import { CheckCircle2, Crosshair, Flame, Focus, Hand, HandMetal, Layers, Shield, Timer, Zap } from "lucide-react";
+import { Brain, CheckCircle2, Crosshair, Flame, Focus, Hand, HandMetal, Layers, Shield, Timer, Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { StageClassification } from "@/lib/types";
 
@@ -153,11 +153,21 @@ function StageColumnDiagram() {
         />
         <DiagramRow
           visual={
+            <span className="inline-flex text-indigo-500" aria-label="Stage complexity" role="img">
+              <Brain className="w-3.5 h-3.5" aria-hidden="true" />
+            </span>
+          }
+          badge="4"
+          title="Complexity"
+          description="Intrinsic stage complexity based on course length, target count, constraints, and target variety. Higher = more planning and memorisation required. Complements difficulty, which reflects how the field performed."
+        />
+        <DiagramRow
+          visual={
             <span className="text-xs text-muted-foreground tabular-nums whitespace-nowrap">
               {MOCK_STAGE_ROUNDS}r · {MOCK_STAGE_PAPER}P · {MOCK_STAGE_STEEL}S
             </span>
           }
-          badge="4"
+          badge="5"
           title="Rounds & targets"
           description="Minimum round count, paper targets (P), and steel targets (S). Indicates stage type — high round count suggests a long course."
         />
@@ -169,7 +179,7 @@ function StageColumnDiagram() {
               <HandMetal className="w-3.5 h-3.5 text-cyan-500" />
             </div>
           }
-          badge="4"
+          badge="5"
           title="Constraint badges"
           description={<>Shown when the stage brief includes a shooting restriction: <span className="inline-flex items-center gap-0.5 text-amber-600 dark:text-amber-400"><Hand className="w-3 h-3" aria-hidden="true" /> strong hand only</span>, <span className="inline-flex items-center gap-0.5 text-cyan-600 dark:text-cyan-400"><HandMetal className="w-3 h-3" aria-hidden="true" /> weak hand only</span>, or <span className="inline-flex items-center gap-0.5 text-teal-600 dark:text-teal-400"><Crosshair className="w-3 h-3" aria-hidden="true" /> moving targets</span>. Tap the icon for a tooltip. Also visible in the stage info popover on mobile.</>}
         />
@@ -180,7 +190,7 @@ function StageColumnDiagram() {
               med: {MOCK_STAGE_MEDIAN_HF.toFixed(2)}
             </span>
           }
-          badge="5"
+          badge="6"
           title="Field median HF"
           description="Median hit factor of all competitors on this stage. A useful baseline — compare it with the hit factors in the cells above."
         />

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -12,7 +12,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { AlertTriangle, ArrowDown, ArrowRight, ArrowUp, CheckCircle2, ChevronDown, ChevronUp, Crosshair, ExternalLink, Flame, Focus, Gauge, Hand, HandMetal, HelpCircle, Info, Layers, Shield, Target, Timer, TrendingUp, X, Zap } from "lucide-react";
+import { AlertTriangle, ArrowDown, ArrowRight, ArrowUp, Brain, CheckCircle2, ChevronDown, ChevronUp, Crosshair, ExternalLink, Flame, Focus, Gauge, Hand, HandMetal, HelpCircle, Info, Layers, Shield, Target, Timer, TrendingUp, X, Zap } from "lucide-react";
 import { cn, formatHF, formatTime, formatPct, computePointsDelta, formatDelta } from "@/lib/utils";
 import { buildColorMap } from "@/lib/colors";
 import { HitZoneBar } from "@/components/hit-zone-bar";
@@ -168,6 +168,42 @@ function StageArchetypeIcon({ archetype }: { archetype: StageArchetype }) {
       </TooltipTrigger>
       <TooltipContent side="top" className="text-xs">
         {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+const COMPLEXITY_COLORS: Record<1 | 2 | 3 | 4 | 5, string> = {
+  1: "text-sky-400",
+  2: "text-sky-500",
+  3: "text-blue-500",
+  4: "text-indigo-500",
+  5: "text-violet-500",
+};
+
+function StageComplexityIcon({
+  level,
+  label,
+}: {
+  level: 1 | 2 | 3 | 4 | 5;
+  label: string;
+}) {
+  const color = COMPLEXITY_COLORS[level];
+  const tooltipText = `Complexity: ${label.charAt(0).toUpperCase() + label.slice(1)}`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={cn("inline-flex cursor-help", color)}
+          aria-label={tooltipText}
+          role="img"
+        >
+          <Brain className="w-3 h-3" aria-hidden="true" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="text-xs">
+        {tooltipText}
       </TooltipContent>
     </Tooltip>
   );
@@ -828,11 +864,22 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
                                 label={stage.stageDifficultyLabel}
                                 medianHF={stage.field_median_hf}
                               />
+                              {stage.stageComplexityLevel != null && stage.stageComplexityLabel != null && (
+                                <StageComplexityIcon
+                                  level={stage.stageComplexityLevel}
+                                  label={stage.stageComplexityLabel}
+                                />
+                              )}
                               {stage.stageArchetype && (
                                 <StageArchetypeIcon archetype={stage.stageArchetype} />
                               )}
                               <StageConstraintBadges constraints={stage.constraints} />
                             </div>
+                            {stage.stageComplexityLabel && (
+                              <span className="text-xs text-muted-foreground">
+                                Complexity: {stage.stageComplexityLabel.charAt(0).toUpperCase() + stage.stageComplexityLabel.slice(1)}
+                              </span>
+                            )}
                             {stage.stageArchetype && (
                               <span className="text-xs text-muted-foreground">
                                 Type: {stage.stageArchetype.charAt(0).toUpperCase() + stage.stageArchetype.slice(1)}
@@ -889,6 +936,12 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
                           label={stage.stageDifficultyLabel}
                           medianHF={stage.field_median_hf}
                         />
+                        {stage.stageComplexityLevel != null && stage.stageComplexityLabel != null && (
+                          <StageComplexityIcon
+                            level={stage.stageComplexityLevel}
+                            label={stage.stageComplexityLabel}
+                          />
+                        )}
                         {stage.stageArchetype && (
                           <StageArchetypeIcon archetype={stage.stageArchetype} />
                         )}

--- a/lib/coaching-prompt.ts
+++ b/lib/coaching-prompt.ts
@@ -45,7 +45,8 @@ function buildStageLines(
       const cs = s.competitors[competitorId];
       if (!cs) return null;
 
-      const stageMeta = `${s.stageDifficultyLabel}, ${courseSize(s)}`;
+      const complexityPart = s.stageComplexityLabel ? `, ${s.stageComplexityLabel} complexity` : "";
+      const stageMeta = `${s.stageDifficultyLabel}, ${courseSize(s)}${complexityPart}`;
 
       if (cs.dq)
         return `  Stage ${s.stage_num} "${s.stage_name}" [${stageMeta}]: DQ`;

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -41,6 +41,7 @@ export const RELEASES: Release[] = [
           "Archetype performance breakdown: compare your group's average stage % across Speed, Precision, and Mixed stages to spot strengths and weaknesses.",
           "Division position chart: see where each competitor sits within their division on every stage. The shaded band shows the middle 50% of the division, with median and minimum lines for context.",
           "If selected competitors span multiple divisions, use the division selector to switch between them.",
+          "Stage complexity indicator: a brain icon next to each stage rates how much planning and memorisation it demands (simple \u2192 intricate), based on course length, target count, constraints, and target variety.",
           "Constraint badges on stage headers: strong hand, weak hand, and moving target stages are flagged with coloured icons.",
           "Course length & constraint breakdowns: see how performance varies by Short / Medium / Long courses, and between constrained (e.g. strong hand only) vs standard stages.",
         ],

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -165,6 +165,8 @@ export interface StageComparison {
   stageDifficultyLevel: 1 | 2 | 3 | 4 | 5; // relative difficulty on a 1–5 scale (1=easy, 5=brutal)
   stageDifficultyLabel: string;       // human-readable label: easy/moderate/hard/very hard/brutal
   stageArchetype?: StageArchetype | null; // speed / precision / mixed — null when target data is insufficient
+  stageComplexityLevel?: 1 | 2 | 3 | 4 | 5; // intrinsic stage complexity on a 1–5 scale (1=simple, 5=intricate)
+  stageComplexityLabel?: string;              // human-readable label: simple/structured/involved/complex/intricate
   competitors: Record<number, CompetitorSummary>; // keyed by competitor_id
   /** Per-division HF distribution (quartiles) for this stage. Keyed by competitor_division string. */
   divisionDistributions?: Record<string, DivisionHFDistribution>;

--- a/tests/unit/compare-logic.test.ts
+++ b/tests/unit/compare-logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeGroupRankings, computePenaltyStats, assignDifficulty, computePercentile, computePercentileRank, assignArchetype, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, computeQuartiles, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance, computeStageDegradationData, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
+import { computeGroupRankings, computePenaltyStats, assignDifficulty, computePercentile, computePercentileRank, assignArchetype, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, computeQuartiles, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance, computeStageDegradationData, assignComplexity, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
 import type { CompetitorInfo, StageComparison } from "@/lib/types";
 
 const competitors: CompetitorInfo[] = [
@@ -3026,5 +3026,162 @@ describe("computeStageDegradationData", () => {
     const result = computeStageDegradationData(cards);
     expect(result[0].stageNum).toBe(1);
     expect(result[1].stageNum).toBe(2);
+  });
+});
+
+// ── assignComplexity ─────────────────────────────────────────────────────────
+
+describe("assignComplexity", () => {
+  it("returns empty array for empty input", () => {
+    expect(assignComplexity([])).toEqual([]);
+  });
+
+  it("assigns level 1 (simple) for a short, few-target, no-constraint, paper-only stage", () => {
+    const result = assignComplexity([{
+      course_display: "Short",
+      min_rounds: 6,
+      max_points: 30,
+      paper_targets: 3,
+      steel_targets: 0,
+      constraints: { strongHand: false, weakHand: false, movingTargets: false, unloadedStart: false },
+    }]);
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe(1);
+    expect(result[0].label).toBe("simple");
+  });
+
+  it("assigns level 5 (intricate) for a long, high-target, all-constraint, mixed-target stage", () => {
+    const result = assignComplexity([
+      // Include a minimal stage to set the low end of target normalisation
+      {
+        course_display: "Short",
+        min_rounds: 6,
+        max_points: 30,
+        paper_targets: 2,
+        steel_targets: 0,
+        constraints: { strongHand: false, weakHand: false, movingTargets: false, unloadedStart: false },
+      },
+      // The complex stage
+      {
+        course_display: "Long",
+        min_rounds: 32,
+        max_points: 160,
+        paper_targets: 12,
+        steel_targets: 6,
+        constraints: { strongHand: true, weakHand: true, movingTargets: true, unloadedStart: true },
+      },
+    ]);
+    expect(result[1].level).toBe(5);
+    expect(result[1].label).toBe("intricate");
+  });
+
+  it("handles a single stage (target normalisation edge case → factor 0.5)", () => {
+    const result = assignComplexity([{
+      course_display: "Medium",
+      min_rounds: 12,
+      max_points: 60,
+      paper_targets: 6,
+      steel_targets: 0,
+      constraints: { strongHand: false, weakHand: false, movingTargets: false, unloadedStart: false },
+    }]);
+    expect(result).toHaveLength(1);
+    // Medium course (0.5*0.35) + single stage target normalisation (0.5*0.25) + no constraints (0) + no variety (0)
+    // = 0.175 + 0.125 = 0.30 → level 2
+    expect(result[0].level).toBe(2);
+    expect(result[0].label).toBe("structured");
+  });
+
+  it("handles all-null metadata gracefully with reasonable defaults", () => {
+    const result = assignComplexity([{
+      course_display: null,
+      min_rounds: null,
+      max_points: 0,
+      paper_targets: null,
+      steel_targets: null,
+      constraints: null,
+    }]);
+    expect(result).toHaveLength(1);
+    // Unknown course (0.5*0.35) + target normalisation 0.5 (equal min/max, both 0) (0.5*0.25) + no constraints (0) + no variety (0)
+    // = 0.175 + 0.125 = 0.30 → level 2
+    expect(result[0].level).toBe(2);
+    expect(result[0].label).toBe("structured");
+  });
+
+  it("constraint factor correctly contributes to score", () => {
+    // Two identical stages except one has all constraints
+    const base = {
+      course_display: "Medium" as const,
+      min_rounds: 12,
+      max_points: 60,
+      paper_targets: 6,
+      steel_targets: 0,
+    };
+    const result = assignComplexity([
+      { ...base, constraints: { strongHand: false, weakHand: false, movingTargets: false, unloadedStart: false } },
+      { ...base, constraints: { strongHand: true, weakHand: true, movingTargets: true, unloadedStart: true } },
+    ]);
+    // Constrained stage should have a higher level
+    expect(result[1].level).toBeGreaterThan(result[0].level);
+  });
+
+  it("target variety factor increases complexity when both paper and steel are present", () => {
+    const base = {
+      course_display: "Medium" as const,
+      min_rounds: 12,
+      max_points: 60,
+      constraints: { strongHand: false, weakHand: false, movingTargets: false, unloadedStart: false },
+    };
+    const result = assignComplexity([
+      { ...base, paper_targets: 6, steel_targets: 0 },
+      { ...base, paper_targets: 4, steel_targets: 2 },
+    ]);
+    // Mixed targets stage should have higher or equal level
+    expect(result[1].level).toBeGreaterThanOrEqual(result[0].level);
+  });
+
+  it("uses min_rounds heuristic when course_display is null", () => {
+    const result = assignComplexity([
+      {
+        course_display: null,
+        min_rounds: 6,
+        max_points: 30,
+        paper_targets: 3,
+        steel_targets: 0,
+        constraints: null,
+      },
+      {
+        course_display: null,
+        min_rounds: 28,
+        max_points: 140,
+        paper_targets: 12,
+        steel_targets: 2,
+        constraints: null,
+      },
+    ]);
+    // Short (min_rounds=6) should have lower complexity than Long (min_rounds=28)
+    expect(result[0].level).toBeLessThan(result[1].level);
+  });
+
+  it("uses max_points fallback when both course_display and min_rounds are null", () => {
+    const result = assignComplexity([
+      {
+        course_display: null,
+        min_rounds: null,
+        max_points: 30,
+        paper_targets: null,
+        steel_targets: null,
+        constraints: null,
+      },
+      {
+        course_display: null,
+        min_rounds: null,
+        max_points: 160,
+        paper_targets: null,
+        steel_targets: null,
+        constraints: null,
+      },
+    ]);
+    // Low max_points should have lower complexity than high max_points
+    expect(result[0].level).toBeLessThanOrEqual(result[1].level);
   });
 });


### PR DESCRIPTION
## Summary

- Adds an intrinsic **stage complexity** indicator (1–5 scale: simple → structured → involved → complex → intricate) that measures how much planning and memorisation a stage demands based on stage metadata alone
- Uses an extensible weighted factor array: course length (0.35), target count (0.25), constraint count (0.25), and target variety (0.15) — adding a new factor later is just appending one entry
- Brain icon with blue-to-violet colour gradient (sky-400 → violet-500), visually distinct from difficulty's green-to-red bars
- Shown in both mobile popover and desktop stage header, with tooltip and text label
- Included in AI coaching prompt metadata and cell help modal
- 8 new unit tests covering edge cases (empty input, null metadata, single stage, factor isolation)

## Test plan

- [x] `pnpm -w run typecheck` — zero errors
- [x] `pnpm -w test` — 589 tests pass (all new + existing)
- [x] `pnpm -w run lint` — zero warnings
- [ ] `pnpm dev` → open a match with multiple stages → verify Brain icon appears next to difficulty bars
- [ ] Verify tooltip shows "Complexity: {label}" on hover/tap
- [ ] Verify short/paper-only stages show lower complexity than long/mixed/constrained stages
- [ ] Cell help modal shows the new complexity row (badge 4)
- [ ] `pnpm build` — production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)