### PR TITLE
fix: lab sync skips 404 matches instead of retrying

### DIFF
--- a/lab/src/data/store.py
+++ b/lab/src/data/store.py
@@ -99,6 +99,20 @@ class Store:
         ).fetchone()
         return row is not None
 
+    def skip_match(self, ct: int, match_id: str, name: str) -> None:
+        """Record a match as known but without results (e.g. no scorecards on SSI).
+
+        Prevents the sync from retrying it on every run.
+        """
+        synced_at = datetime.now(UTC).isoformat()
+        self.db.execute(
+            """INSERT OR IGNORE INTO matches
+               (ct, match_id, name, date, level, region,
+                competitor_count, stage_count, scoring_completed, synced_at)
+               VALUES (?, ?, ?, NULL, NULL, NULL, 0, 0, 0, ?)""",
+            [ct, match_id, name, synced_at],
+        )
+
     def store_match_results(self, results: MatchResults) -> None:
         """Store a full match result set (metadata + competitors + stages + results)."""
         meta = results.meta

--- a/lab/src/data/sync.py
+++ b/lab/src/data/sync.py
@@ -164,7 +164,14 @@ class SyncClient:
                     synced += 1
                     progress.update(task, advance=1, description=f"[green]{m.name}[/green]")
                 except httpx.HTTPStatusError as e:
-                    console.print(f"  [red]Error fetching {m.name}: {e.response.status_code}[/red]")
+                    if e.response.status_code == 404:
+                        # No scorecard data on SSI — record as known so we don't retry
+                        self.store.skip_match(m.ct, m.match_id, m.name)
+                        console.print(f"  [yellow]Skipped {m.name} (no data on SSI)[/yellow]")
+                    else:
+                        console.print(
+                            f"  [red]Error fetching {m.name}: {e.response.status_code}[/red]"
+                        )
                     progress.update(task, advance=1)
                 except Exception as e:
                     console.print(f"  [red]Error processing {m.name}: {e}[/red]")


### PR DESCRIPTION
## Summary

- Matches without scorecard data on SSI (old 2020 matches, cancelled events) return 404 from the results endpoint
- Previously these were logged as errors and retried on every `--full` sync
- Now the sync client calls `store.skip_match()` on 404, recording the match as known (with no results) so `has_match()` returns true on subsequent runs
- Non-404 errors are still logged normally

## Test plan

- [x] `uv run ruff check src/` — clean
- [x] `uv run mypy src/` — clean
- [ ] `uv run rating sync --full` — 7 matches show "Skipped (no data on SSI)" instead of errors, and subsequent runs don't retry them

🤖 Generated with [Claude Code](https://claude.com/claude-code)