### PR TITLE
feat: add OG image for shooter dashboard

### DIFF
--- a/app/api/og/match/[ct]/[id]/route.tsx
+++ b/app/api/og/match/[ct]/[id]/route.tsx
@@ -12,20 +12,21 @@ import {
   assignArchetype,
 } from "@/app/api/compare/logic";
 import { PALETTE } from "@/lib/colors";
+import {
+  C,
+  OG_W,
+  OG_H,
+  formatDate,
+  formatPct,
+  topAccent,
+  brandHeader,
+  statBadge,
+  pill,
+  pctBar,
+  targetBgLayers,
+  fallbackImage,
+} from "@/lib/og-helpers";
 import type { CompetitorInfo } from "@/lib/types";
-
-// ── Design tokens ──────────────────────────────────────────────────────
-
-const C = {
-  bg: "#0a0a0a",
-  cardBg: "#18181b",
-  border: "#27272a",
-  text: "#fafafa",
-  muted: "#a1a1aa",
-  dim: "#52525b",
-  accent: "#f97316",
-  barBg: "#27272a",
-} as const;
 
 // ── Compare data types (minimal subset of CompareResponse) ─────────────
 
@@ -249,22 +250,6 @@ async function fetchOgCompareStatsImpl(
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
-function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toLocaleDateString("en-US", {
-      day: "numeric",
-      month: "short",
-      year: "numeric",
-    });
-  } catch {
-    return iso;
-  }
-}
-
-function formatPct(pct: number): string {
-  return pct >= 100 ? "100" : pct.toFixed(1);
-}
-
 /**
  * Inline SVG icon for each archetype — same icons as lucide-react uses in
  * the comparison table (Target, Crosshair, Gauge, TrendingUp).
@@ -319,139 +304,6 @@ function archetypeIcon(archetype: string, size: number, color: string) {
     default:
       return null;
   }
-}
-
-// ── Shared layout pieces ────────────────────────────────────────────────
-
-/** Brand icon — concentric-circles target using design system colors. */
-function brandIcon() {
-  return (
-    <svg
-      width={48}
-      height={48}
-      viewBox="0 0 100 100"
-      style={{ display: "flex" }}
-    >
-      <circle cx="50" cy="50" r="44" fill="none" stroke={C.dim} strokeWidth="4" />
-      <circle cx="50" cy="50" r="28" fill="none" stroke={C.muted} strokeWidth="4" />
-      <circle cx="50" cy="50" r="12" fill="none" stroke={C.accent} strokeWidth="6" />
-    </svg>
-  );
-}
-
-function topAccent() {
-  return (
-    <div
-      style={{
-        display: "flex",
-        width: "100%",
-        height: "4px",
-        backgroundColor: C.accent,
-      }}
-    />
-  );
-}
-
-function brandHeader(rightText?: string) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "space-between",
-        width: "100%",
-      }}
-    >
-      <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
-        {brandIcon()}
-        <div style={{ fontSize: "24px", fontWeight: 600 }}>SSI Scoreboard</div>
-      </div>
-      {rightText !== undefined && rightText !== "" ? (
-        <div
-          style={{
-            display: "flex",
-            fontSize: "22px",
-            color: C.muted,
-            maxWidth: "600px",
-            backgroundColor: "rgba(10, 10, 10, 0.65)",
-            padding: "6px 14px",
-            borderRadius: "8px",
-          }}
-        >
-          {rightText}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function statBadge(value: string, label: string) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        padding: "14px 24px",
-        backgroundColor: C.cardBg,
-        borderRadius: "12px",
-        border: `1px solid ${C.border}`,
-      }}
-    >
-      <div style={{ fontSize: "36px", fontWeight: 700 }}>{value}</div>
-      <div style={{ fontSize: "18px", color: C.muted, marginTop: "2px" }}>
-        {label}
-      </div>
-    </div>
-  );
-}
-
-function pill(label: string, color: string, icon?: React.ReactNode) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: "8px",
-        padding: "8px 18px",
-        borderRadius: "20px",
-        backgroundColor: C.cardBg,
-        border: `1px solid ${C.border}`,
-        fontSize: "20px",
-        color,
-      }}
-    >
-      {icon ?? null}
-      {label}
-    </div>
-  );
-}
-
-/** Horizontal percentage bar */
-function pctBar(percent: number, color: string, height: string) {
-  const clamped = Math.max(0, Math.min(100, percent));
-  return (
-    <div
-      style={{
-        display: "flex",
-        width: "100%",
-        height,
-        backgroundColor: C.barBg,
-        borderRadius: "6px",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          width: `${String(clamped)}%`,
-          height: "100%",
-          backgroundColor: color,
-          borderRadius: "6px",
-        }}
-      />
-    </div>
-  );
 }
 
 function matchSubtitle(match: OgMatchData): string {
@@ -606,12 +458,6 @@ function singleCompetitorImage(
   return singleCompetitorNoStats(match, competitor, matchInfo, details);
 }
 
-// OG canvas dimensions (must match ImageResponse width/height).
-// Used for explicit pixel heights on absolutely-positioned layers so Satori
-// doesn't have to resolve "100%" through a chain of percentage containers.
-const OG_W = 1200;
-const OG_H = 630;
-
 /**
  * Background layer: the match image sits in the rightmost 1/3 of the canvas
  * (400px wide) at full OG height, with a linear gradient spanning the FULL
@@ -669,68 +515,6 @@ function matchImageBgLayers(
         style={{ objectFit: "cover", display: "flex" }}
       />
       {/* Gradient spans the FULL display width → perfectly linear fade */}
