### PR TITLE
fix: use afterResponse(waitUntil) for D1 writes in compare route

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -4,6 +4,7 @@ import { cachedExecuteQuery, gqlCacheKey, SCORECARDS_QUERY, MATCH_QUERY } from "
 import cache from "@/lib/cache-impl";
 import { computeMatchTtl } from "@/lib/match-ttl";
 import { persistToMatchStore } from "@/lib/match-data-store";
+import { afterResponse } from "@/lib/background-impl";
 
 import { formatDivisionDisplay } from "@/lib/divisions";
 import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance, computeStageDegradationData } from "@/app/api/compare/logic";
@@ -116,7 +117,7 @@ export async function GET(req: Request) {
       if (raw) {
         await cache.persist(matchKey); // remove TTL → permanent
         // Persist completed match data to D1/SQLite for durable storage
-        void persistToMatchStore(matchKey, raw);
+        afterResponse(persistToMatchStore(matchKey, raw));
       }
     } else if (!matchCachedAt) {
       // Cache miss: correct the initial 30s write TTL
@@ -148,7 +149,7 @@ export async function GET(req: Request) {
       if (raw) {
         await cache.persist(scorecardsKey);
         // Persist completed scorecard data to D1/SQLite for durable storage
-        void persistToMatchStore(scorecardsKey, raw);
+        afterResponse(persistToMatchStore(scorecardsKey, raw));
       }
     } else if (!scorecardsCachedAt) {
       await cache.expire(scorecardsKey, dataTtl);
@@ -364,7 +365,7 @@ export async function GET(req: Request) {
         await cache.set(matchGlobalKey, globalPayload, dataTtl);
         // Persist matchglobal to D1/SQLite if this is a completed match
         if (dataTtl === null) {
-          void persistToMatchStore(matchGlobalKey, globalPayload);
+          afterResponse(persistToMatchStore(matchGlobalKey, globalPayload));
         }
       } catch { /* ignore */ }
     }


### PR DESCRIPTION
## Root cause

All three `persistToMatchStore()` calls in `app/api/compare/route.ts` were using bare `void promise` instead of `afterResponse()`. On Cloudflare Pages/Workers, the isolate is terminated as soon as the HTTP response is sent — without `waitUntil()`, those D1 writes are silently abandoned.

The `/api/data/matches?hasScorecard=true` endpoint (used by the lab sync) requires **both** `GetMatch` and `GetMatchScorecards` to be present in D1. `GetMatch` was written correctly (via `afterResponse` in `lib/match-data.ts`), but `GetMatchScorecards` and `matchglobal` were not — so the lab sync was only seeing the rare matches where the D1 write happened to win the race before the Worker exited (7 out of 63 warmed matches).

## Fix

Import `afterResponse` from `lib/background-impl` in the compare route and wrap all three `persistToMatchStore()` calls, matching the existing pattern in `lib/match-data.ts`.

## Recovery for current warm-cache run

After the warm-cache run completes, the permanent Redis keys will be populated. Run:
```
pnpm tsx scripts/migrate-match-cache.ts --drain
```
This sweeps all permanent Redis keys into D1 and sets a 24h drain TTL on Redis. Once deployed with this fix, future compare requests will correctly persist to D1 via `waitUntil`.

## Test plan

- [x] `pnpm -w run typecheck` — zero errors
- [x] `pnpm -w run lint` — zero warnings
- [ ] After deploying: warm a completed match, verify `GetMatchScorecards` entry appears in D1

🤖 Generated with [Claude Code](https://claude.com/claude-code)