### PR TITLE
feat: per-region, per-division, per-category ranking in ratings lab

### DIFF
--- a/app/api/data/match/[ct]/[id]/results/route.ts
+++ b/app/api/data/match/[ct]/[id]/results/route.ts
@@ -30,6 +30,9 @@ interface RawMatchData {
       handgun_div?: string | null;
       get_handgun_div_display?: string | null;
       shooter?: { id: string } | null;
+      region?: string | null;
+      get_region_display?: string | null;
+      category?: string | null;
     }>;
   } | null;
 }
@@ -89,6 +92,9 @@ export async function GET(
     name: [c.first_name, c.last_name].filter(Boolean).join(" "),
     club: c.club ?? null,
     division: c.get_handgun_div_display ?? c.handgun_div ?? null,
+    region: c.region ?? null,
+    regionDisplay: c.get_region_display ?? null,
+    category: c.category ?? null,
   }));
 
   // Build stage metadata

--- a/lab/src/algorithms/base.py
+++ b/lab/src/algorithms/base.py
@@ -29,6 +29,11 @@ class RatingAlgorithm(ABC):
         match_date: str | None,
         stage_results: list[tuple[int, int, float | None, bool, bool, bool]],
         competitor_shooter_map: dict[int, int | None],
+        *,
+        name_map: dict[int, str] | None = None,
+        division_map: dict[int, str | None] | None = None,
+        region_map: dict[int, str | None] | None = None,
+        category_map: dict[int, str | None] | None = None,
     ) -> None:
         """Process a single match's stage results.
 
@@ -38,6 +43,10 @@ class RatingAlgorithm(ABC):
             match_date: ISO date string or None
             stage_results: List of (competitor_id, stage_id, hit_factor, dq, dnf, zeroed)
             competitor_shooter_map: competitor_id → shooter_id mapping
+            name_map: competitor_id → name mapping (optional)
+            division_map: competitor_id → division mapping (optional)
+            region_map: competitor_id → region mapping (optional)
+            category_map: competitor_id → category mapping (optional)
         """
 
     @abstractmethod

--- a/lab/src/algorithms/elo.py
+++ b/lab/src/algorithms/elo.py
@@ -28,6 +28,8 @@ class MultiElo(RatingAlgorithm):
         self._ratings: dict[int, float] = {}
         self._names: dict[int, str] = {}
         self._divisions: dict[int, str | None] = {}
+        self._regions: dict[int, str | None] = {}
+        self._categories: dict[int, str | None] = {}
         self._matches: dict[int, int] = defaultdict(int)
         self._seen_matches: set[str] = set()
 
@@ -54,6 +56,11 @@ class MultiElo(RatingAlgorithm):
         match_date: str | None,
         stage_results: list[tuple[int, int, float | None, bool, bool, bool]],
         competitor_shooter_map: dict[int, int | None],
+        *,
+        name_map: dict[int, str] | None = None,
+        division_map: dict[int, str | None] | None = None,
+        region_map: dict[int, str | None] | None = None,
+        category_map: dict[int, str | None] | None = None,
     ) -> None:
         match_key = f"{ct}:{match_id}"
         if match_key in self._seen_matches:
@@ -115,9 +122,20 @@ class MultiElo(RatingAlgorithm):
                 current = self._ratings.get(sid, DEFAULT_RATING)
                 self._ratings[sid] = current + delta
 
-        # Update match counts
-        for sid in match_shooters:
-            self._matches[sid] += 1
+        # Update match counts and metadata
+        for comp_id, shooter_id in competitor_shooter_map.items():
+            if shooter_id is None:
+                continue
+            if shooter_id in match_shooters:
+                self._matches[shooter_id] += 1
+            if name_map and comp_id in name_map:
+                self._names[shooter_id] = name_map[comp_id]
+            if division_map and comp_id in division_map:
+                self._divisions[shooter_id] = division_map[comp_id]
+            if region_map and comp_id in region_map:
+                self._regions[shooter_id] = region_map[comp_id]
+            if category_map and comp_id in category_map:
+                self._categories[shooter_id] = category_map[comp_id]
 
     def get_ratings(self) -> dict[int, Rating]:
         result: dict[int, Rating] = {}
