### PR TITLE
Harden Redis config and prevent unbounded growth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
-    command: redis-server --maxmemory 100mb --maxmemory-policy allkeys-lru
+    command: redis-server --maxmemory 100mb --maxmemory-policy volatile-lru --appendonly yes
     volumes:
       - redis_data:/data
     deploy:

--- a/lib/cache-edge.ts
+++ b/lib/cache-edge.ts
@@ -3,6 +3,7 @@
 // Never import ioredis or any Node.js-only module from this file.
 import { Redis } from "@upstash/redis";
 import type { CacheAdapter } from "@/lib/cache";
+import { MAX_SHOOTER_MATCHES } from "@/lib/constants";
 
 // Lazily initialised so that Cloudflare secrets (injected into process.env at
 // request time by @opennextjs/cloudflare) are read on first use rather than at
@@ -65,6 +66,20 @@ async function getPopularKeys(
     { byScore: true },
   )) as string[];
 
+  // Prune hits: remove members no longer present in seen.
+  const allHitMembers = (await getRedis().zrange(
+    pk("popular:matches:hits"),
+    0,
+    -1,
+  )) as string[];
+  if (allHitMembers.length > 0) {
+    const aliveSet = new Set(recentKeys);
+    const stale = allHitMembers.filter((m: string) => !aliveSet.has(m));
+    if (stale.length > 0) {
+      await getRedis().zrem(pk("popular:matches:hits"), ...stale);
+    }
+  }
+
   if (recentKeys.length === 0) return [];
 
   // Look up hit counts for each recent key in parallel.
@@ -91,10 +106,12 @@ async function indexShooterMatch(
   matchRef: string,
   startTimestamp: number,
 ): Promise<void> {
-  await getRedis().zadd(pk(`shooter:${shooterId}:matches`), {
-    score: startTimestamp,
-    member: matchRef,
-  });
+  const key = pk(`shooter:${shooterId}:matches`);
+  await getRedis().zadd(key, { score: startTimestamp, member: matchRef });
+  const count = await getRedis().zcard(key);
+  if (count > MAX_SHOOTER_MATCHES) {
+    await getRedis().zremrangebyrank(key, 0, count - MAX_SHOOTER_MATCHES - 1);
+  }
 }
 
 async function setShooterProfile(shooterId: number, profile: string): Promise<void> {

--- a/lib/cache-node.ts
+++ b/lib/cache-node.ts
@@ -2,6 +2,7 @@
 // Never import from client components or files with "use client".
 import Redis from "ioredis";
 import type { CacheAdapter } from "@/lib/cache";
+import { MAX_SHOOTER_MATCHES } from "@/lib/constants";
 
 const redis = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", {
   maxRetriesPerRequest: 1,
@@ -56,7 +57,15 @@ const adapter: CacheAdapter = {
   },
 
   async indexShooterMatch(shooterId, matchRef, startTimestamp) {
-    await redis.zadd(pk(`shooter:${shooterId}:matches`), startTimestamp, matchRef);
+    const key = pk(`shooter:${shooterId}:matches`);
+    const p = redis.pipeline();
+    p.zadd(key, startTimestamp, matchRef);
+    p.zcard(key);
+    const res = await p.exec();
+    const count = (res?.[1]?.[1] as number) ?? 0;
+    if (count > MAX_SHOOTER_MATCHES) {
+      await redis.zremrangebyrank(key, 0, count - MAX_SHOOTER_MATCHES - 1);
+    }
   },
 
   async setShooterProfile(shooterId, profile) {
@@ -95,6 +104,16 @@ const adapter: CacheAdapter = {
       cutoff,
       "+inf",
     );
+
+    // Prune hits: remove members no longer present in seen.
+    const allHitMembers = await redis.zrange(pk("popular:matches:hits"), 0, -1);
+    if (allHitMembers.length > 0) {
+      const aliveSet = new Set(recentKeys);
+      const stale = allHitMembers.filter((m) => !aliveSet.has(m));
+      if (stale.length > 0) {
+        await redis.zrem(pk("popular:matches:hits"), ...stale);
+      }
+    }
 
     if (recentKeys.length === 0) return [];
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -18,3 +18,10 @@ export const MAX_COMPETITORS = 12;
  *   6 → added shooter { id } to IpscCompetitorNode in MATCH_QUERY; shooterId on CompetitorInfo
  */
 export const CACHE_SCHEMA_VERSION = 6;
+
+/**
+ * Maximum number of match references to keep per shooter in the
+ * `shooter:{id}:matches` sorted set. Oldest entries are trimmed
+ * after each indexShooterMatch() call to prevent unbounded growth.
+ */
+export const MAX_SHOOTER_MATCHES = 200;


### PR DESCRIPTION
## Summary
- Switch Redis eviction policy from `allkeys-lru` to `volatile-lru` so permanent keys (shooter index, profiles, completed matches) are never evicted under memory pressure
- Enable AOF persistence (`appendonly yes`) to protect permanent data against container restarts
- Cap `shooter:{id}:matches` sorted sets at 200 most recent entries to prevent unbounded growth
- Prune stale members from `popular:matches:hits` during `getPopularKeys()` reads (the `seen` set was already pruned, but `hits` grew indefinitely)

Relates to #208

## Test plan
- [x] `pnpm -w run typecheck` — zero errors
- [x] `pnpm -w test` — all 635 tests pass
- [ ] Verify Redis AOF file appears in `redis_data` volume after `docker-compose up`
- [ ] Confirm permanent keys survive `docker-compose restart redis`

🤖 Generated with [Claude Code](https://claude.com/claude-code)