### PR TITLE
feat: add upcoming matches section to shooter dashboard

### DIFF
--- a/app/api/shooter/[shooterId]/route.ts
+++ b/app/api/shooter/[shooterId]/route.ts
@@ -12,6 +12,7 @@ import { evaluateAchievements } from "@/lib/achievements/evaluate";
 import type {
   ShooterDashboardResponse,
   ShooterMatchSummary,
+  UpcomingMatch,
 } from "@/lib/types";
 import type { RawScorecardsData } from "@/lib/scorecard-data";
 import type { RawScorecard } from "@/app/api/compare/logic";
@@ -194,13 +195,15 @@ export async function GET(
     }
   } catch { /* ignore cache errors */ }
 
-  // ── 2. Load profile and match refs from ShooterStore ─────────────────────
+  // ── 2. Load profile, match refs, and upcoming refs from ShooterStore ────
   let profile: ShooterProfile | null = null;
   let matchRefs: string[] = [];
+  let upcomingRefs: string[] = [];
   try {
-    [profile, matchRefs] = await Promise.all([
+    [profile, matchRefs, upcomingRefs] = await Promise.all([
       db.getShooterProfile(shooterId),
       db.getShooterMatches(shooterId),
+      db.getUpcomingMatches(shooterId),
     ]);
   } catch { /* ignore store errors */ }
 
@@ -208,11 +211,15 @@ export async function GET(
     return NextResponse.json({ error: "Shooter not found" }, { status: 404 });
   }
 
-  const totalMatchCount = matchRefs.length;
+  // Exclude upcoming refs from regular match processing
+  const upcomingSet = new Set(upcomingRefs);
+  const pastRefs = matchRefs.filter((ref) => !upcomingSet.has(ref));
+
+  const totalMatchCount = pastRefs.length;
 
   // ── 3. Process most recent N matches ─────────────────────────────────────
-  // matchRefs is sorted ascending by timestamp; take the last MAX_MATCHES
-  const recentRefs = matchRefs.slice(-MAX_MATCHES).reverse(); // newest first
+  // pastRefs is sorted ascending by timestamp; take the last MAX_MATCHES
+  const recentRefs = pastRefs.slice(-MAX_MATCHES).reverse(); // newest first
 
   // Load match + scorecard cache entries in parallel (batched to avoid flood)
   const BATCH = 10;
@@ -355,6 +362,51 @@ export async function GET(
     }
   }
 
+  // ── 3b. Resolve upcoming match metadata ──────────────────────────────────
+  const upcomingMatches: UpcomingMatch[] = [];
+  for (const ref of upcomingRefs) {
+    const parts = ref.split(":");
+    if (parts.length < 2) continue;
+    const [ct, ...idParts] = parts;
+    const matchId = idParts.join(":");
+    if (!ct || !matchId) continue;
+    const ctNum = parseInt(ct, 10);
+    if (isNaN(ctNum)) continue;
+
+    const matchKey = gqlCacheKey("GetMatch", { ct: ctNum, id: matchId });
+    let matchRaw: string | null = null;
+    try {
+      matchRaw = await cache.get(matchKey);
+    } catch { continue; }
+    if (!matchRaw) continue;
+
+    try {
+      const matchEntry = JSON.parse(matchRaw) as CacheEntry<RawMatchData>;
+      if (matchEntry.v !== CACHE_SCHEMA_VERSION) continue;
+      if (!matchEntry.data?.event) continue;
+
+      const ev = matchEntry.data.event;
+      const competitor = (
+        ev.competitors_approved_w_wo_results_not_dnf ?? []
+      ).find((c) => decodeShooterId(c.shooter?.id) === shooterId);
+      if (!competitor) continue;
+
+      upcomingMatches.push({
+        ct,
+        matchId,
+        name: ev.name,
+        date: ev.starts ?? null,
+        venue: ev.venue ?? null,
+        level: ev.level ?? null,
+        division: formatDivisionDisplay(
+          competitor.get_handgun_div_display ?? competitor.handgun_div,
+          competitor.shoots_handgun_major,
+        ),
+        competitorId: parseInt(competitor.id, 10),
+      });
+    } catch { /* skip on parse error */ }
+  }
+
   // ── 4. Compute cross-match aggregates ─────────────────────────────────────
   const stats = computeAggregateStats(matchSummaries);
 
@@ -381,6 +433,7 @@ export async function GET(
     matches: matchSummaries,
     stats,
     achievements,
+    ...(upcomingMatches.length > 0 ? { upcomingMatches } : {}),
   };
 
   // ── 6. Cache the result ───────────────────────────────────────────────────

--- a/app/shooter/[shooterId]/shooter-dashboard-client.tsx
+++ b/app/shooter/[shooterId]/shooter-dashboard-client.tsx
@@ -27,6 +27,7 @@ import {
   Check,
   Plus,
   ArrowLeft,
+  Calendar,
   Trophy,
   Swords,
   Crosshair,
@@ -65,6 +66,7 @@ import type {
   ShooterMatchSummary,
   BackfillProgress,
   AchievementProgress,
+  UpcomingMatch,
 } from "@/lib/types";
 
 // ─── Formatting helpers ───────────────────────────────────────────────────────
@@ -236,6 +238,55 @@ function MatchCard({ match }: { match: ShooterMatchSummary }) {
             {formatHF(match.avgHF)} HF
           </span>
         )}
+      </div>
+      <ChevronRight
+        className="w-4 h-4 text-muted-foreground shrink-0 group-hover:text-foreground transition-colors"
+        aria-hidden="true"
+      />
+    </Link>
+  );
+}
+
+// ─── Upcoming match card ─────────────────────────────────────────────────────
+
+function UpcomingMatchCard({ match }: { match: UpcomingMatch }) {
+  const href = `/match/${match.ct}/${match.matchId}?competitors=${match.competitorId}`;
+  const badge = levelBadge(match.level);
+
+  return (
+    <Link
+      href={href}
+      className="flex items-center gap-3 p-3 rounded-lg border border-border hover:bg-muted/50 transition-colors group min-h-[44px]"
+      aria-label={`Upcoming: ${match.name}${match.date ? `, ${formatDate(match.date)}` : ""}`}
+    >
+      <Calendar
+        className="w-4 h-4 text-muted-foreground shrink-0"
+        aria-hidden="true"
+      />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-medium text-sm truncate">{match.name}</span>
+          {badge && (
+            <span className="shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-muted text-muted-foreground uppercase tracking-wide">
+              {badge}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+          <span className="text-xs text-muted-foreground">
+            {formatDate(match.date)}
+          </span>
+          {match.venue && (
+            <span className="text-xs text-muted-foreground">
+              · {match.venue}
+            </span>
+          )}
+          {match.division && (
+            <span className="text-xs text-muted-foreground">
+              · {match.division}
+            </span>
+          )}
+        </div>
       </div>
       <ChevronRight
         className="w-4 h-4 text-muted-foreground shrink-0 group-hover:text-foreground transition-colors"
@@ -1098,6 +1149,7 @@ export function ShooterDashboardClient({ shooterId, from }: Props) {
     shooterId,
   );
   const [historyOpen, setHistoryOpen] = useState(true);
+  const [upcomingOpen, setUpcomingOpen] = useState(false);
   const [divisionFilter, setDivisionFilter] = useState<string | null | "unset">("unset");
 
   // Derive divisions and default filter once data loads
@@ -1334,6 +1386,52 @@ export function ShooterDashboardClient({ shooterId, from }: Props) {
             matches={filteredMatches}
             divisionFilter={effectiveFilter}
           />
+        </section>
+      )}
+
+      {/* ── Upcoming matches ──────────────────────────────────────────── */}
+      {data.upcomingMatches && data.upcomingMatches.length > 0 && (
+        <section>
+          <h2 className="text-sm font-semibold m-0 leading-none">
+            <button
+              type="button"
+              id="upcoming-heading"
+              onClick={() => setUpcomingOpen((v) => !v)}
+              aria-expanded={upcomingOpen}
+              aria-controls="upcoming-panel"
+              className="flex w-full items-center justify-between text-left gap-2 mb-3 min-h-[2.75rem]"
+            >
+              <span className="flex items-center gap-2">
+                <span className="text-muted-foreground uppercase tracking-wide">
+                  Upcoming
+                </span>
+                <span className="text-xs font-normal text-muted-foreground">
+                  ({data.upcomingMatches.length})
+                </span>
+              </span>
+              {upcomingOpen ? (
+                <ChevronUp className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />
+              ) : (
+                <ChevronDown className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />
+              )}
+            </button>
+          </h2>
+
+          {upcomingOpen && (
+            <div
+              id="upcoming-panel"
+              role="region"
+              aria-labelledby="upcoming-heading"
+              className="flex flex-col gap-2"
+            >
+              {data.upcomingMatches.map((match) => (
+                <UpcomingMatchCard
+                  key={`${match.ct}:${match.matchId}`}
+                  match={match}
+                />
+              ))}
+            </div>
+          )}
         </section>
       )}
 

--- a/lib/db-d1.ts
+++ b/lib/db-d1.ts
@@ -104,6 +104,20 @@ const db: AppDatabase = {
     return result.results.map((r) => r.match_ref);
   },
 
+  async getUpcomingMatches(shooterId) {
+    const now = Math.floor(Date.now() / 1000);
+    const db = getDb();
+    const result = await db
+      .prepare(
+        `SELECT match_ref FROM shooter_matches
+         WHERE shooter_id = ? AND start_timestamp > ?
+         ORDER BY start_timestamp ASC`,
+      )
+      .bind(shooterId, now)
+      .all<{ match_ref: string }>();
+    return result.results.map((r) => r.match_ref);
+  },
+
   async getShooterProfile(shooterId) {
     const db = getDb();
     const row = await db

--- a/lib/db-sqlite.ts
+++ b/lib/db-sqlite.ts
@@ -141,6 +141,18 @@ export function createSqliteDatabase(
       return rows.map((r) => r.match_ref);
     },
 
+    async getUpcomingMatches(shooterId) {
+      const now = Math.floor(Date.now() / 1000);
+      const rows = getDb()
+        .prepare(
+          `SELECT match_ref FROM shooter_matches
+           WHERE shooter_id = ? AND start_timestamp > ?
+           ORDER BY start_timestamp ASC`,
+        )
+        .all(shooterId, now) as { match_ref: string }[];
+      return rows.map((r) => r.match_ref);
+    },
+
     async getShooterProfile(shooterId) {
       const row = getDb()
         .prepare(

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -30,6 +30,9 @@ export interface AppDatabase {
   /** Return all match refs for a shooter, sorted by match date ascending. */
   getShooterMatches(shooterId: number): Promise<string[]>;
 
+  /** Return match refs where start_timestamp > now(), sorted ascending. */
+  getUpcomingMatches(shooterId: number): Promise<string[]>;
+
   /** Return the shooter profile, or null if not found. */
   getShooterProfile(shooterId: number): Promise<ShooterProfile | null>;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -496,6 +496,19 @@ export interface BackfillProgress {
   errorMessage?: string;
 }
 
+// ── Upcoming Matches ──────────────────────────────────────────────────────────
+
+export interface UpcomingMatch {
+  ct: string;
+  matchId: string;
+  name: string;
+  date: string | null;
+  venue: string | null;
+  level: string | null;
+  division: string | null;
+  competitorId: number;
+}
+
 // ── Shooter Dashboard ─────────────────────────────────────────────────────────
 
 // Per-match summary for the shooter dashboard.
@@ -566,6 +579,8 @@ export interface ShooterDashboardResponse {
   /** Up to 50 most recent matches, sorted newest first. */
   matches: ShooterMatchSummary[];
   stats: ShooterAggregateStats;
+  /** Matches with start_timestamp in the future. Only present when non-empty. */
+  upcomingMatches?: UpcomingMatch[];
   /** Achievement progress (preview feature). */
   achievements?: _AchievementProgress[];
 }


### PR DESCRIPTION
## Summary

- Add `getUpcomingMatches()` to `AppDatabase` interface with SQLite and D1 implementations — queries `shooter_matches` for rows with `start_timestamp > now()`
- Add `UpcomingMatch` type and include optional `upcomingMatches` in `ShooterDashboardResponse`
- Shooter API route fetches upcoming refs, excludes them from past-match stats processing, resolves match metadata from cache, and returns them separately
- Dashboard UI shows a collapsed "Upcoming (N)" accordion section above Match history with `UpcomingMatchCard` components (calendar icon, match name, level badge, date, venue, division)

## Test plan

- [x] `pnpm -w run typecheck` — zero errors
- [x] `pnpm -w run lint` — zero warnings
- [x] `pnpm -w test` — all 691 tests pass
- [ ] Manual: visit a shooter dashboard with an indexed future match → "Upcoming" section appears
- [ ] Manual: section is collapsed by default, expands on tap, cards link to match page with `?competitors=`
- [ ] Manual: shooter with no upcoming matches → section does not render

🤖 Generated with [Claude Code](https://claude.com/claude-code)