-      <div
-        style={{
-          position: "absolute",
-          left: 0,
-          top: 0,
-          width: displayW,
-          height: OG_H,
-          backgroundImage: `linear-gradient(to right, ${C.bg}, transparent)`,
-          display: "flex",
-        }}
-      />
-    </div>
-  );
-}
-
-/**
- * Decorative target background — shown when no match image is available.
- * Positioned on the right third like match images, with left-to-right fade.
- */
-function targetBgLayers() {
-  const displayW = Math.round(OG_W / 3);
-  const containerLeft = OG_W - displayW;
-  const targetSize = OG_H;
-
-  return (
-    <div
-      style={{
-        position: "absolute",
-        left: containerLeft,
-        top: 0,
-        width: displayW,
-        height: OG_H,
-        display: "flex",
-      }}
-    >
-      {/* Target — shifted right so only the left portion is visible */}
-      <div
-        style={{
-          position: "absolute",
-          left: displayW * 0.15,
-          top: 0,
-          width: targetSize,
-          height: targetSize,
-          display: "flex",
-          opacity: 0.1,
-        }}
-      >
-        <svg
-          width={targetSize}
-          height={targetSize}
-          viewBox="0 0 200 200"
-          style={{ display: "flex" }}
-        >
-          <circle cx="100" cy="100" r="96" fill="none" stroke={C.muted} strokeWidth="2" />
-          <circle cx="100" cy="100" r="72" fill="none" stroke={C.muted} strokeWidth="2" />
-          <circle cx="100" cy="100" r="48" fill="none" stroke={C.muted} strokeWidth="2" />
-          <circle cx="100" cy="100" r="24" fill="none" stroke={C.muted} strokeWidth="2" />
-          <line x1="100" y1="4" x2="100" y2="196" stroke={C.muted} strokeWidth="1" />
-          <line x1="4" y1="100" x2="196" y2="100" stroke={C.muted} strokeWidth="1" />
-        </svg>
-      </div>
-      {/* Gradient fade — same direction as match images */}
       <div
         style={{
           position: "absolute",
@@ -1352,51 +1136,3 @@ function multiCompetitorNoStats(
   );
 }
 
-/** Fallback — shown when the match cannot be loaded. */
-function fallbackImage() {
-  return (
-    <div
-      style={{
-        position: "relative",
-        display: "flex",
-        width: "100%",
-        height: "100%",
-        backgroundColor: C.bg,
-        color: C.text,
-      }}
-    >
-      {targetBgLayers()}
-
-      <div
-        style={{
-          position: "absolute",
-          left: 0,
-          top: 0,
-          width: OG_W,
-          height: OG_H,
-          display: "flex",
-          flexDirection: "column",
-        }}
-      >
-        {topAccent()}
-
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            flex: 1,
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "20px",
-          }}
-        >
-          {brandIcon()}
-          <div style={{ fontSize: "40px", fontWeight: 700 }}>SSI Scoreboard</div>
-          <div style={{ fontSize: "22px", color: C.muted }}>
-            Live IPSC competitor comparison
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -1,19 +1,12 @@
 import { ImageResponse } from "next/og";
-
-// ── Design tokens (same as match OG images) ─────────────────────────────
-
-const C = {
-  bg: "#0a0a0a",
-  cardBg: "#18181b",
-  border: "#27272a",
-  text: "#fafafa",
-  muted: "#a1a1aa",
-  dim: "#52525b",
-  accent: "#f97316",
-} as const;
-
-const OG_W = 1200;
-const OG_H = 630;
+import {
+  C,
+  OG_W,
+  OG_H,
+  brandIcon,
+  topAccent,
+  targetBgLayers,
+} from "@/lib/og-helpers";
 
 // ── Route handler ────────────────────────────────────────────────────────
 
@@ -44,15 +37,7 @@ export async function GET() {
             flexDirection: "column",
           }}
         >
-          {/* Top accent bar */}
-          <div
-            style={{
-              display: "flex",
-              width: "100%",
-              height: "4px",
-              backgroundColor: C.accent,
-            }}
-          />
+          {topAccent()}
 
           <div
             style={{
@@ -66,16 +51,7 @@ export async function GET() {
             }}
           >
             {/* App icon — concentric-circles target */}
-            <svg
-              width={96}
-              height={96}
-              viewBox="0 0 100 100"
-              style={{ display: "flex" }}
-            >
-              <circle cx="50" cy="50" r="44" fill="none" stroke={C.dim} strokeWidth="4" />
-              <circle cx="50" cy="50" r="28" fill="none" stroke={C.muted} strokeWidth="4" />
-              <circle cx="50" cy="50" r="12" fill="none" stroke={C.accent} strokeWidth="6" />
-            </svg>
+            {brandIcon(96)}
 
             {/* Title */}
             <div
@@ -144,62 +120,5 @@ export async function GET() {
       height: OG_H,
       headers: { "Cache-Control": "public, max-age=86400, s-maxage=604800" },
     },
-  );
-}
-
-/** Decorative target background — faded half-target on the right side. */
-function targetBgLayers() {
-  const displayW = Math.round(OG_W / 3);
-  const containerLeft = OG_W - displayW;
-  const targetSize = OG_H;
-
-  return (
-    <div
-      style={{
-        position: "absolute",
-        left: containerLeft,
-        top: 0,
-        width: displayW,
-        height: OG_H,
-        display: "flex",
-      }}
-    >
-      <div
-        style={{
-          position: "absolute",
-          left: displayW * 0.15,
-          top: 0,
-          width: targetSize,
-          height: targetSize,
-          display: "flex",
-          opacity: 0.1,
-        }}
-      >
-        <svg
-          width={targetSize}
-          height={targetSize}
-          viewBox="0 0 200 200"
-          style={{ display: "flex" }}
-        >
-          <circle cx="100" cy="100" r="96" fill="none" stroke={C.muted} strokeWidth="2" />
-          <circle cx="100" cy="100" r="72" fill="none" stroke={C.muted} strokeWidth="2" />
-          <circle cx="100" cy="100" r="48" fill="none" stroke={C.muted} strokeWidth="2" />
-          <circle cx="100" cy="100" r="24" fill="none" stroke={C.muted} strokeWidth="2" />
-          <line x1="100" y1="4" x2="100" y2="196" stroke={C.muted} strokeWidth="1" />
-          <line x1="4" y1="100" x2="196" y2="100" stroke={C.muted} strokeWidth="1" />
-        </svg>
-      </div>
-      <div
-        style={{
-          position: "absolute",
-          left: 0,
-          top: 0,
-          width: displayW,
-          height: OG_H,
-          backgroundImage: `linear-gradient(to right, ${C.bg}, transparent)`,
-          display: "flex",
-        }}
-      />
-    </div>
   );
 }

--- a/app/api/og/shooter/[shooterId]/route.tsx
+++ b/app/api/og/shooter/[shooterId]/route.tsx
@@ -1,0 +1,354 @@
+import { ImageResponse } from "next/og";
+import { fetchOgShooterData, type OgShooterData } from "@/lib/og-data";
+import {
+  C,
+  OG_W,
+  OG_H,
+  formatDate,
+  formatPct,
+  topAccent,
+  brandHeader,
+  statBadge,
+  pill,
+  pctBar,
+  targetBgLayers,
+  fallbackImage,
+} from "@/lib/og-helpers";
+
+// ── Route handler ──────────────────────────────────────────────────────
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ shooterId: string }> },
+) {
+  const { shooterId: shooterIdStr } = await params;
+  const shooterId = parseInt(shooterIdStr, 10);
+  if (isNaN(shooterId) || shooterId <= 0) {
+    return new ImageResponse(
+      fallbackImage("Shooter performance dashboard"),
+      {
+        width: OG_W,
+        height: OG_H,
+        headers: { "Cache-Control": "public, max-age=3600" },
+      },
+    );
+  }
+
+  // Social-media crawlers are patient — allow up to 5s for cold cache
+  const shooter = await fetchOgShooterData(shooterId, 5_000);
+
+  if (!shooter) {
+    return new ImageResponse(
+      fallbackImage("Shooter performance dashboard"),
+      {
+        width: OG_W,
+        height: OG_H,
+        headers: { "Cache-Control": "public, max-age=60" },
+      },
+    );
+  }
+
+  const hasStats = shooter.overallMatchPct != null && shooter.totalStages > 0;
+  const element = hasStats
+    ? shooterWithStatsImage(shooter)
+    : shooterProfileImage(shooter);
+  const cacheControl = hasStats
+    ? "public, max-age=300, s-maxage=1800"
+    : "public, max-age=60, s-maxage=300";
+
+  try {
+    return new ImageResponse(element, {
+      width: OG_W,
+      height: OG_H,
+      headers: { "Cache-Control": cacheControl },
+    });
+  } catch (err) {
+    console.error("[og] Shooter ImageResponse failed:", err);
+    return new ImageResponse(
+      fallbackImage("Shooter performance dashboard"),
+      {
+        width: OG_W,
+        height: OG_H,
+        headers: { "Cache-Control": "public, max-age=60" },
+      },
+    );
+  }
+}
+
+// ── Image variants ──────────────────────────────────────────────────────
+
+/** Full stats card — shown when dashboard cache is populated. */
+function shooterWithStatsImage(shooter: OgShooterData) {
+  const details = [shooter.division, shooter.club]
+    .filter(Boolean)
+    .join("  \u00b7  ");
+
+  const matchPct = shooter.overallMatchPct ?? 0;
+
+  // Date range text
+  const dateRange =
+    shooter.dateRange.from && shooter.dateRange.to
+      ? `${formatDate(shooter.dateRange.from)} \u2013 ${formatDate(shooter.dateRange.to)}`
+      : null;
+
+  // Trend pill
+  const trendLabel =
+    shooter.hfTrendSlope != null
+      ? shooter.hfTrendSlope > 0.01
+        ? "Improving"
+        : shooter.hfTrendSlope < -0.01
+          ? "Declining"
+          : "Stable"
+      : null;
+  const trendColor =
+    trendLabel === "Improving"
+      ? "#22c55e"
+      : trendLabel === "Declining"
+        ? "#ef4444"
+        : C.muted;
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        display: "flex",
+        width: "100%",
+        height: "100%",
+        backgroundColor: C.bg,
+        color: C.text,
+      }}
+    >
+      {targetBgLayers()}
+
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          top: 0,
+          width: OG_W,
+          height: OG_H,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {topAccent()}
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: 1,
+            padding: "36px 56px 32px",
+            gap: "24px",
+          }}
+        >
+          {brandHeader("Shooter Dashboard")}
+
+          {/* Content card */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              flex: 1,
+              justifyContent: "center",
+              gap: "24px",
+              width: "100%",
+              maxWidth: 700,
+              padding: "28px 36px",
+              backgroundColor: C.cardBg,
+              borderRadius: "16px",
+              border: `1px solid ${C.border}`,
+            }}
+          >
+            {/* Name + details */}
+            <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+              <div
+                style={{
+                  fontSize: "48px",
+                  fontWeight: 700,
+                  lineHeight: 1.15,
+                  letterSpacing: "-0.02em",
+                }}
+              >
+                {shooter.name}
+              </div>
+              {details !== "" ? (
+                <div style={{ display: "flex", fontSize: "24px", color: C.muted }}>
+                  {details}
+                </div>
+              ) : null}
+            </div>
+
+            {/* Match % + bar */}
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "flex-end",
+                gap: "20px",
+                width: "100%",
+              }}
+            >
+              <div style={{ display: "flex", flexDirection: "column" }}>
+                <div style={{ display: "flex", fontSize: "18px", color: C.dim }}>
+                  avg match performance
+                </div>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "baseline",
+                    gap: "4px",
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: "60px",
+                      fontWeight: 700,
+                      color: C.accent,
+                      lineHeight: 1,
+                    }}
+                  >
+                    {formatPct(matchPct)}
+                  </div>
+                  <div style={{ fontSize: "28px", color: C.dim }}>%</div>
+                </div>
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  flex: 1,
+                  flexDirection: "column",
+                  gap: "8px",
+                  paddingBottom: "8px",
+                }}
+              >
+                {pctBar(matchPct, C.accent, "20px")}
+                <div style={{ display: "flex", fontSize: "18px", color: C.dim }}>
+                  {`${String(shooter.matchCount)} matches  \u00b7  ${String(shooter.totalStages)} stages`}
+                </div>
+              </div>
+            </div>
+
+            {/* Stat badges + trend pill */}
+            <div style={{ display: "flex", gap: "10px", flexWrap: "wrap" }}>
+              {shooter.overallAvgHF != null
+                ? pill(`${shooter.overallAvgHF.toFixed(2)} avg HF`, C.muted)
+                : null}
+              {shooter.aPercent != null
+                ? pill(`${formatPct(shooter.aPercent)}% A-zone`, C.muted)
+                : null}
+              {trendLabel ? pill(trendLabel, trendColor) : null}
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "row",
+              justifyContent: "space-between",
+              alignItems: "flex-end",
+              width: "100%",
+            }}
+          >
+            {dateRange ? (
+              <div style={{ display: "flex", fontSize: "20px", color: C.dim }}>
+                {dateRange}
+              </div>
+            ) : (
+              <div style={{ display: "flex" }} />
+            )}
+            <div style={{ fontSize: "22px", color: C.dim }}>
+              scoreboard.urdr.dev
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Profile-only card — shown when no dashboard cache is available. */
+function shooterProfileImage(shooter: OgShooterData) {
+  const details = [shooter.division, shooter.club]
+    .filter(Boolean)
+    .join("  \u00b7  ");
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        display: "flex",
+        width: "100%",
+        height: "100%",
+        backgroundColor: C.bg,
+        color: C.text,
+      }}
+    >
+      {targetBgLayers()}
+
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          top: 0,
+          width: OG_W,
+          height: OG_H,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {topAccent()}
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: 1,
+            padding: "40px 56px 36px",
+            justifyContent: "space-between",
+          }}
+        >
+          {brandHeader("Shooter Dashboard")}
+
+          {/* Name + details */}
+          <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+            <div
+              style={{
+                fontSize: "56px",
+                fontWeight: 700,
+                lineHeight: 1.15,
+                letterSpacing: "-0.02em",
+              }}
+            >
+              {shooter.name}
+            </div>
+            {details !== "" ? (
+              <div style={{ display: "flex", fontSize: "28px", color: C.muted }}>
+                {details}
+              </div>
+            ) : null}
+          </div>
+
+          {/* Stats row */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "row",
+              alignItems: "flex-end",
+              justifyContent: "space-between",
+              width: "100%",
+            }}
+          >
+            <div style={{ display: "flex", gap: "20px" }}>
+              {statBadge(String(shooter.matchCount), "matches")}
+            </div>
+            <div style={{ fontSize: "22px", color: C.dim }}>
+              scoreboard.urdr.dev
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/shooter/[shooterId]/page.tsx
+++ b/app/shooter/[shooterId]/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { fetchOgShooterData } from "@/lib/og-data";
 import { ShooterDashboardClient } from "./shooter-dashboard-client";
 
 interface Props {
@@ -7,23 +9,47 @@ interface Props {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { shooterId } = await params;
-  const title = `Shooter #${shooterId} — SSI Scoreboard`;
+  const id = parseInt(shooterId, 10);
+
+  const shooter = !isNaN(id) && id > 0 ? await fetchOgShooterData(id) : null;
+
+  const name = shooter?.name ?? `Shooter #${shooterId}`;
+  const title = `${name} — SSI Scoreboard`;
+
+  const descParts = [
+    shooter?.division,
+    shooter?.club,
+    shooter ? `${String(shooter.matchCount)} matches` : null,
+  ].filter(Boolean);
   const description =
-    "Personal match history and performance stats across IPSC competitions.";
+    descParts.length > 0
+      ? descParts.join(" \u00b7 ")
+      : "Personal match history and performance stats across IPSC competitions.";
+
+  // Build absolute OG image URL
+  const headersList = await headers();
+  const host = headersList.get("host") ?? "localhost:3000";
+  const proto = headersList.get("x-forwarded-proto") ?? "http";
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || `${proto}://${host}`;
+
+  const ogUrl = `${baseUrl}/api/og/shooter/${shooterId}`;
+  const alt = `${name} shooter dashboard`;
 
   return {
     title,
     description,
     openGraph: {
-      title,
+      title: name,
       description,
       type: "website",
       siteName: "SSI Scoreboard",
+      images: [{ url: ogUrl, width: 1200, height: 630, alt }],
     },
     twitter: {
-      card: "summary",
-      title,
+      card: "summary_large_image",
+      title: name,
       description,
+      images: [{ url: ogUrl, alt }],
     },
   };
 }

--- a/lib/og-data.ts
+++ b/lib/og-data.ts
@@ -1,10 +1,11 @@
-// Server-only — fetches match metadata for OG image and page metadata generation.
-// Uses the same cached GraphQL path as the match API route.
+// Server-only — fetches match/shooter metadata for OG images and page metadata.
+// Uses cached data (GraphQL cache for matches, Redis index for shooters).
 
 import { fetchRawMatchData } from "@/lib/match-data";
 import { formatDivisionDisplay } from "@/lib/divisions";
 import { decodeShooterId } from "@/lib/shooter-index";
-import type { CompetitorInfo } from "@/lib/types";
+import cache from "@/lib/cache-impl";
+import type { CompetitorInfo, ShooterDashboardResponse } from "@/lib/types";
 
 // ── Public types ────────────────────────────────────────────────────────
 
@@ -108,6 +109,103 @@ async function fetchOgMatchDataImpl(
     };
   } catch (err) {
     console.error("[og] Failed to fetch match data:", err);
+    return null;
+  }
+}
+
+// ── Shooter OG data ──────────────────────────────────────────────────────
+
+export interface OgShooterData {
+  name: string;
+  club: string | null;
+  division: string | null;
+  matchCount: number;
+  totalStages: number;
+  overallAvgHF: number | null;
+  overallMatchPct: number | null;
+  aPercent: number | null;
+  hfTrendSlope: number | null;
+  dateRange: { from: string | null; to: string | null };
+}
+
+/**
+ * Fetch shooter data needed for OG images and page metadata.
+ * Reads from the pre-computed dashboard cache (same key the shooter API uses,
+ * 5min TTL). Falls back to profile + match count from the Redis index.
+ *
+ * Returns null if the shooter is not found in Redis at all.
+ */
+export async function fetchOgShooterData(
+  shooterId: number,
+  timeoutMs: number = METADATA_FETCH_TIMEOUT_MS,
+): Promise<OgShooterData | null> {
+  return Promise.race([
+    fetchOgShooterDataImpl(shooterId),
+    new Promise<null>((resolve) =>
+      setTimeout(() => resolve(null), timeoutMs),
+    ),
+  ]);
+}
+
+interface ShooterProfile {
+  name: string;
+  club: string | null;
+  division: string | null;
+  lastSeen: string;
+}
+
+async function fetchOgShooterDataImpl(
+  shooterId: number,
+): Promise<OgShooterData | null> {
+  try {
+    // Try pre-computed dashboard first (has full aggregate stats)
+    const dashboardKey = `computed:shooter:${String(shooterId)}:dashboard`;
+    const dashboardRaw = await cache.get(dashboardKey);
+    if (dashboardRaw) {
+      const dashboard = JSON.parse(dashboardRaw) as ShooterDashboardResponse;
+      return {
+        name: dashboard.profile?.name ?? `Shooter #${String(shooterId)}`,
+        club: dashboard.profile?.club ?? null,
+        division: dashboard.profile?.division ?? null,
+        matchCount: dashboard.matchCount,
+        totalStages: dashboard.stats.totalStages,
+        overallAvgHF: dashboard.stats.overallAvgHF,
+        overallMatchPct: dashboard.stats.overallMatchPct,
+        aPercent: dashboard.stats.aPercent,
+        hfTrendSlope: dashboard.stats.hfTrendSlope,
+        dateRange: dashboard.stats.dateRange,
+      };
+    }
+
+    // Fall back to profile + match count from the Redis index
+    const [profileRaw, matchRefs] = await Promise.all([
+      cache.getShooterProfile(shooterId),
+      cache.getShooterMatches(shooterId),
+    ]);
+
+    if (!profileRaw && matchRefs.length === 0) return null;
+
+    let profile: ShooterProfile | null = null;
+    if (profileRaw) {
+      try {
+        profile = JSON.parse(profileRaw) as ShooterProfile;
+      } catch { /* ignore */ }
+    }
+
+    return {
+      name: profile?.name ?? `Shooter #${String(shooterId)}`,
+      club: profile?.club ?? null,
+      division: profile?.division ?? null,
+      matchCount: matchRefs.length,
+      totalStages: 0,
+      overallAvgHF: null,
+      overallMatchPct: null,
+      aPercent: null,
+      hfTrendSlope: null,
+      dateRange: { from: null, to: null },
+    };
+  } catch (err) {
+    console.error("[og] Failed to fetch shooter data:", err);
     return null;
   }
 }

