### PR TITLE
feat(lab): add match_pct_combined cross-division scoring mode

### DIFF
--- a/lab/docs/algorithms.md
+++ b/lab/docs/algorithms.md
@@ -11,6 +11,9 @@ researchers, data quality considerations, and the automated tuning methodology.
 1. [The core idea: what is a skill rating?](#the-core-idea-what-is-a-skill-rating)
 2. [How performance is measured in IPSC](#how-performance-is-measured-in-ipsc)
 3. [Scoring modes](#scoring-modes)
+   - [Stage HF](#stage-hf-stage_hf)
+   - [Match Percentage](#match-percentage-match_pct)
+   - [Combined Match Percentage](#combined-match-percentage-match_pct_combined)
 4. [The algorithms](#the-algorithms)
    - [ELO — the classic baseline](#elo-elo--the-classic-baseline)
    - [OpenSkill Plackett-Luce](#openskill-plackett-luce-openskill--the-full-ranking-model)
@@ -102,12 +105,56 @@ signal per match.
 **Disadvantages:** Fewer data points per match (1 vs N stages). Less granular — cannot
 distinguish between "consistently mediocre" and "brilliant on 9 stages, DQ on 1".
 
+### Combined Match Percentage (match_pct_combined)
+
+The entire match is one ranking event, like `match_pct`, but all divisions compete
+**on a single combined scale** instead of being rated independently. Each competitor's
+metric is their average `overall_percent` (percentage of the stage winner's hit factor
+across all competitors), normalised by a **division weight factor**.
+
+Division weights are computed from a set of anchor matches (high-level events) and
+represent the Nth percentile of performance within each division:
+
+    weight(division) = Nth percentile of avg_overall_percent for division competitors
+                       measured across anchor events
+
+    normalised_score = competitor_avg_overall_percent / weight(division) × 100
+
+A normalised score of 100 means the competitor performed at the anchor percentile for
+their division. This collapses Open, Production, Standard, etc. onto a single axis —
+enabling cross-division comparisons and career ratings that don't require division choice.
+
+**Anchor hyperparameters (tunable):**
+
+| Parameter | Values | Description |
+|---|---|---|
+| `anchor_percentile` | 50, 60, 67, 75, 80 | Percentile used as the division weight. 67 mirrors the Swedish ICS 2.0 system. |
+| `anchor_source` | `l4plus`, `l3plus` | Which matches to use as anchors. `l4plus` = World/Continental (L4–L5); `l3plus` = National+ (L3–L5). |
+
+**Advantages:** Enables cross-division career ratings; directly answers "who is the
+best shooter overall regardless of division?"; comparable to the Swedish ICS 2.0 national
+team selection methodology.
+
+**Disadvantages:** Ratings depend on the anchor event quality and percentile choice.
+Divisions with few anchor-event competitors get less reliable weights. A new algorithm
+entry — ratings are stored with a `_combined` suffix so they coexist with per-division
+modes.
+
+**Design note:** When a competitor's division is missing from the anchor data, a neutral
+weight of 100.0 is used (no normalisation). All competitors rank in a single group with
+`division=None` key in the ratings store.
+
 ### Which to use?
 
 For **national team selection** (the primary use case), `match_pct` is recommended
 as the default because it aligns with how matches are officially scored and how
 selectors think about performance. A shooter's overall match result — not individual
 stage hit factors — determines standings in real competitions.
+
+Use `match_pct_combined` when you need **cross-division comparison** — for example,
+when the selection committee wants to rank the top N Swedish shooters across all
+divisions rather than selecting separately per division. Benchmark results for this
+mode are under active development; see the tuning report for the latest findings.
 
 `stage_hf` remains available for research and may perform better on certain metrics
 due to higher data volume per match.

--- a/lab/src/algorithms/base.py
+++ b/lab/src/algorithms/base.py
@@ -60,6 +60,43 @@ def group_stage_by_division(
     return by_div, match_keys
 
 
+def compute_division_weights(
+    pct_by_division: dict[str | None, list[float]],
+    percentile: float = 67.0,
+) -> dict[str | None, float]:
+    """Compute division weight factors as the Nth percentile of avg_overall_percent.
+
+    Used for ``match_pct_combined`` scoring to normalise per-division performance
+    onto a single cross-division scale. The weight for a division is the Nth
+    percentile of competitors' average overall_percent values observed at the
+    anchor events. A higher weight means the division historically scores higher
+    percentages, so normalising by this weight equalises divisions.
+
+    Args:
+        pct_by_division: division → list of avg_overall_percent values from anchor matches.
+        percentile: The percentile to use as the weight (0–100). Default 67.
+
+    Returns:
+        division → weight. Falls back to 100.0 for divisions with no anchor data.
+
+    Example (ICS 2.0 style):
+        weights = compute_division_weights(pct_by_div, percentile=67)
+        normalized = competitor_avg_pct / weights.get(division, 100.0) * 100.0
+    """
+    weights: dict[str | None, float] = {}
+    for div, pcts in pct_by_division.items():
+        if not pcts:
+            continue
+        sorted_pcts = sorted(pcts)
+        n = len(sorted_pcts)
+        idx = (percentile / 100.0) * (n - 1)
+        lo = int(idx)
+        hi = min(lo + 1, n - 1)
+        frac = idx - lo
+        weights[div] = sorted_pcts[lo] + frac * (sorted_pcts[hi] - sorted_pcts[lo])
+    return weights
+
+
 # ---------------------------------------------------------------------------
 # Abstract base class
 # ---------------------------------------------------------------------------

--- a/lab/src/benchmark/runner.py
+++ b/lab/src/benchmark/runner.py
@@ -88,20 +88,44 @@ def _actual_ranking_by_division(
 
 
 def _get_results(
-    store: Store, source: str, ct: int, match_id: str, scoring: str
-) -> list[tuple[int, int, float | None, bool, bool, bool]]:
-    """Return stage results in the format expected by process_match_data.
+    store: Store,
+    source: str,
+    ct: int,
+    match_id: str,
+    scoring: str,
+    division_weights: dict[str | None, float] | None = None,
+) -> tuple[list[tuple[int, int, float | None, bool, bool, bool]], dict[int, str | None] | None]:
+    """Return (stage_results, division_map) in the format expected by process_match_data.
 
-    stage_hf  — one row per stage per competitor (hit factor as metric).
-    match_pct — one synthetic row per competitor; metric is total match points.
-                Treating the whole match as a single ranking event aligns with
-                how IPSC officially scores competitors.
+    stage_hf          — one row per stage per competitor (hit factor as metric).
+    match_pct         — one synthetic row per competitor; metric is total match points.
+    match_pct_combined — one synthetic row per competitor; metric is division-weight-
+                         normalised avg overall_percent. All competitors rank in one
+                         combined group (division_map=None).
+
+    Returns a (results, division_map) tuple so callers can pass both to process_match_data.
     """
     if scoring == "stage_hf":
-        return store.get_stage_results_for_match(source, ct, match_id)
+        return (
+            store.get_stage_results_for_match(source, ct, match_id),
+            store.get_competitor_division_map(source, ct, match_id),
+        )
+    if scoring == "match_pct_combined":
+        weights = division_weights or {}
+        pct_scores = store.get_match_scores_pct(source, ct, match_id)
+        combined: list[tuple[int, int, float | None, bool, bool, bool]] = []
+        for cid, avg_pct, is_dq, is_zeroed, division in pct_scores:
+            w = weights.get(division, 100.0)
+            normalized: float | None = (avg_pct / w * 100.0) if w > 0 else avg_pct
+            combined.append((cid, 0, normalized, is_dq, False, is_zeroed))
+        return combined, None  # None division_map → single combined group
+    # match_pct
     scores = store.get_match_scores(source, ct, match_id)
     # Synthetic stage_id = 0; dnf=False because absent competitors are already excluded
-    return [(cid, 0, pts, is_dq, False, is_zeroed) for cid, pts, is_dq, is_zeroed in scores]
+    return (
+        [(cid, 0, pts, is_dq, False, is_zeroed) for cid, pts, is_dq, is_zeroed in scores],
+        store.get_competitor_division_map(source, ct, match_id),
+    )
 
 
 def _empty_metrics() -> dict[str, list[float]]:
@@ -129,20 +153,40 @@ def _run_mode(
     """Train and evaluate all algorithms for one scoring mode.
 
     Returns (algo_metrics, division_taus) with algorithm names suffixed by
-    '_mpct' when scoring == 'match_pct' so both modes can coexist in one table.
+    '_mpct' / '_combined' when scoring != 'stage_hf' so both modes can coexist.
     """
+    from src.algorithms.base import compute_division_weights
+
     algo_metrics: dict[str, dict[str, list[float]]] = {}
     division_taus: dict[str, dict[str, list[float]]] = {}
+
+    # Pre-compute division weights for combined scoring using all training matches.
+    division_weights: dict[str | None, float] = {}
+    if scoring == "match_pct_combined":
+        anchor_keys = [(s, ct, mid) for s, ct, mid, _d, _l in train_matches]
+        pct_by_div = store.get_overall_pct_by_division(anchor_keys)
+        division_weights = compute_division_weights(pct_by_div, percentile=67.0)
+        console.print(
+            "  Division weights (p=67): "
+            + ", ".join(
+                f"{d or 'None'}={w:.1f}"
+                for d, w in sorted(
+                    division_weights.items(), key=lambda x: x[1], reverse=True
+                )
+            )
+        )
 
     for algo in get_algorithms():
         console.print(f"\n[cyan]Training {algo.name}[/cyan] ({scoring})")
 
         for source, ct, match_id, match_date, match_level in train_matches:
-            results = _get_results(store, source, ct, match_id, scoring)
+            results, div_map = _get_results(store, source, ct, match_id, scoring, division_weights)
             comp_map = store.get_canonical_competitor_map(source, ct, match_id)
             if results:
                 algo.process_match_data(
-                    ct, match_id, match_date, results, comp_map, match_level=match_level
+                    ct, match_id, match_date, results, comp_map,
+                    division_map=div_map,
+                    match_level=match_level,
                 )
 
         all_ratings = algo.get_ratings()
@@ -174,14 +218,21 @@ def _run_mode(
                 if len(div_predicted) >= 2:
                     algo_div_taus[div].append(kendall_tau(div_predicted, div_actual))
 
-            results = _get_results(store, source, ct, match_id, scoring)
+            results, div_map = _get_results(store, source, ct, match_id, scoring, division_weights)
             comp_map = store.get_canonical_competitor_map(source, ct, match_id)
             if results:
                 algo.process_match_data(
-                    ct, match_id, match_date, results, comp_map, match_level=match_level
+                    ct, match_id, match_date, results, comp_map,
+                    division_map=div_map,
+                    match_level=match_level,
                 )
 
-        suffix = "" if scoring == "stage_hf" else "_mpct"
+        if scoring == "stage_hf":
+            suffix = ""
+        elif scoring == "match_pct_combined":
+            suffix = "_combined"
+        else:
+            suffix = "_mpct"
         name = f"{algo.name}{suffix}"
         algo_metrics[name] = base_m
         algo_metrics[f"{name}+cons"] = cons_m
@@ -221,7 +272,10 @@ def run_benchmark(
     test_matches = matches[split_idx:]
 
     modes = ["stage_hf", "match_pct"] if scoring == "all" else [scoring]
-    mode_label = " + ".join("stage HF" if m == "stage_hf" else "match %" for m in modes)
+    _mode_labels = {
+        "stage_hf": "stage HF", "match_pct": "match %", "match_pct_combined": "combined %"
+    }
+    mode_label = " + ".join(_mode_labels.get(m, m) for m in modes)
     console.print(f"[bold]Benchmark: {len(matches)} matches — scoring: {mode_label}[/bold]")
     console.print(f"  Train: {len(train_matches)} | Test: {len(test_matches)}")
 

--- a/lab/src/cli.py
+++ b/lab/src/cli.py
@@ -83,6 +83,7 @@ def _train_single_algo(
     scoring: str,
     skip_set: set[tuple[str, int, str]],
     suffix: str,
+    division_weights: dict[str | None, float] | None = None,
 ) -> tuple[
     str,
     dict[
@@ -105,6 +106,7 @@ def _train_single_algo(
     store = Store(db_path, read_only=True)
     shooter_last_date: dict[int, str] = {}
     skipped = 0
+    weights = division_weights or {}
 
     try:
         for source, ct, match_id, match_date, match_level in matches:
@@ -114,19 +116,29 @@ def _train_single_algo(
 
             if scoring == "stage_hf":
                 results = store.get_stage_results_for_match(source, ct, match_id)
+                div_map = store.get_competitor_division_map(source, ct, match_id)
+            elif scoring == "match_pct_combined":
+                pct_scores = store.get_match_scores_pct(source, ct, match_id)
+                results = []
+                for cid, avg_pct, is_dq, is_zeroed, division in pct_scores:
+                    w = weights.get(division, 100.0)
+                    normalized = (avg_pct / w * 100.0) if w > 0 else avg_pct
+                    results.append((cid, 0, normalized, is_dq, False, is_zeroed))
+                div_map = None  # all in one combined group
             else:
                 scores = store.get_match_scores(source, ct, match_id)
                 results = [
                     (cid, 0, pts, is_dq, False, is_zeroed)
                     for cid, pts, is_dq, is_zeroed in scores
                 ]
+                div_map = store.get_competitor_division_map(source, ct, match_id)
             comp_map = store.get_canonical_competitor_map(source, ct, match_id)
             if not results:
                 continue
             algo.process_match_data(
                 ct, match_id, match_date, results, comp_map,
                 name_map=store.get_competitor_name_map(source, ct, match_id),
-                division_map=store.get_competitor_division_map(source, ct, match_id),
+                division_map=div_map,
                 region_map=store.get_competitor_region_map(source, ct, match_id),
                 category_map=store.get_competitor_category_map(source, ct, match_id),
                 match_level=match_level,
@@ -186,10 +198,31 @@ def _run_train_mode(
     from src.algorithms.base import DivKey
     from src.data.store import RatingRow
 
-    suffix = "" if scoring == "stage_hf" else "_mpct"
+    if scoring == "stage_hf":
+        suffix = ""
+    elif scoring == "match_pct_combined":
+        suffix = "_combined"
+    else:
+        suffix = "_mpct"
     if name_suffix:
         suffix += f"_{name_suffix}"
     skip = skip_set or set()
+
+    # Pre-compute division weights for combined scoring (needs full match list).
+    division_weights: dict[str | None, float] | None = None
+    if scoring == "match_pct_combined":
+        from src.algorithms.base import compute_division_weights
+
+        all_keys = [(s, ct, mid) for s, ct, mid, _d, _l in matches if (s, ct, mid) not in skip]
+        pct_by_div = store.get_overall_pct_by_division(all_keys)
+        division_weights = compute_division_weights(pct_by_div, percentile=67.0)
+        console.print(
+            "  Division weights (p=67): "
+            + ", ".join(
+                f"{d or 'None'}={w:.1f}"
+                for d, w in sorted(division_weights.items(), key=lambda x: x[1], reverse=True)
+            )
+        )
 
     effective_workers = workers if workers is not None else _default_workers()
 
@@ -212,7 +245,8 @@ def _run_train_mode(
             with ProcessPoolExecutor(max_workers=n_workers) as pool:
                 futures = {
                     pool.submit(
-                        _train_single_algo, name, db_path, matches, scoring, skip, suffix
+                        _train_single_algo, name, db_path, matches, scoring, skip, suffix,
+                        division_weights,
                     ): name
                     for name in algo_names
                 }
@@ -265,19 +299,30 @@ def _run_train_mode(
 
             if scoring == "stage_hf":
                 results = store.get_stage_results_for_match(source, ct, match_id)
+                div_map = store.get_competitor_division_map(source, ct, match_id)
+            elif scoring == "match_pct_combined":
+                weights = division_weights or {}
+                pct_scores = store.get_match_scores_pct(source, ct, match_id)
+                results = []
+                for cid, avg_pct, is_dq, is_zeroed, division in pct_scores:
+                    w = weights.get(division, 100.0)
+                    normalized = (avg_pct / w * 100.0) if w > 0 else avg_pct
+                    results.append((cid, 0, normalized, is_dq, False, is_zeroed))
+                div_map = None  # all in one combined group
             else:
                 scores = store.get_match_scores(source, ct, match_id)
                 results = [
                     (cid, 0, pts, is_dq, False, is_zeroed)
                     for cid, pts, is_dq, is_zeroed in scores
                 ]
+                div_map = store.get_competitor_division_map(source, ct, match_id)
             comp_map = store.get_canonical_competitor_map(source, ct, match_id)
             if not results:
                 continue
             algo.process_match_data(
                 ct, match_id, match_date, results, comp_map,
                 name_map=store.get_competitor_name_map(source, ct, match_id),
-                division_map=store.get_competitor_division_map(source, ct, match_id),
+                division_map=div_map,
                 region_map=store.get_competitor_region_map(source, ct, match_id),
                 category_map=store.get_competitor_category_map(source, ct, match_id),
                 match_level=match_level,
@@ -516,7 +561,11 @@ def train(
     ),
     scoring: str = typer.Option(
         "match_pct",
-        help="Scoring mode: match_pct (whole-match points, default) or stage_hf (per-stage HF)",
+        help=(
+            "Scoring mode: match_pct (whole-match points, default), "
+            "stage_hf (per-stage HF), or match_pct_combined (division-weight-normalised "
+            "cross-division scoring)."
+        ),
     ),
     date_from: str | None = typer.Option(
         None,
@@ -580,8 +629,11 @@ def train(
     from src.algorithms.base import get_algorithms
     from src.data.store import Store
 
-    if scoring not in ("stage_hf", "match_pct"):
-        console.print(f"[red]Unknown scoring mode '{scoring}'. Use stage_hf or match_pct.[/red]")
+    if scoring not in ("stage_hf", "match_pct", "match_pct_combined"):
+        console.print(
+            f"[red]Unknown scoring mode '{scoring}'. "
+            "Use stage_hf, match_pct, or match_pct_combined.[/red]"
+        )
         raise typer.Exit(1)
 
     name_suffix = label if label is not None else _date_label(date_from, date_to)
@@ -593,7 +645,10 @@ def train(
         matches = _filter_matches_by_date(all_matches, date_from, date_to)
         skip_set = store.get_dedup_skip_set()
         n_algo, n_match = len(algorithms), len(matches)
-        mode_label = "stage HF" if scoring == "stage_hf" else "match %"
+        _mode_labels = {
+            "stage_hf": "stage HF", "match_pct": "match %", "match_pct_combined": "combined %"
+        }
+        mode_label = _mode_labels.get(scoring, scoring)
 
         date_range = ""
         if date_from or date_to:
@@ -645,7 +700,10 @@ def benchmark(
 
 @app.command()
 def tune(
-    scoring: str = typer.Option("match_pct", help="Scoring mode: match_pct or stage_hf"),
+    scoring: str = typer.Option(
+        "match_pct",
+        help="Scoring mode: match_pct, stage_hf, or match_pct_combined",
+    ),
     split: float = typer.Option(0.7, help="Train/test split ratio"),
     workers: int | None = typer.Option(None, help="Max parallel workers (default: CPU-1)"),
     db_path: Path = DB_PATH_OPTION,

--- a/lab/src/data/store.py
+++ b/lab/src/data/store.py
@@ -395,6 +395,77 @@ class Store:
             for r in rows
         ]
 
+    def get_match_scores_pct(
+        self, source: str, ct: int, match_id: str
+    ) -> list[tuple[int, float, bool, bool, str | None]]:
+        """Return (competitor_id, avg_overall_percent, is_dq, is_zeroed, division).
+
+        Used for match_pct_combined scoring. DNF competitors are excluded.
+        DQ competitors get avg_overall_percent=0.0. overall_percent is the
+        per-stage % vs the stage winner across all competitors (cross-division).
+        """
+        from src.data.divisions import normalize_division
+
+        rows = self.db.execute(
+            """SELECT sr.competitor_id,
+                      AVG(COALESCE(sr.overall_percent, 0.0)) AS avg_pct,
+                      BOOL_OR(sr.dq)     AS is_dq,
+                      BOOL_OR(sr.zeroed) AS is_zeroed,
+                      c.division
+               FROM stage_results sr
+               JOIN competitors c
+                 ON c.source = sr.source AND c.ct = sr.ct
+                AND c.match_id = sr.match_id
+                AND c.competitor_id = sr.competitor_id
+               WHERE sr.source = ? AND sr.ct = ? AND sr.match_id = ?
+                 AND sr.dnf = false
+               GROUP BY sr.competitor_id, c.division""",
+            [source, ct, match_id],
+        ).fetchall()
+        return [
+            (
+                int(r[0]),
+                0.0 if r[2] else float(r[1]),
+                bool(r[2]),
+                bool(r[3]),
+                normalize_division(r[4]),
+            )
+            for r in rows
+        ]
+
+    def get_overall_pct_by_division(
+        self, match_keys: list[tuple[str, int, str]]
+    ) -> dict[str | None, list[float]]:
+        """Return per-division lists of avg_overall_percent across a set of matches.
+
+        Used to compute division weight factors for match_pct_combined scoring.
+        DNF competitors are excluded. DQ/zeroed competitors contribute 0.0.
+        """
+        from collections import defaultdict
+
+        from src.data.divisions import normalize_division
+
+        result: dict[str | None, list[float]] = defaultdict(list)
+        for source, ct, match_id in match_keys:
+            rows = self.db.execute(
+                """SELECT c.division,
+                          AVG(CASE WHEN sr.dq OR sr.zeroed THEN 0.0
+                                   ELSE COALESCE(sr.overall_percent, 0.0) END) AS avg_pct
+                   FROM stage_results sr
+                   JOIN competitors c
+                     ON c.source = sr.source AND c.ct = sr.ct
+                    AND c.match_id = sr.match_id
+                    AND c.competitor_id = sr.competitor_id
+                   WHERE sr.source = ? AND sr.ct = ? AND sr.match_id = ?
+                     AND sr.dnf = false
+                   GROUP BY sr.competitor_id, c.division""",
+                [source, ct, match_id],
+            ).fetchall()
+            for div_raw, avg_pct in rows:
+                if avg_pct is not None:
+                    result[normalize_division(div_raw)].append(float(avg_pct))
+        return dict(result)
+
     def get_stage_results_for_match(
         self, source: str, ct: int, match_id: str
     ) -> list[tuple[int, int, float | None, bool, bool, bool]]:

--- a/lab/src/tuning/sweep.py
+++ b/lab/src/tuning/sweep.py
@@ -13,6 +13,10 @@ from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.data.store import Store
 
 from rich.console import Console
 from rich.table import Table
@@ -35,7 +39,10 @@ class TuneConfig:
 
     algo_class: str  # e.g. "elo", "openskill_bt_lvl"
     params: dict[str, float | int]
-    label: str  # human-readable label for the results table
+    label: str
+    # Scoring-mode-specific parameters (e.g. anchor_percentile for match_pct_combined).
+    # These are separate from algo hyperparams and not passed to the algorithm constructor.
+    scoring_params: dict[str, str | float] = field(default_factory=dict)
 
 
 @dataclass
@@ -85,8 +92,13 @@ def _make_algo(config: TuneConfig) -> RatingAlgorithm:
     return cls(**config.params)
 
 
-def get_search_space() -> list[TuneConfig]:
-    """Define the full hyperparameter grid."""
+def get_search_space(scoring: str = "match_pct") -> list[TuneConfig]:
+    """Define the full hyperparameter grid.
+
+    For ``match_pct_combined`` scoring, returns algorithm configs cross-producted
+    with anchor hyperparameters (percentile × source filter). For other scoring
+    modes the anchor params are ignored and not included.
+    """
     configs: list[TuneConfig] = []
 
     # ELO: default_k x min_k x k_decay_matches
@@ -138,7 +150,98 @@ def get_search_space() -> list[TuneConfig]:
     configs.append(TuneConfig("openskill", {}, "openskill(baseline)"))
     configs.append(TuneConfig("openskill_bt", {}, "openskill_bt(baseline)"))
 
-    return configs
+    if scoring != "match_pct_combined":
+        return configs
+
+    # match_pct_combined: cross-product of top algorithms × anchor hyperparameters.
+    # We sweep anchor_percentile and anchor_source; algo params use their default values.
+    # The per-mode configs above are NOT used for combined scoring (they have no
+    # scoring_params), so we build a fresh combined list here and return it.
+    combined: list[TuneConfig] = []
+    anchor_percentiles = [50, 60, 67, 75, 80]
+    anchor_sources = ["l4plus", "l3plus"]
+
+    # PL+Decay — best algorithm for match_pct; sweep tau × anchor hyperparams.
+    for tau in [0.04, 0.083, 0.15]:
+        for ap in anchor_percentiles:
+            for asrc in anchor_sources:
+                combined.append(
+                    TuneConfig(
+                        algo_class="openskill_pl_decay",
+                        params={"tau": tau},
+                        label=f"pl_decay(\u03c4={tau},p={ap},{asrc})",
+                        scoring_params={"anchor_percentile": ap, "anchor_source": asrc},
+                    )
+                )
+
+    # BT+Level+Decay — second-best; sweep a representative scale × tau × anchor params.
+    for scale in [1.0, 1.5]:
+        for tau in [0.083, 0.15]:
+            for ap in anchor_percentiles:
+                for asrc in anchor_sources:
+                    combined.append(
+                        TuneConfig(
+                            algo_class="openskill_bt_lvl_decay",
+                            params={"level_scale": scale, "tau": tau},
+                            label=f"bt_lvl_decay(scale={scale},\u03c4={tau},p={ap},{asrc})",
+                            scoring_params={"anchor_percentile": ap, "anchor_source": asrc},
+                        )
+                    )
+
+    # Baselines with default anchor settings for combined mode.
+    for ap in [67]:
+        for asrc in anchor_sources:
+            combined.append(
+                TuneConfig(
+                    "openskill",
+                    {},
+                    f"openskill(baseline,p={ap},{asrc})",
+                    scoring_params={"anchor_percentile": ap, "anchor_source": asrc},
+                )
+            )
+            combined.append(
+                TuneConfig(
+                    "openskill_bt",
+                    {},
+                    f"openskill_bt(baseline,p={ap},{asrc})",
+                    scoring_params={"anchor_percentile": ap, "anchor_source": asrc},
+                )
+            )
+
+    return combined
+
+
+def _compute_division_weights_for_sweep(
+    store: Store,
+    train_matches: list[tuple[str, int, str, str | None, str | None]],
+    anchor_percentile: float,
+    anchor_source: str,
+) -> dict[str | None, float]:
+    """Pre-compute division weights from a filtered subset of training matches.
+
+    anchor_source:
+      "l4plus"  — use only L4/L5 matches (World/Continental championships).
+      "l3plus"  — use L3, L4, and L5 matches (National + above).
+
+    Falls back to all training matches if no anchor matches qualify under the filter.
+    """
+    from src.algorithms.base import compute_division_weights
+
+    if anchor_source == "l4plus":
+        anchor_keys = [
+            (s, ct, mid) for s, ct, mid, _d, lvl in train_matches if lvl in ("l4", "l5")
+        ]
+    else:  # l3plus
+        anchor_keys = [
+            (s, ct, mid) for s, ct, mid, _d, lvl in train_matches if lvl in ("l3", "l4", "l5")
+        ]
+
+    if not anchor_keys:
+        # No qualifying matches — fall back to the full training set.
+        anchor_keys = [(s, ct, mid) for s, ct, mid, _d, _l in train_matches]
+
+    pct_by_div = store.get_overall_pct_by_division(anchor_keys)
+    return compute_division_weights(pct_by_div, anchor_percentile)
 
 
 def _conservative_rank(
@@ -197,16 +300,36 @@ def _evaluate_config(
     store = Store(db_path, read_only=True)
 
     try:
+        # Pre-compute division weights for combined scoring (before the training loop).
+        division_weights: dict[str | None, float] = {}
+        if scoring == "match_pct_combined":
+            anchor_percentile = float(config.scoring_params.get("anchor_percentile", 67.0))
+            anchor_source = str(config.scoring_params.get("anchor_source", "l4plus"))
+            division_weights = _compute_division_weights_for_sweep(
+                store, train_matches, anchor_percentile, anchor_source
+            )
+
         # Train phase
         for source, ct, match_id, match_date, match_level in train_matches:
             if scoring == "stage_hf":
                 results = store.get_stage_results_for_match(source, ct, match_id)
+                division_map_arg = store.get_competitor_division_map(source, ct, match_id)
+            elif scoring == "match_pct_combined":
+                pct_scores = store.get_match_scores_pct(source, ct, match_id)
+                results = []
+                for cid, avg_pct, is_dq, is_zeroed, division in pct_scores:
+                    w = division_weights.get(division, 100.0)
+                    normalized = (avg_pct / w * 100.0) if w > 0 else avg_pct
+                    results.append((cid, 0, normalized, is_dq, False, is_zeroed))
+                # Pass division_map=None so all competitors rank in one combined group.
+                division_map_arg = None
             else:
                 scores = store.get_match_scores(source, ct, match_id)
                 results = [
                     (cid, 0, pts, is_dq, False, is_zeroed)
                     for cid, pts, is_dq, is_zeroed in scores
                 ]
+                division_map_arg = store.get_competitor_division_map(source, ct, match_id)
             comp_map = store.get_canonical_competitor_map(source, ct, match_id)
             if not results:
                 continue
@@ -216,7 +339,7 @@ def _evaluate_config(
                 match_date,
                 results,
                 comp_map,
-                division_map=store.get_competitor_division_map(source, ct, match_id),
+                division_map=division_map_arg,
                 match_level=match_level,
             )
 
@@ -271,12 +394,22 @@ def _evaluate_config(
 
             if scoring == "stage_hf":
                 results = store.get_stage_results_for_match(source, ct, match_id)
+                test_div_map = store.get_competitor_division_map(source, ct, match_id)
+            elif scoring == "match_pct_combined":
+                pct_scores = store.get_match_scores_pct(source, ct, match_id)
+                results = []
+                for cid, avg_pct, is_dq, is_zeroed, division in pct_scores:
+                    w = division_weights.get(division, 100.0)
+                    normalized = (avg_pct / w * 100.0) if w > 0 else avg_pct
+                    results.append((cid, 0, normalized, is_dq, False, is_zeroed))
+                test_div_map = None
             else:
                 scores = store.get_match_scores(source, ct, match_id)
                 results = [
                     (cid, 0, pts, is_dq, False, is_zeroed)
                     for cid, pts, is_dq, is_zeroed in scores
                 ]
+                test_div_map = store.get_competitor_division_map(source, ct, match_id)
             if results:
                 algo.process_match_data(
                     ct,
@@ -284,7 +417,7 @@ def _evaluate_config(
                     match_date,
                     results,
                     comp_map,
-                    division_map=store.get_competitor_division_map(source, ct, match_id),
+                    division_map=test_div_map,
                     match_level=match_level,
                 )
     finally:
@@ -373,6 +506,9 @@ _DEFAULT_LABELS: set[str] = {
     "bt_lvl_decay(scale=1.0,\u03c4=0.083)",
     "openskill(baseline)",
     "openskill_bt(baseline)",
+    # match_pct_combined defaults (ICS 2.0-style: 67th percentile, L4+ anchor)
+    "pl_decay(\u03c4=0.083,p=67,l4plus)",
+    "bt_lvl_decay(scale=1.0,\u03c4=0.083,p=67,l4plus)",
 }
 
 
@@ -492,7 +628,7 @@ def run_sweep(
     console.print(f"  Train: {len(train_matches)} | Test: {len(test_matches)}")
     console.print(f"  Workers: {effective_workers}")
 
-    configs = get_search_space()
+    configs = get_search_space(scoring)
     console.print(f"  Configurations: {len(configs)}")
 
     results: list[TuneResult] = []
@@ -544,6 +680,7 @@ def run_sweep(
                 "label": r.config.label,
                 "algo_class": r.config.algo_class,
                 "params": r.config.params,
+                "scoring_params": r.config.scoring_params,
                 "scoring": r.scoring,
                 "elapsed_s": round(r.elapsed_s, 2),
                 "metrics": {k: round(v, 6) for k, v in r.metrics.items()},


### PR DESCRIPTION
Closes #232

## Summary

- Adds `match_pct_combined` scoring mode that folds all divisions onto a single cross-division rating scale, enabling "who is the best shooter overall?" rankings across Open, Production, Standard, etc.
- Division weight factors computed as the Nth percentile of `avg_overall_percent` within each division at anchor events (L4+/L3+ matches), mirroring the Swedish ICS 2.0 methodology
- Each competitor's normalised score = `avg_overall_percent / division_weight × 100`; all competitors rank in a single group (no per-division split)

## New tuning hyperparameters

| Parameter | Values | Notes |
|---|---|---|
| `anchor_percentile` | 50, 60, 67, 75, 80 | 67 = ICS 2.0 default |
| `anchor_source` | `l4plus`, `l3plus` | L4/L5 events vs L3+ events as anchor |

The sweep grid covers PL+Decay and BT+Level+Decay across the full percentile × source grid (~80 configs).

## Files changed

- `store.py` — `get_match_scores_pct()`, `get_overall_pct_by_division()`
- `base.py` — `compute_division_weights()` pure helper (percentile interpolation, no I/O)
- `sweep.py` — `TuneConfig.scoring_params`, combined search space, weight pre-computation in `_evaluate_config`
- `runner.py` — `_get_results()` returns `(results, division_map)` tuple; `_run_mode()` handles combined mode
- `cli.py` — `train` and `tune` commands accept `match_pct_combined`; parallel and sequential paths both updated
- `docs/algorithms.md` — full documentation with formula, hyperparameter table, design notes

## Test plan

- [x] All 114 existing tests pass (`uv run pytest`)
- [x] `uv run mypy src/` — no errors
- [x] `uv run ruff check src/` — no errors
- [ ] Run `uv run rating tune --scoring match_pct_combined` on real data and add results to tuning report

🤖 Generated with [Claude Code](https://claude.com/claude-code)