@@ -126,6 +144,8 @@ class MultiElo(RatingAlgorithm):
                 shooter_id=sid,
                 name=self._names.get(sid, f"Shooter {sid}"),
                 division=self._divisions.get(sid),
+                region=self._regions.get(sid),
+                category=self._categories.get(sid),
                 mu=rating,
                 sigma=0.0,  # ELO doesn't have a separate sigma
                 matches_played=self._matches.get(sid, 0),
@@ -143,6 +163,8 @@ class MultiElo(RatingAlgorithm):
             "matches": {str(k): v for k, v in self._matches.items()},
             "names": {str(k): v for k, v in self._names.items()},
             "divisions": {str(k): v for k, v in self._divisions.items()},
+            "regions": {str(k): v for k, v in self._regions.items()},
+            "categories": {str(k): v for k, v in self._categories.items()},
             "seen_matches": list(self._seen_matches),
         }
         path.write_text(json.dumps(state))
@@ -153,4 +175,6 @@ class MultiElo(RatingAlgorithm):
         self._matches = defaultdict(int, {int(k): v for k, v in state["matches"].items()})
         self._names = {int(k): v for k, v in state.get("names", {}).items()}
         self._divisions = {int(k): v for k, v in state.get("divisions", {}).items()}
+        self._regions = {int(k): v for k, v in state.get("regions", {}).items()}
+        self._categories = {int(k): v for k, v in state.get("categories", {}).items()}
         self._seen_matches = set(state.get("seen_matches", []))

--- a/lab/src/algorithms/openskill_pl.py
+++ b/lab/src/algorithms/openskill_pl.py
@@ -27,6 +27,10 @@ class OpenSkillPL(RatingAlgorithm):
         self._names: dict[int, str] = {}
         # shooter_id → division (most recent)
         self._divisions: dict[int, str | None] = {}
+        # shooter_id → region (most recent)
+        self._regions: dict[int, str | None] = {}
+        # shooter_id → category (most recent)
+        self._categories: dict[int, str | None] = {}
         # shooter_id → matches_played count
         self._matches: dict[int, int] = defaultdict(int)
         # Track which shooters participated in each match (by match key)
@@ -50,6 +54,11 @@ class OpenSkillPL(RatingAlgorithm):
         match_date: str | None,
         stage_results: list[tuple[int, int, float | None, bool, bool, bool]],
         competitor_shooter_map: dict[int, int | None],
+        *,
+        name_map: dict[int, str] | None = None,
+        division_map: dict[int, str | None] | None = None,
+        region_map: dict[int, str | None] | None = None,
+        category_map: dict[int, str | None] | None = None,
     ) -> None:
         match_key = f"{ct}:{match_id}"
         if match_key in self._seen_matches:
@@ -103,10 +112,20 @@ class OpenSkillPL(RatingAlgorithm):
                 new_r = updated[i][0]
                 self._ratings[sid] = (new_r.mu, new_r.sigma)
 
-        # Update match counts and names
-        for _comp_id, shooter_id in competitor_shooter_map.items():
-            if shooter_id is not None and shooter_id in match_shooters:
+        # Update match counts and metadata
+        for comp_id, shooter_id in competitor_shooter_map.items():
+            if shooter_id is None:
+                continue
+            if shooter_id in match_shooters:
                 self._matches[shooter_id] += 1
+            if name_map and comp_id in name_map:
+                self._names[shooter_id] = name_map[comp_id]
+            if division_map and comp_id in division_map:
+                self._divisions[shooter_id] = division_map[comp_id]
+            if region_map and comp_id in region_map:
+                self._regions[shooter_id] = region_map[comp_id]
+            if category_map and comp_id in category_map:
+                self._categories[shooter_id] = category_map[comp_id]
 
     def get_ratings(self) -> dict[int, Rating]:
         result: dict[int, Rating] = {}
@@ -115,6 +134,8 @@ class OpenSkillPL(RatingAlgorithm):
                 shooter_id=sid,
                 name=self._names.get(sid, f"Shooter {sid}"),
                 division=self._divisions.get(sid),
+                region=self._regions.get(sid),
+                category=self._categories.get(sid),
                 mu=mu,
                 sigma=sigma,
                 matches_played=self._matches.get(sid, 0),