--- a/lib/og-helpers.tsx
+++ b/lib/og-helpers.tsx
@@ -1,0 +1,284 @@
+// Shared OG image design tokens, constants, and visual primitives.
+// Used by all OG image routes (match, shooter, root).
+
+import type React from "react";
+
+// ── Design tokens ──────────────────────────────────────────────────────
+
+export const C = {
+  bg: "#0a0a0a",
+  cardBg: "#18181b",
+  border: "#27272a",
+  text: "#fafafa",
+  muted: "#a1a1aa",
+  dim: "#52525b",
+  accent: "#f97316",
+  barBg: "#27272a",
+} as const;
+
+// ── Canvas dimensions ──────────────────────────────────────────────────
+
+export const OG_W = 1200;
+export const OG_H = 630;
+
+// ── Formatters ─────────────────────────────────────────────────────────
+
+export function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString("en-US", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function formatPct(pct: number): string {
+  return pct >= 100 ? "100" : pct.toFixed(1);
+}
+
+// ── Shared layout pieces ───────────────────────────────────────────────
+
+/** Brand icon — concentric-circles target using design system colors. */
+export function brandIcon(size = 48) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 100 100"
+      style={{ display: "flex" }}
+    >
+      <circle cx="50" cy="50" r="44" fill="none" stroke={C.dim} strokeWidth="4" />
+      <circle cx="50" cy="50" r="28" fill="none" stroke={C.muted} strokeWidth="4" />
+      <circle cx="50" cy="50" r="12" fill="none" stroke={C.accent} strokeWidth="6" />
+    </svg>
+  );
+}
+
+export function topAccent() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        width: "100%",
+        height: "4px",
+        backgroundColor: C.accent,
+      }}
+    />
+  );
+}
+
+export function brandHeader(rightText?: string) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "space-between",
+        width: "100%",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+        {brandIcon()}
+        <div style={{ fontSize: "24px", fontWeight: 600 }}>SSI Scoreboard</div>
+      </div>
+      {rightText !== undefined && rightText !== "" ? (
+        <div
+          style={{
+            display: "flex",
+            fontSize: "22px",
+            color: C.muted,
+            maxWidth: "600px",
+            backgroundColor: "rgba(10, 10, 10, 0.65)",
+            padding: "6px 14px",
+            borderRadius: "8px",
+          }}
+        >
+          {rightText}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function statBadge(value: string, label: string) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        padding: "14px 24px",
+        backgroundColor: C.cardBg,
+        borderRadius: "12px",
+        border: `1px solid ${C.border}`,
+      }}
+    >
+      <div style={{ fontSize: "36px", fontWeight: 700 }}>{value}</div>
+      <div style={{ fontSize: "18px", color: C.muted, marginTop: "2px" }}>
+        {label}
+      </div>
+    </div>
+  );
+}
+
+export function pill(label: string, color: string, icon?: React.ReactNode) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        padding: "8px 18px",
+        borderRadius: "20px",
+        backgroundColor: C.cardBg,
+        border: `1px solid ${C.border}`,
+        fontSize: "20px",
+        color,
+      }}
+    >
+      {icon ?? null}
+      {label}
+    </div>
+  );
+}
+
+/** Horizontal percentage bar */
+export function pctBar(percent: number, color: string, height: string) {
+  const clamped = Math.max(0, Math.min(100, percent));
+  return (
+    <div
+      style={{
+        display: "flex",
+        width: "100%",
+        height,
+        backgroundColor: C.barBg,
+        borderRadius: "6px",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          width: `${String(clamped)}%`,
+          height: "100%",
+          backgroundColor: color,
+          borderRadius: "6px",
+        }}
+      />
+    </div>
+  );
+}
+
+/**
+ * Decorative target background — shown when no match image is available.
+ * Positioned on the right third like match images, with left-to-right fade.
+ */
+export function targetBgLayers() {
+  const displayW = Math.round(OG_W / 3);
+  const containerLeft = OG_W - displayW;
+  const targetSize = OG_H;
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: containerLeft,
+        top: 0,
+        width: displayW,
+        height: OG_H,
+        display: "flex",
+      }}
+    >
+      {/* Target — shifted right so only the left portion is visible */}
+      <div
+        style={{
+          position: "absolute",
+          left: displayW * 0.15,
+          top: 0,
+          width: targetSize,
+          height: targetSize,
+          display: "flex",
+          opacity: 0.1,
+        }}
+      >
+        <svg
+          width={targetSize}
+          height={targetSize}
+          viewBox="0 0 200 200"
+          style={{ display: "flex" }}
+        >
+          <circle cx="100" cy="100" r="96" fill="none" stroke={C.muted} strokeWidth="2" />
+          <circle cx="100" cy="100" r="72" fill="none" stroke={C.muted} strokeWidth="2" />
+          <circle cx="100" cy="100" r="48" fill="none" stroke={C.muted} strokeWidth="2" />
+          <circle cx="100" cy="100" r="24" fill="none" stroke={C.muted} strokeWidth="2" />
+          <line x1="100" y1="4" x2="100" y2="196" stroke={C.muted} strokeWidth="1" />
+          <line x1="4" y1="100" x2="196" y2="100" stroke={C.muted} strokeWidth="1" />
+        </svg>
+      </div>
+      {/* Gradient fade — same direction as match images */}
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          top: 0,
+          width: displayW,
+          height: OG_H,
+          backgroundImage: `linear-gradient(to right, ${C.bg}, transparent)`,
+          display: "flex",
+        }}
+      />
+    </div>
+  );
+}
+
+/** Fallback — shown when data cannot be loaded. Tagline is configurable. */
+export function fallbackImage(tagline = "Live IPSC competitor comparison") {
+  return (
+    <div
+      style={{
+        position: "relative",
+        display: "flex",
+        width: "100%",
+        height: "100%",
+        backgroundColor: C.bg,
+        color: C.text,
+      }}
+    >
+      {targetBgLayers()}
+
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          top: 0,
+          width: OG_W,
+          height: OG_H,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {topAccent()}
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: 1,
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "20px",
+          }}
+        >
+          {brandIcon()}
+          <div style={{ fontSize: "40px", fontWeight: 700 }}>SSI Scoreboard</div>
+          <div style={{ fontSize: "22px", color: C.muted }}>
+            {tagline}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Extract shared OG design tokens and visual primitives (`C`, `OG_W`, `OG_H`, `brandIcon`, `topAccent`, `brandHeader`, `statBadge`, `pill`, `pctBar`, `targetBgLayers`, `fallbackImage`) into `lib/og-helpers.tsx`, removing duplication across the match and root OG routes
- Add `fetchOgShooterData()` to `lib/og-data.ts` — reads from the pre-computed dashboard cache (`computed:shooter:{id}:dashboard`), falling back to profile + match count from the Redis index
- Create `/api/og/shooter/[shooterId]` endpoint with two image variants: full stats card (match %, avg HF, A-zone %, trend pill, date range) and profile-only card (name, division, club, match count)
- Enrich `generateMetadata()` in the shooter page with real shooter name, division, club, and match count; set `og:image` and `twitter:card: summary_large_image`

## Test plan

- [ ] `pnpm -w run typecheck && pnpm -w run lint && pnpm -w test` — zero errors/warnings
- [ ] `curl http://localhost:3000/api/og/shooter/{id}` — returns PNG
- [ ] `curl -s http://localhost:3000/shooter/{id} | grep 'og:image'` — meta tag present
- [ ] Existing match OG still works: `curl http://localhost:3000/api/og/match/22/{id}` — returns PNG
- [ ] Root OG still works: `curl http://localhost:3000/api/og` — returns PNG

🤖 Generated with [Claude Code](https://claude.com/claude-code)