@@ -135,14 +156,18 @@ class OpenSkillPL(RatingAlgorithm):
             "matches": {str(k): v for k, v in self._matches.items()},
             "names": {str(k): v for k, v in self._names.items()},
             "divisions": {str(k): v for k, v in self._divisions.items()},
+            "regions": {str(k): v for k, v in self._regions.items()},
+            "categories": {str(k): v for k, v in self._categories.items()},
             "seen_matches": list(self._seen_matches),
         }
         path.write_text(json.dumps(state))
 
     def load_state(self, path: Path) -> None:
         state = json.loads(path.read_text())
-        self._ratings = {int(k): tuple(v) for k, v in state["ratings"].items()}
+        self._ratings = {int(k): (v[0], v[1]) for k, v in state["ratings"].items()}
         self._matches = defaultdict(int, {int(k): v for k, v in state["matches"].items()})
         self._names = {int(k): v for k, v in state.get("names", {}).items()}
         self._divisions = {int(k): v for k, v in state.get("divisions", {}).items()}
+        self._regions = {int(k): v for k, v in state.get("regions", {}).items()}
+        self._categories = {int(k): v for k, v in state.get("categories", {}).items()}
         self._seen_matches = set(state.get("seen_matches", []))

--- a/lab/src/cli.py
+++ b/lab/src/cli.py
@@ -18,7 +18,7 @@ def sync(
     url: str = typer.Option("http://localhost:3000", help="Base URL of the SSI Scoreboard app"),
     token: str = typer.Option(..., envvar="CACHE_PURGE_SECRET", help="Bearer token for auth"),
     full: bool = typer.Option(False, help="Full sync (ignore watermark)"),
-    force: bool = typer.Option(False, help="Force re-download of all matches (even if already stored)"),
+    force: bool = typer.Option(False, help="Force re-download of all matches (even if already stored)"),  # noqa: E501
     delay: float = typer.Option(2.0, help="Delay between requests in seconds (0 for no delay)"),
     db_path: Path = DB_PATH_OPTION,
 ) -> None:
@@ -59,15 +59,27 @@ def train(
                 comp_map = store.get_competitor_shooter_map(ct, match_id)
                 if not results:
                     continue
-                algo.process_match_data(ct, match_id, match_date, results, comp_map)
+                name_map = store.get_competitor_name_map(ct, match_id)
+                div_map = store.get_competitor_division_map(ct, match_id)
+                region_map = store.get_competitor_region_map(ct, match_id)
+                cat_map = store.get_competitor_category_map(ct, match_id)
+                algo.process_match_data(
+                    ct, match_id, match_date, results, comp_map,
+                    name_map=name_map, division_map=div_map,
+                    region_map=region_map, category_map=cat_map,
+                )
 
             ratings = algo.get_ratings()
             console.print(f"  Rated {len(ratings)} shooters")
 
             # Save to DuckDB
-            rating_data: dict[int, tuple[str, str | None, float, float, int, str | None]] = {}
+            from src.data.store import RatingRow
+            rating_data: dict[int, RatingRow] = {}
             for sid, r in ratings.items():
-                rating_data[sid] = (r.name, r.division, r.mu, r.sigma, r.matches_played, None)
+                rating_data[sid] = (
+                    r.name, r.division, r.region, r.category,
+                    r.mu, r.sigma, r.matches_played, None,
+                )
             store.save_ratings(algo.name, rating_data)
             console.print(f"  [green]Saved ratings for {algo.name}[/green]")
     finally:

--- a/lab/src/data/models.py
+++ b/lab/src/data/models.py
@@ -46,6 +46,9 @@ class CompetitorMeta(BaseModel):
     name: str
     club: str | None = None
     division: str | None = None
+    region: str | None = None
+    region_display: str | None = None
+    category: str | None = None
 
 
 class StageResult(BaseModel):
@@ -99,6 +102,8 @@ class Rating(BaseModel):
     shooter_id: int
     name: str
     division: str | None = None
+    region: str | None = None
+    category: str | None = None
     mu: float
     sigma: float
     matches_played: int = 0

--- a/lab/src/data/store.py
+++ b/lab/src/data/store.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import contextlib
 from datetime import UTC, datetime
 from pathlib import Path
 
 import duckdb
 
 from src.data.models import MatchResults
+
+# (name, division, region, category, mu, sigma, matches_played, last_match_date)
+RatingRow = tuple[str, str | None, str | None, str | None, float, float, int, str | None]
 
 DEFAULT_DB_PATH = Path("data/lab.duckdb")
 
@@ -27,6 +31,7 @@ CREATE TABLE IF NOT EXISTS matches (
 CREATE TABLE IF NOT EXISTS competitors (
   ct INTEGER, match_id TEXT, competitor_id INTEGER,
   shooter_id INTEGER, name TEXT, club TEXT, division TEXT,
+  region TEXT, region_display TEXT, category TEXT,
   PRIMARY KEY (ct, match_id, competitor_id)
 );
 
@@ -52,6 +57,7 @@ CREATE TABLE IF NOT EXISTS stage_results (
 -- Rating results per algorithm
 CREATE TABLE IF NOT EXISTS shooter_ratings (
   algorithm TEXT, shooter_id INTEGER, name TEXT, division TEXT,
+  region TEXT, category TEXT,
   mu DOUBLE, sigma DOUBLE, matches_played INTEGER,
   last_match_date TIMESTAMP, updated_at TIMESTAMP,
   PRIMARY KEY (algorithm, shooter_id)
@@ -73,6 +79,13 @@ class Store:
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self.db = duckdb.connect(str(db_path))
         self.db.execute(SCHEMA_SQL)
+        # Migrate existing databases to add new columns
+        for col in ["region TEXT", "region_display TEXT", "category TEXT"]:
+            with contextlib.suppress(Exception):
+                self.db.execute(f"ALTER TABLE competitors ADD COLUMN IF NOT EXISTS {col}")
+        for col in ["region TEXT", "category TEXT"]:
+            with contextlib.suppress(Exception):
+                self.db.execute(f"ALTER TABLE shooter_ratings ADD COLUMN IF NOT EXISTS {col}")
 
     def close(self) -> None:
         self.db.close()
@@ -136,9 +149,11 @@ class Store:
         for c in results.competitors:
             self.db.execute(
                 """INSERT OR REPLACE INTO competitors
-                   (ct, match_id, competitor_id, shooter_id, name, club, division)
-                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                [meta.ct, meta.match_id, c.competitor_id, c.shooter_id, c.name, c.club, c.division],
+                   (ct, match_id, competitor_id, shooter_id, name, club, division,
+                    region, region_display, category)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                [meta.ct, meta.match_id, c.competitor_id, c.shooter_id, c.name, c.club, c.division,
+                 c.region, c.region_display, c.category],
             )
 
         # Upsert stages
@@ -212,23 +227,44 @@ class Store:
         ).fetchall()
         return {r[0]: r[1] for r in rows}
 
-    def save_ratings(
-        self,
-        algorithm: str,
-        ratings: dict[int, tuple[str, str | None, float, float, int, str | None]],
-    ) -> None:
+    def get_competitor_name_map(self, ct: int, match_id: str) -> dict[int, str]:
+        """Return competitor_id → name mapping for a match."""
+        rows = self.db.execute(
+            "SELECT competitor_id, name FROM competitors WHERE ct = ? AND match_id = ?",
+            [ct, match_id],
+        ).fetchall()
+        return {r[0]: r[1] for r in rows}
+
+    def get_competitor_region_map(self, ct: int, match_id: str) -> dict[int, str | None]:
+        """Return competitor_id → region mapping for a match."""
+        rows = self.db.execute(
+            "SELECT competitor_id, region FROM competitors WHERE ct = ? AND match_id = ?",
+            [ct, match_id],
+        ).fetchall()
+        return {r[0]: r[1] for r in rows}
+
+    def get_competitor_category_map(self, ct: int, match_id: str) -> dict[int, str | None]:
+        """Return competitor_id → category mapping for a match."""
+        rows = self.db.execute(
+            "SELECT competitor_id, category FROM competitors WHERE ct = ? AND match_id = ?",
+            [ct, match_id],
+        ).fetchall()
+        return {r[0]: r[1] for r in rows}
+
+    def save_ratings(self, algorithm: str, ratings: dict[int, RatingRow]) -> None:
         """Save ratings for an algorithm.
 
-        Values: (name, division, mu, sigma, matches_played, last_match_date).
+        Values: (name, division, region, category, mu, sigma, matches_played, last_match_date).
         """
         updated_at = datetime.now(UTC).isoformat()
-        for sid, (name, div, mu, sigma, played, last_date) in ratings.items():
+        for sid, (name, div, region, category, mu, sigma, played, last_date) in ratings.items():
             self.db.execute(
                 """INSERT OR REPLACE INTO shooter_ratings
-                   (algorithm, shooter_id, name, division, mu, sigma,
+                   (algorithm, shooter_id, name, division, region, category, mu, sigma,
                     matches_played, last_match_date, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                [algorithm, sid, name, div, mu, sigma, played, last_date, updated_at],
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                [algorithm, sid, name, div, region, category, mu, sigma, played,
+                 last_date, updated_at],
             )
 
     def save_rating_snapshot(

--- a/lab/src/data/sync.py
+++ b/lab/src/data/sync.py
@@ -111,6 +111,9 @@ class SyncClient:
                 name=c["name"],
                 club=c.get("club"),
                 division=c.get("division"),
+                region=c.get("region"),
+                region_display=c.get("regionDisplay"),
+                category=c.get("category"),
             )
             for c in data.get("competitors", [])
         ]
@@ -146,7 +149,7 @@ class SyncClient:
         """Run incremental (or full) sync. Returns number of new matches synced."""
         since = None if (full or force) else self.store.get_sync_watermark()
 
-        mode = "force re-download" if force else "full sync" if full else f"since {since}" if since else "initial sync"
+        mode = "force re-download" if force else "full sync" if full else f"since {since}" if since else "initial sync"  # noqa: E501
         console.print(f"[bold]Fetching match list[/bold] ({mode})...")
         listing = self.fetch_match_list(since=since)
         console.print(f"  Found {len(listing.matches)} matches with scorecards")

--- a/lab/src/engine/main.py
+++ b/lab/src/engine/main.py
@@ -14,6 +14,8 @@ class RatingResponse(BaseModel):
     shooter_id: int
     name: str
     division: str | None
+    region: str | None
+    category: str | None
     mu: float
     sigma: float
     matches_played: int
@@ -38,24 +40,38 @@ def create_app(db_path: Path = Path("data/lab.duckdb")) -> FastAPI:
         algorithm: str,
         limit: int = 50,
         offset: int = 0,
+        division: str | None = None,
+        region: str | None = None,
+        category: str | None = None,
     ) -> list[RatingResponse]:
         """Get top ratings for an algorithm, sorted by mu descending."""
+        filters = ["algorithm = ?"]
+        params: list[object] = [algorithm]
+        if division:
+            filters.append("division = ?")
+            params.append(division)
+        if region:
+            filters.append("region = ?")
+            params.append(region)
+        if category:
+            filters.append("category = ?")
+            params.append(category)
+        where = " AND ".join(filters)
         rows = store.db.execute(
-            """SELECT shooter_id, name, division, mu, sigma, matches_played
-               FROM shooter_ratings
-               WHERE algorithm = ?
-               ORDER BY mu DESC
-               LIMIT ? OFFSET ?""",
-            [algorithm, limit, offset],
+            f"SELECT shooter_id, name, division, region, category, mu, sigma, matches_played "
+            f"FROM shooter_ratings WHERE {where} ORDER BY mu DESC LIMIT ? OFFSET ?",
+            params + [limit, offset],
         ).fetchall()
         return [
             RatingResponse(
                 shooter_id=r[0],
                 name=r[1] or f"Shooter {r[0]}",
                 division=r[2],
-                mu=r[3],
-                sigma=r[4],
-                matches_played=r[5],
+                region=r[3],
+                category=r[4],
+                mu=r[5],
+                sigma=r[6],
+                matches_played=r[7],
             )
             for r in rows
         ]
@@ -64,7 +80,7 @@ def create_app(db_path: Path = Path("data/lab.duckdb")) -> FastAPI:
     async def get_rating(algorithm: str, shooter_id: int) -> RatingResponse | None:
         """Get a specific shooter's rating."""
         row = store.db.execute(
-            """SELECT shooter_id, name, division, mu, sigma, matches_played
+            """SELECT shooter_id, name, division, region, category, mu, sigma, matches_played
                FROM shooter_ratings
                WHERE algorithm = ? AND shooter_id = ?""",
             [algorithm, shooter_id],
@@ -75,9 +91,11 @@ def create_app(db_path: Path = Path("data/lab.duckdb")) -> FastAPI:
             shooter_id=row[0],
             name=row[1] or f"Shooter {row[0]}",
             division=row[2],
-            mu=row[3],
-            sigma=row[4],
-            matches_played=row[5],
+            region=row[3],
+            category=row[4],
+            mu=row[5],
+            sigma=row[6],
+            matches_played=row[7],
         )
 
     @app.get("/history/{algorithm}/{shooter_id}")

--- a/lab/src/engine/scheduler.py
+++ b/lab/src/engine/scheduler.py
@@ -37,12 +37,24 @@ def _recalc(db_path: Path, app_url: str, token: str) -> None:
                 results = store.get_stage_results_for_match(ct, match_id)
                 comp_map = store.get_competitor_shooter_map(ct, match_id)
                 if results:
-                    algo.process_match_data(ct, match_id, match_date, results, comp_map)
+                    name_map = store.get_competitor_name_map(ct, match_id)
+                    div_map = store.get_competitor_division_map(ct, match_id)
+                    region_map = store.get_competitor_region_map(ct, match_id)
+                    cat_map = store.get_competitor_category_map(ct, match_id)
+                    algo.process_match_data(
+                        ct, match_id, match_date, results, comp_map,
+                        name_map=name_map, division_map=div_map,
+                        region_map=region_map, category_map=cat_map,
+                    )
 
             ratings = algo.get_ratings()
-            rating_data: dict[int, tuple[str, str | None, float, float, int, str | None]] = {}
+            from src.data.store import RatingRow
+            rating_data: dict[int, RatingRow] = {}
             for sid, r in ratings.items():
-                rating_data[sid] = (r.name, r.division, r.mu, r.sigma, r.matches_played, None)
+                rating_data[sid] = (
+                    r.name, r.division, r.region, r.category,
+                    r.mu, r.sigma, r.matches_played, None,
+                )
             store.save_ratings(algo.name, rating_data)
 
         n = len(algorithms)


### PR DESCRIPTION
## Summary

- **Data API route**: exposes `region`, `regionDisplay`, `category` on competitor objects in `/api/data/match/{ct}/{id}/results`
- **Lab models/sync**: `CompetitorMeta` and `Rating` gain `region`/`category` fields; `sync.py` passes them from the API response
- **Lab store**: adds columns to `competitors` and `shooter_ratings` tables with `ALTER TABLE … ADD COLUMN IF NOT EXISTS` migration for existing DBs; new `get_competitor_name_map()`, `get_competitor_region_map()`, `get_competitor_category_map()` helpers; updated `save_ratings()` signature (`RatingRow` type alias)
- **Lab algorithms** (`base`, `openskill_pl`, `elo`): `process_match_data()` accepts optional `name_map`/`division_map`/`region_map`/`category_map` kwargs; `get_ratings()` returns `region`/`category`; `save_state()`/`load_state()` persist the new dicts
- **Lab CLI + scheduler**: fetch and pass all four maps per match; `rating_data` includes `region`/`category`
- **FastAPI** (`/ratings/{algorithm}`): `RatingResponse` gains `region`/`category`; endpoint accepts `?division=`, `?region=`, `?category=` filter query params

## Test plan

- [x] `pnpm -w run typecheck` — zero errors
- [x] `pnpm -w run lint` — zero warnings
- [x] `pnpm -w test` — 698 tests pass
- [x] `cd lab && uv run mypy src/` — zero errors
- [x] `cd lab && uv run ruff check src/` — zero errors
- [x] `cd lab && uv run pytest` — 31 tests pass
- [ ] After deploying: `uv run rating sync --force` to re-populate region/category columns in DuckDB
- [ ] After sync: `uv run rating train` to rebuild ratings with new metadata
- [ ] Smoke: `curl "localhost:8000/ratings/openskill?region=SWE"` returns only Swedish shooters
- [ ] Smoke: `curl "localhost:8000/ratings/openskill?division=Production"` returns only Production shooters
- [ ] Smoke: `curl "localhost:8000/ratings/openskill?category=S"` returns only Senior-category shooters

🤖 Generated with [Claude Code](https://claude.com/claude-code)