### PR TITLE
feat(lab): implement ICS 2.0 as benchmark baseline algorithm

### DIFF
--- a/lab/docs/algorithms.md
+++ b/lab/docs/algorithms.md
@@ -21,6 +21,7 @@ researchers, data quality considerations, and the automated tuning methodology.
    - [BradleyTerry with Level-Scaled Beta](#bradleyterry-with-level-scaled-beta-openskill_bt_lvl)
    - [Plackett-Luce with Inactivity Decay](#plackett-luce-with-inactivity-decay-openskill_pl_decay)
    - [BradleyTerry with Level Scaling + Decay](#bradleyterry-with-level-scaling--decay-openskill_bt_lvl_decay)
+   - [ICS 2.0 — Swedish federation team selection benchmark](#ics-20-ics--swedish-federation-team-selection-benchmark)
 5. [Conservative ranking](#conservative-ranking-cons)
 6. [Percentile score (0–100)](#percentile-score-0100)
 7. [Cross-division fairness](#cross-division-fairness)
@@ -464,6 +465,204 @@ but is a real limitation in the benchmark's test window.
 
 ---
 
+### ICS 2.0 (`ics`) — Swedish federation team selection benchmark
+
+**Reference:** https://ics2.pages.dev/
+
+**What it is:** The method used by the Swedish IPSC federation for 2026 national
+team selection. It is included here as a **benchmark baseline** — not because we
+necessarily think it is the best approach, but because having hard numbers enables
+a genuine conversation: "here is where ICS is stronger; here is where our Bayesian
+approaches are stronger."
+
+ICS 2.0 is **fundamentally different** from all the other algorithms in this lab.
+It is *not* a skill model that learns over time. It does not update a shooter's
+belief incrementally after every match. Instead, it is a **batch peer-comparison
+system**: for each match, it asks: *"How would this shooter have performed at the
+World Shoot, based on how they did here relative to World Shoot participants who
+also competed in this match?"*
+
+#### Plain-language walkthrough
+
+**Step 1 — Anchor event.**
+The most recent L4 or L5 match (World/Continental Championship) is the *anchor*.
+Every competitor at that event gets a **reference score** representing their
+normalised performance. This reference score is the fixed "gold standard" against
+which all future results are measured.
+
+**Step 2 — Division weighting.**
+Different IPSC divisions produce different score levels by design — an Open shooter
+hitting 85% is not the same as a Production shooter hitting 85%, because Open allows
+optical sights, compensators, and higher-capacity magazines. To compare them fairly,
+ICS first establishes each division's *typical level* at the anchor event:
+
+> The division weight is the **67th percentile** of all competitors' scores in that
+> division at the anchor. If Production shooters typically score around 78% at the
+> World Shoot, then 78% is the Production benchmark.
+
+A competitor's **combined score** (comb) at any match is then:
+
+    comb = their avg_overall_percent / division_weight × 100
+
+A Production shooter who scores exactly at the 67th-percentile level gets comb = 100.
+A stronger shooter gets comb > 100. This normalisation collapses Open, Production,
+Standard etc. onto a single shared scale.
+
+**Step 3 — Peer comparison at each match.**
+At a regular ranking match, some of the competitors were also at the anchor event
+(they have a known reference score). For each such "reference competitor" B:
+
+    contrib(A, B) = (A's comb at this match / B's comb at this match) × B's comb at anchor
+
+Plain language: if A outperformed B by 10% at this match, and B scored 88% at the
+World Shoot, then A would have scored approximately 88% × 1.10 = 96.8% at the World
+Shoot. Each reference competitor B provides one such estimate. They are averaged to
+produce A's **match weighted score**.
+
+**Step 4 — Final ranking.**
+A shooter's final ICS score is the **average of their best `top_n` match weighted
+scores** (default: 3). The idea is similar to track and field rankings — your best
+three results count, not your average over everything.
+
+#### Worked example
+
+Suppose the World Shoot anchor establishes these division weights:
+
+- Production: 67th percentile = 78%
+- Open: 67th percentile = 82%
+
+Two World Shoot participants who will appear as references:
+
+- David (Production): scored 88% at the World Shoot → comb_anchor = 88/78 × 100 = 112.8
+- Erik (Open): scored 84% at the World Shoot → comb_anchor = 84/82 × 100 = 102.4
+
+Now Anton (Production) competes at a regional match alongside David and Erik:
+
+| Shooter | Division | % at regional | comb at regional |
+|---|---|---|---|
+| Anton | Production | 90% | 90/78 × 100 = 115.4 |
+| David | Production | 85% | 85/78 × 100 = 109.0 |
+| Erik | Open | 80% | 80/82 × 100 = 97.6 |
+
+**contrib(Anton, David)** = (115.4 / 109.0) × 112.8 = **119.5**
+> Anton outperformed David by 5.9% at this match. Scaled to David's World Shoot
+> level (112.8), that puts Anton at ≈ 119.5.
+
+**contrib(Anton, Erik)** = (115.4 / 97.6) × 102.4 = **121.1**
+> Anton outperformed Erik by 18.2% at this match. Scaled to Erik's World Shoot
+> level (102.4), that puts Anton at ≈ 121.1.
+
+**Anton's match score** = (119.5 + 121.1) / 2 = **120.3**
+
+After several matches, Anton's final ICS score is the average of his three best
+match scores. A score around 100 means "World-Shoot-level performance in this
+division." A score above 100 means better than the 67th percentile at the World Shoot.
+
+#### Mathematical formulation
+
+**Division weight:**
+
+    weight(D) = pth percentile of {avg_overall_percent of all competitors
+                                   in division D at the anchor event}
+
+Default p = 67 (tunable: 50, 60, 67, 75, 80).
+
+**Normalised combined score:**
+
+    comb(competitor, match) = avg_overall_percent / weight(division) × 100
+
+**Peer contribution:**
+
+    contrib(A, B) = comb(A, current_match) / comb(B, current_match) × comb(B, anchor)
+
+This can be rewritten as:
+
+    contrib(A, B) = (A's performance relative to B at this match) × B's known World-Shoot level
+
+**Match weighted score:**
+
+    weighted(A, match) = mean of contrib(A, B) for all reference competitors B
+                         present in this match who have an anchor score
+
+**Final ICS score:**
+
+    ICS(A) = mean of top top_n values in {weighted(A, match) for all matches A has played}
+
+**Special case — anchor event itself:**
+At the anchor event, every competitor is also a reference competitor. Since each
+competitor's current-match comb equals their anchor comb, the contribution formula
+simplifies:
+
+    contrib(A, B) = comb(A, anchor) / comb(B, anchor) × comb(B, anchor) = comb(A, anchor)
+
+So at the anchor event every competitor's match score equals their own normalised score.
+This is mathematically consistent and exactly what ICS intends.
+
+**Fallback — no reference competitors:**
+If no anchor event has been processed yet, or if no reference competitors happen to
+appear in a particular match, the normalised comb score is used directly as the match
+score. This ensures the algorithm degrades gracefully on early historical data.
+
+#### How this benchmark adaptation differs from real ICS 2.0
+
+The official ICS 2.0 uses a single fixed anchor: World Shoot 2025. In this benchmark:
+
+- **Rolling anchor:** whenever an L4 or L5 match is processed chronologically, it
+  becomes the new anchor and replaces the previous one. This is necessary because the
+  dataset spans 2004–2026 with multiple World Shoots.
+- **No manual override list:** the official system uses a hand-curated list of 11
+  ranking matches for 2026 selection. Here, all L2+ matches feed the algorithm.
+- **Continuous vs batch:** the official system is recalculated in a single batch at
+  the end of the selection period. Here, matches are processed one-by-one in
+  chronological order (required by the benchmark framework).
+
+These adaptations are necessary for a fair apples-to-apples benchmark but mean the
+benchmark ICS results are an approximation of the official method, not an exact replica.
+
+#### Tunable parameters
+
+| Parameter | Default | Values tested | What it controls |
+|---|---|---|---|
+| `anchor_percentile` | 67 | 50, 60, 67, 75, 80 | Which percentile to use as the division weight. 67 mirrors the official ICS 2.0 specification. A higher percentile raises the bar, making scores lower overall. |
+| `top_n` | 3 | 2, 3, 4, 5 | How many best results count. Official ICS 2.0 uses 3. More results averages out single-match luck but dilutes peak performance. |
+
+The sweep tests all 20 combinations (5 × 4) with `match_pct` scoring.
+
+#### Strengths
+
+- **Transparent and interpretable:** every number in the ranking can be traced
+  directly to specific match results. There is no statistical black box.
+- **Cross-division by design:** the division weighting explicitly handles Open vs
+  Production vs Standard — no approximations needed.
+- **Familiar to the federation:** since this is the actual selection method, results
+  can be directly discussed with federation officials.
+- **Rewards peak performance:** the top-N structure means one exceptional match at a
+  major event can carry a shooter, which many selectors feel is appropriate.
+
+#### Weaknesses
+
+- **Not a skill model:** it produces no uncertainty estimate (sigma). Conservative
+  ranking cannot differentiate between a shooter with 1 result and one with 20.
+- **Anchor dependency:** all scores depend on the quality and composition of the
+  anchor event. A rolling anchor that changes mid-season can cause discontinuities.
+- **Sparse reference links:** at any given match, most competitors are *not* World
+  Shoot participants. If only 2 out of 80 competitors have anchor scores, those 2
+  people's results dominate A's match score. Results from low-reference-density
+  matches may be unreliable.
+- **No recency:** a result from 5 years ago counts the same as one from last month,
+  as long as it is in the top N. The Bayesian models with decay handle this better.
+- **Not online:** designed as a batch calculation over a fixed season, not as a
+  running ranking. Adapting it to the chronological benchmark framework requires
+  approximations (see above).
+
+**Why does ICS matter for this project?**
+The Swedish IPSC community deserves a data-driven comparison between ICS and the
+Bayesian approaches — not just opinions. Benchmark numbers showing "ICS has 0.45 Kendall
+tau while BT+LD has 0.52, but ICS has better top-5 accuracy for the Open division"
+enable a constructive, specific conversation rather than a philosophical debate.
+
+---
+
 ## Conservative ranking (+cons)
 
 Every algorithm above produces two ranking signals:
@@ -790,7 +989,7 @@ benchmark.
 
 ### Grid search space
 
-The search space covers approximately 80 configurations:
+The search space covers approximately 100 configurations for `match_pct` scoring:
 
 | Algorithm | Parameters | Combinations |
 |---|---|---|
@@ -800,6 +999,7 @@ The search space covers approximately 80 configurations:
 | BT+Level+Decay | level_scale x tau | 36 |
 | PL (baseline) | — | 1 |
 | BT (baseline) | — | 1 |
+| ICS 2.0 | anchor_percentile x top_n | 20 |
 
 **ELO grid:** K_default in {24, 32, 40, 48}, K_min in {8, 12, 16}, K_decay_matches in
 {15, 20, 30}. Combinations where K_min >= K_default are excluded (invalid).
@@ -809,6 +1009,11 @@ The search space covers approximately 80 configurations:
 **PL+Decay grid:** tau in {0.04, 0.06, 0.083, 0.10, 0.12, 0.15}.
 
 **BT+Level+Decay grid:** Full cross-product of level_scale x tau (36 combinations).
+
+**ICS 2.0 grid:** anchor_percentile in {50, 60, 67, 75, 80} x top_n in {2, 3, 4, 5}.
+ICS is only evaluated with `match_pct` scoring — it handles division weighting
+internally, so running it with `match_pct_combined` (which pre-normalises scores)
+would double-normalise and produce incorrect results.
 
 ### Parallelisation
 
@@ -850,19 +1055,23 @@ Designed to run unattended on a server.
 
 ## Summary table
 
-| Short tag | Algorithm | Model | Level weighting | Recency decay | Best at |
-|---|---|---|---|---|---|
-| ELO | `elo` | ELO | No | No | Simple baseline |
-| PL | `openskill` | Plackett-Luce | No | No | Starting point |
-| BT | `openskill_bt` | BradleyTerry | No | No | Top-5/Top-10 accuracy |
-| BT+L | `openskill_bt_lvl` | BradleyTerry | Yes | No | Best for current data |
-| PL+D | `openskill_pl_decay` | Plackett-Luce | No | Yes | Recency-aware PL |
-| BT+LD | `openskill_bt_lvl_decay` | BradleyTerry | Yes | Yes | Most complete model |
+| Short tag | Algorithm | Model type | Level weighting | Recency decay | Uncertainty (sigma) | Best at |
+|---|---|---|---|---|---|---|
+| ELO | `elo` | Pairwise ELO | No | No | No | Simple baseline |
+| PL | `openskill` | Bayesian Plackett-Luce | No | No | Yes | Starting point |
+| BT | `openskill_bt` | Bayesian BradleyTerry | No | No | Yes | Top-5/Top-10 accuracy |
+| BT+L | `openskill_bt_lvl` | Bayesian BradleyTerry | Yes | No | Yes | Best for current data |
+| PL+D | `openskill_pl_decay` | Bayesian Plackett-Luce | No | Yes | Yes | Recency-aware PL |
+| BT+LD | `openskill_bt_lvl_decay` | Bayesian BradleyTerry | Yes | Yes | Yes | Most complete Bayesian model |
+| ICS | `ics` | Peer comparison | No (div-weighted) | No | No | Federation benchmark |
 
 **Recommended for national team selection:** `openskill_bt_lvl` base ranking
 or `openskill_bt_lvl_decay +cons` (conservative) — the former identifies top
 performers most reliably; the latter is the most principled approach for long-term
 ranking where recency and experience level should count.
+
+**ICS 2.0** is included as the federation baseline. See benchmark results for a
+direct numerical comparison of where ICS and the Bayesian approaches differ.
 
 ---
 
@@ -874,3 +1083,10 @@ The level-scaled beta values and inactivity decay formula used in `openskill_bt_
 licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 Only the algorithmic ideas were borrowed; all code was written independently to fit
 this project's architecture and conventions.
+
+The ICS 2.0 algorithm (`ics`) is the Swedish IPSC federation's national team selection
+method. The specification and formula were reconstructed from the publicly available
+description at [ics2.pages.dev](https://ics2.pages.dev/). The implementation here is
+an independent reconstruction for benchmarking purposes; it is not the official ICS
+software. Any discrepancies between this implementation and the official results should
+be reported so they can be corrected.

--- a/lab/src/algorithms/base.py
+++ b/lab/src/algorithms/base.py
@@ -187,10 +187,11 @@ def get_algorithms(name: str | None = None) -> list[RatingAlgorithm]:
     """Get algorithm instances by name.
 
     None or 'default' → recommended algorithms only (bt_lvl, pl_decay, bt_lvl_decay).
-    'all' → all algorithms including baselines (elo, openskill, openskill_bt).
+    'all' → all algorithms including baselines (elo, openskill, openskill_bt, ics).
     Any other string → the single algorithm with that name.
     """
     from src.algorithms.elo import MultiElo
+    from src.algorithms.ics import ICSAlgorithm
     from src.algorithms.openskill_bt import OpenSkillBT
     from src.algorithms.openskill_bt_lvl import OpenSkillBTLvl
     from src.algorithms.openskill_bt_lvl_decay import OpenSkillBTLvlDecay
@@ -209,6 +210,7 @@ def get_algorithms(name: str | None = None) -> list[RatingAlgorithm]:
         OpenSkillPL(),
         OpenSkillBT(),
         MultiElo(),
+        ICSAlgorithm(),
     ]
 
     all_algos = default_algos + extra_algos

--- a/lab/src/algorithms/ics.py
+++ b/lab/src/algorithms/ics.py
@@ -1,0 +1,434 @@
+"""ICS 2.0 — Swedish federation team selection algorithm.
+
+Reference: https://ics2.pages.dev/
+
+Background
+----------
+ICS 2.0 is the method used by the Swedish IPSC federation for 2026 national
+team selection. It is implemented here as a benchmark baseline so it can be
+evaluated head-to-head against the Bayesian approaches using the same metrics
+(Kendall tau, top-k accuracy, MRR).
+
+Unlike every other algorithm in this lab, ICS 2.0 is NOT a skill model.
+It does not maintain a running skill estimate that updates with every match.
+Instead it is a batch peer-comparison system that asks, for each match:
+
+    "How would this shooter have performed at the World Shoot, based on
+     how they did here relative to World Shoot participants who competed
+     in the same match?"
+
+The final ranking score is the average of a shooter's best N such estimates.
+
+How it works — plain language
+------------------------------
+1. ANCHOR EVENT
+   The most recent L4 or L5 match (World/Continental Championship) is the
+   "anchor". Every competitor at that event receives a reference score
+   representing their normalised performance. This is the "gold standard"
+   against which all future results are measured.
+
+2. DIVISION WEIGHTING
+   Different IPSC divisions produce different score levels by design.
+   An Open shooter hitting 85% is not the same as a Production shooter
+   hitting 85% because the divisions use different equipment.
+
+   To compare them fairly, ICS normalises each competitor's score against
+   their division's typical level at the anchor event. The "division weight"
+   is the 67th percentile of all competitors' scores in that division:
+
+       Example: if Production shooters typically score around 78% at the
+       World Shoot, the Production weight = 78. A Production shooter who
+       scores 78% at any match gets a normalised "comb" score of 100.
+       A stronger shooter scoring 90% gets comb = 90/78 * 100 = 115.
+
+3. PEER COMPARISON AT EACH MATCH
+   At a regular ranking match, some competitors were also at the anchor
+   event (they have a known reference score). For each such reference
+   competitor B, one "contribution" estimate is computed:
+
+       contrib(A, B) = (A's comb here / B's comb here) * B's comb at anchor
+
+   Plain language: if A outperformed B by 10% at this match, and B scored
+   the equivalent of 112 at the World Shoot, then A would have scored
+   approximately 112 * 1.10 = 123 at the World Shoot. Each reference
+   competitor B gives one such estimate; they are averaged to produce A's
+   "match weighted score".
+
+4. FINAL RANKING
+   A shooter's ICS score is the average of their best top_n (default: 3)
+   match weighted scores. One exceptional performance at a major event can
+   carry a shooter — only your best results count.
+
+Mathematical formulation
+------------------------
+Division weight:
+
+    weight(D) = pth percentile of {avg_overall_percent of all competitors
+                                   in division D at the anchor event}
+
+Default p = 67 (the ICS 2.0 specification; tunable to 50, 60, 75, 80).
+
+Normalised combined score ("comb"):
+
+    comb(competitor, match) = avg_overall_percent / weight(division) * 100
+
+Peer contribution:
+
+    contrib(A, B) = comb(A, this_match) / comb(B, this_match) * comb(B, anchor)
+
+Match weighted score:
+
+    weighted(A, match) = mean of contrib(A, B) for all reference competitors
+                         B present in this match who have an anchor score
+
+Final ICS score (the number used for ranking):
+
+    ICS(A) = mean of top top_n values of {weighted(A, match) for all matches}
+
+Fallbacks
+---------
+- No anchor yet: the normalised comb score is used directly as the match score.
+  This applies to all matches before the first L4/L5 event is processed.
+- No reference competitors in a match: same fallback — comb is used directly.
+  This happens when none of the anchor-event participants compete in a given match.
+
+Special case — the anchor event itself:
+At the anchor event, each competitor's current-match comb equals their anchor
+comb, so the formula simplifies to contrib(A, B) = comb(A, anchor) for every B.
+The match score equals the shooter's own normalised score. This is mathematically
+consistent and exactly what ICS intends.
+
+Benchmark adaptation notes
+---------------------------
+The official ICS 2.0 uses a single fixed anchor (World Shoot 2025) and a
+hand-curated list of 11 ranking matches. This implementation differs in:
+
+- Rolling anchor: whenever an L4/L5 match is processed chronologically it
+  becomes the new anchor, replacing the previous one. Required because the
+  benchmark spans 2004-2026 with multiple World Shoots.
+- All L2+ matches are used, not a hand-curated list.
+- Matches are processed one-by-one in time order (online approximation of
+  the official batch calculation).
+
+These differences mean benchmark ICS results are an approximation of the
+official method, not an exact replica.
+
+Full documentation: docs/algorithms.md — section "ICS 2.0"
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+
+from src.algorithms.base import (
+    DivKey,
+    RatingAlgorithm,
+    compute_division_weights,
+    decode_div_key,
+    encode_div_key,
+)
+from src.data.models import Rating
+
+# ICS produces a percentage score, not a (mu, sigma) pair.
+# Sigma is fixed so that the conservative ranking in the sweep framework
+# treats ICS the same as the base score (no uncertainty penalty).
+_FIXED_SIGMA: float = 1.0
+_DEFAULT_SCORE: float = 0.0
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+class ICSAlgorithm(RatingAlgorithm):
+    """ICS 2.0 — Swedish federation team selection benchmark.
+
+    Parameters
+    ----------
+    anchor_percentile:
+        Percentile used to derive division weight factors from the anchor
+        event. The ICS 2.0 specification uses 67 (default). Higher values
+        raise the bar, producing lower normalised scores overall. Tunable
+        range in the sweep: {50, 60, 67, 75, 80}.
+    top_n:
+        Number of best match results to average for the final ranking score.
+        ICS 2.0 specification uses 3 (default). More results dampens the
+        impact of a single exceptional performance. Tunable range: {2, 3, 4, 5}.
+    """
+
+    def __init__(
+        self, anchor_percentile: float = 67.0, top_n: int = 3
+    ) -> None:
+        self.anchor_percentile = anchor_percentile
+        self.top_n = top_n
+
+        # Shooter metadata (name, region, category) — updated as matches are processed.
+        self._names: dict[int, str] = {}
+        self._regions: dict[int, str | None] = {}
+        self._categories: dict[int, str | None] = {}
+        # Match count per (shooter_id, None) key — ICS is cross-division so division=None.
+        self._matches: dict[DivKey, int] = defaultdict(int)
+        # Idempotency guard: skip matches already processed.
+        self._seen_matches: set[str] = set()
+
+        # Division weight factors derived from the most recent anchor (L4/L5) event.
+        # Keys are division strings (e.g. "Production") or None if no division was recorded.
+        # A weight of 100.0 is the fallback before any anchor has been processed.
+        self._div_weights: dict[str | None, float] = {}
+
+        # Reference scores from the most recent anchor event.
+        # shooter_id → their normalised comb score at that event.
+        # Used as "b_vm" (B's World Shoot level) in the peer-comparison formula.
+        self._anchor_perf: dict[int, float] = {}
+
+        # All weighted match scores ever computed for each shooter (unsorted).
+        # The final score is derived by taking the top top_n entries.
+        self._match_scores: dict[int, list[float]] = defaultdict(list)
+
+        # Final ranking scores: shooter_id → average of best top_n match scores.
+        # This is the number displayed and used for predict_rank().
+        self._scores: dict[int, float] = {}
+
+    @property
+    def name(self) -> str:
+        return "ics"
+
+    @property
+    def per_division(self) -> bool:
+        return False
+
+    def _normalize(self, pct: float, division: str | None) -> float:
+        """Scale a percentage by the division weight for the current anchor.
+
+        Returns the "combined score" (comb) used throughout the ICS formula:
+
+            comb = avg_overall_percent / division_weight * 100
+
+        A value of 100 means the shooter performed at exactly the anchor
+        percentile for their division. Values above 100 mean above that bar.
+
+        Falls back to weight=100 (no normalisation) if the division was not
+        observed at the anchor event or no anchor has been processed yet.
+        """
+        w = self._div_weights.get(division, 100.0)
+        if w <= 0:
+            return pct
+        return pct / w * 100.0
+
+    def process_match_data(
+        self,
+        ct: int,
+        match_id: str,
+        match_date: str | None,
+        stage_results: list[tuple[int, int, float | None, bool, bool, bool]],
+        competitor_shooter_map: dict[int, int | None],
+        *,
+        name_map: dict[int, str] | None = None,
+        division_map: dict[int, str | None] | None = None,
+        region_map: dict[int, str | None] | None = None,
+        category_map: dict[int, str | None] | None = None,
+        match_level: str | None = None,
+    ) -> None:
+        match_key = f"{ct}:{match_id}"
+        if match_key in self._seen_matches:
+            return  # Idempotency: never process the same match twice.
+        self._seen_matches.add(match_key)
+
+        # ── Step 1: collect each competitor's average score across all stages ──
+        # In match_pct scoring mode (the recommended mode for ICS) the sweep
+        # framework passes a single stage_id=0 entry per competitor whose
+        # hit_factor field is already their avg_overall_percent for the whole
+        # match. In stage_hf mode there are multiple stage entries; averaging
+        # them produces a reasonable proxy for the overall match percentage.
+        # DQ and zeroed competitors count as 0 (ranked last, not excluded).
+        # DNF competitors are excluded entirely — they did not complete the match.
+        comp_pcts: dict[int, list[float]] = defaultdict(list)
+        dnf_set: set[int] = set()
+
+        for comp_id, _stage_id, hf, dq, dnf, zeroed in stage_results:
+            if dnf:
+                dnf_set.add(comp_id)
+                continue
+            if dq or zeroed:
+                comp_pcts[comp_id].append(0.0)
+            elif hf is not None:
+                comp_pcts[comp_id].append(hf)
+
+        # Build the list of valid entries: (shooter_id, avg_pct, division).
+        # Only competitors with a resolved shooter_id and at least one score
+        # are included. DNF competitors are dropped.
+        CompEntry = tuple[int, float, str | None]  # type alias for readability
+        entries: list[CompEntry] = []
+        for comp_id, pcts in comp_pcts.items():
+            if comp_id in dnf_set or not pcts:
+                continue
+            sid = competitor_shooter_map.get(comp_id)
+            if sid is None:
+                continue  # Unresolved identity — cannot assign a rating.
+            div = division_map.get(comp_id) if division_map else None
+            entries.append((sid, _mean(pcts), div))
+
+        if not entries:
+            return
+
+        # ── Step 2: update anchor state (L4/L5 events only) ──
+        # The anchor provides two things:
+        #   a) Division weights — the Nth-percentile score for each division,
+        #      used to normalise all future (and current) match scores.
+        #   b) Reference scores (anchor_perf) — each competitor's normalised
+        #      score at this event, stored as their "World Shoot level" (b_vm).
+        #
+        # IMPORTANT: the anchor is updated BEFORE computing match scores so
+        # that anchor participants are immediately available as references
+        # within the same match. At the anchor event itself this causes each
+        # competitor's match score to equal their own comb (see module docstring
+        # for the mathematical proof).
+        if match_level in ("l4", "l5"):
+            # Collect raw scores by division to compute percentile weights.
+            pcts_by_div: dict[str | None, list[float]] = defaultdict(list)
+            for _sid, avg_pct, div in entries:
+                pcts_by_div[div].append(avg_pct)
+            # compute_division_weights returns the Nth percentile per division.
+            self._div_weights = compute_division_weights(
+                dict(pcts_by_div), self.anchor_percentile
+            )
+            # Store each competitor's normalised score as their anchor reference.
+            for sid, avg_pct, div in entries:
+                self._anchor_perf[sid] = self._normalize(avg_pct, div)
+
+        # ── Step 3: compute each competitor's normalised combined score here ──
+        # comb = avg_pct / division_weight * 100
+        # e.g. Production shooter scoring 90% with weight 78 → comb = 115.4
+        norm_scores: dict[int, float] = {
+            sid: self._normalize(avg_pct, div) for sid, avg_pct, div in entries
+        }
+
+        # ── Step 4: peer comparison — compute each competitor's match score ──
+        for sid, _avg_pct, _div in entries:
+            a_comb = norm_scores[sid]  # This competitor's normalised score here.
+
+            # Find reference competitors B: must be present in THIS match (so
+            # we know their b_comb) AND must have an anchor score (so we know
+            # their b_vm = what they scored at the World Shoot).
+            refs: list[tuple[float, float]] = []  # (b_comb, b_vm)
+            for other_sid, b_comb in norm_scores.items():
+                if other_sid == sid:
+                    continue  # Don't compare A against themselves.
+                if b_comb <= 0:
+                    continue  # DQ'd reference competitor — skip to avoid division by zero.
+                b_vm = self._anchor_perf.get(other_sid)
+                if b_vm is not None:
+                    refs.append((b_comb, b_vm))
+
+            if refs:
+                # For each reference competitor B, estimate what score A would
+                # have achieved at the World Shoot:
+                #   contrib(A, B) = (a_comb / b_comb) * b_vm
+                # e.g. A scored 10% better than B here; B scored 112 at WS
+                # → A would have scored 112 * 1.10 = 123 at WS.
+                contribs = [(a_comb / b_comb) * b_vm for b_comb, b_vm in refs]
+                weighted = _mean(contribs)  # Average across all reference pairs.
+            else:
+                # Fallback: no reference competitors available (no anchor yet,
+                # or none of the anchor participants competed here).
+                # Use the normalised score directly — it is still meaningful
+                # as a cross-division metric even without peer calibration.
+                weighted = a_comb
+
+            # Accumulate this match score and recompute the top-N average.
+            self._match_scores[sid].append(weighted)
+            top = sorted(self._match_scores[sid], reverse=True)[: self.top_n]
+            self._scores[sid] = _mean(top)  # This is the final ICS ranking score.
+
+        # ── Step 5: update metadata ──
+        participated_sids = {sid for sid, _, _ in entries}
+        for comp_id, sid in competitor_shooter_map.items():
+            if sid is None:
+                continue
+            key: DivKey = (sid, None)  # ICS is cross-division → division=None always.
+            if sid in participated_sids:
+                self._matches[key] += 1
+            if name_map and comp_id in name_map:
+                self._names[sid] = name_map[comp_id]
+            if region_map and comp_id in region_map:
+                self._regions[sid] = region_map[comp_id]
+            if category_map and comp_id in category_map:
+                self._categories[sid] = category_map[comp_id]
+
+    def get_ratings(self) -> dict[DivKey, Rating]:
+        result: dict[DivKey, Rating] = {}
+        for sid, score in self._scores.items():
+            key: DivKey = (sid, None)
+            result[key] = Rating(
+                shooter_id=sid,
+                name=self._names.get(sid, f"Shooter {sid}"),
+                division=None,
+                region=self._regions.get(sid),
+                category=self._categories.get(sid),
+                mu=score,
+                sigma=_FIXED_SIGMA,
+                matches_played=self._matches.get(key, 0),
+            )
+        return result
+
+    def predict_rank(
+        self, shooter_ids: list[int], division: str | None = None
+    ) -> list[int]:
+        scored = [
+            (sid, self._scores.get(sid, _DEFAULT_SCORE)) for sid in shooter_ids
+        ]
+        scored.sort(key=lambda x: x[1], reverse=True)
+        return [sid for sid, _ in scored]
+
+    def save_state(self, path: Path) -> None:
+        state = {
+            "anchor_percentile": self.anchor_percentile,
+            "top_n": self.top_n,
+            "names": {str(k): v for k, v in self._names.items()},
+            "regions": {str(k): v for k, v in self._regions.items()},
+            "categories": {str(k): v for k, v in self._categories.items()},
+            "matches": {
+                encode_div_key(s, d): v for (s, d), v in self._matches.items()
+            },
+            "seen_matches": list(self._seen_matches),
+            # None key serialised as "" (mirrors encode_div_key convention)
+            "div_weights": {
+                (k if k is not None else ""): v
+                for k, v in self._div_weights.items()
+            },
+            "anchor_perf": {str(k): v for k, v in self._anchor_perf.items()},
+            "match_scores": {str(k): v for k, v in self._match_scores.items()},
+            "scores": {str(k): v for k, v in self._scores.items()},
+        }
+        path.write_text(json.dumps(state))
+
+    def load_state(self, path: Path) -> None:
+        state = json.loads(path.read_text())
+        self.anchor_percentile = float(
+            state.get("anchor_percentile", self.anchor_percentile)
+        )
+        self.top_n = int(state.get("top_n", self.top_n))
+        self._names = {int(k): v for k, v in state.get("names", {}).items()}
+        self._regions = {int(k): v for k, v in state.get("regions", {}).items()}
+        self._categories = {
+            int(k): v for k, v in state.get("categories", {}).items()
+        }
+        self._matches = defaultdict(
+            int,
+            {decode_div_key(k): v for k, v in state.get("matches", {}).items()},
+        )
+        self._seen_matches = set(state.get("seen_matches", []))
+        self._div_weights = {
+            (k if k else None): v
+            for k, v in state.get("div_weights", {}).items()
+        }
+        self._anchor_perf = {
+            int(k): v for k, v in state.get("anchor_perf", {}).items()
+        }
+        self._match_scores = defaultdict(
+            list,
+            {int(k): v for k, v in state.get("match_scores", {}).items()},
+        )
+        self._scores = {int(k): v for k, v in state.get("scores", {}).items()}

--- a/lab/src/tuning/sweep.py
+++ b/lab/src/tuning/sweep.py
@@ -74,6 +74,7 @@ class DataQuality:
 def _make_algo(config: TuneConfig) -> RatingAlgorithm:
     """Instantiate an algorithm with the given hyperparameters."""
     from src.algorithms.elo import MultiElo
+    from src.algorithms.ics import ICSAlgorithm
     from src.algorithms.openskill_bt import OpenSkillBT
     from src.algorithms.openskill_bt_lvl import OpenSkillBTLvl
     from src.algorithms.openskill_bt_lvl_decay import OpenSkillBTLvlDecay
@@ -82,6 +83,7 @@ def _make_algo(config: TuneConfig) -> RatingAlgorithm:
 
     mapping: dict[str, type[RatingAlgorithm]] = {
         "elo": MultiElo,
+        "ics": ICSAlgorithm,
         "openskill": OpenSkillPL,
         "openskill_bt": OpenSkillBT,
         "openskill_bt_lvl": OpenSkillBTLvl,
@@ -149,6 +151,20 @@ def get_search_space(scoring: str = "match_pct") -> list[TuneConfig]:
     # Baselines (no tunable params -- included for comparison)
     configs.append(TuneConfig("openskill", {}, "openskill(baseline)"))
     configs.append(TuneConfig("openskill_bt", {}, "openskill_bt(baseline)"))
+
+    # ICS 2.0: anchor_percentile × top_n.
+    # Only evaluated with match_pct scoring (ICS handles division weighting
+    # internally; stage_hf and match_pct_combined would double-normalise).
+    if scoring == "match_pct":
+        for ap in [50, 60, 67, 75, 80]:
+            for n in [2, 3, 4, 5]:
+                configs.append(
+                    TuneConfig(
+                        algo_class="ics",
+                        params={"anchor_percentile": float(ap), "top_n": n},
+                        label=f"ics(p={ap},n={n})",
+                    )
+                )
 
     if scoring != "match_pct_combined":
         return configs
@@ -506,6 +522,8 @@ _DEFAULT_LABELS: set[str] = {
     "bt_lvl_decay(scale=1.0,\u03c4=0.083)",
     "openskill(baseline)",
     "openskill_bt(baseline)",
+    # ICS 2.0 defaults: 67th-percentile anchor, top-3 results
+    "ics(p=67,n=3)",
     # match_pct_combined defaults (ICS 2.0-style: 67th percentile, L4+ anchor)
     "pl_decay(\u03c4=0.083,p=67,l4plus)",
     "bt_lvl_decay(scale=1.0,\u03c4=0.083,p=67,l4plus)",

--- a/lab/tests/test_algorithms.py
+++ b/lab/tests/test_algorithms.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from src.algorithms.elo import MultiElo
+from src.algorithms.ics import ICSAlgorithm
 from src.algorithms.openskill_bt import OpenSkillBT
 from src.algorithms.openskill_bt_lvl import OpenSkillBTLvl
 from src.algorithms.openskill_bt_lvl_decay import OpenSkillBTLvlDecay
@@ -260,6 +261,156 @@ class TestMultiElo:
         algo2 = MultiElo()
         algo2.load_state(path)
         assert algo.get_ratings()[(100, None)].mu == pytest.approx(algo2.get_ratings()[(100, None)].mu)
+
+
+class TestICSAlgorithm:
+    def test_name(self) -> None:
+        assert ICSAlgorithm().name == "ics"
+
+    def test_per_division_false(self) -> None:
+        assert ICSAlgorithm().per_division is False
+
+    def test_process_match_no_anchor(self) -> None:
+        """Without an anchor event, falls back to normalised score (div_weight=100)."""
+        algo = ICSAlgorithm()
+        algo.process_match_data(22, "M1", "2026-01-01", STAGE_RESULTS, COMP_MAP)
+        ratings = algo.get_ratings()
+        # Keys use None division (cross-division algorithm)
+        assert (100, None) in ratings
+        assert (200, None) in ratings
+        # Winner (shooter 100) should score higher
+        assert ratings[(100, None)].mu > ratings[(200, None)].mu
+
+    def test_predict_rank(self) -> None:
+        algo = ICSAlgorithm()
+        algo.process_match_data(22, "M1", "2026-01-01", STAGE_RESULTS, COMP_MAP)
+        assert algo.predict_rank([100, 200]) == [100, 200]
+
+    def test_predict_rank_with_unknown_shooter(self) -> None:
+        """Shooters with no score are ranked last."""
+        algo = ICSAlgorithm()
+        algo.process_match_data(22, "M1", "2026-01-01", STAGE_RESULTS, COMP_MAP)
+        predicted = algo.predict_rank([999, 100, 200])
+        assert predicted[0] == 100
+        assert predicted[-1] == 999
+
+    def test_anchor_event_enables_peer_comparison(self) -> None:
+        """After an L4 anchor match, subsequent matches use peer comparison."""
+        # 3 shooters: 100 wins, 200 mid, 300 loses at the anchor (L4).
+        anchor_results: list[tuple[int, int, float | None, bool, bool, bool]] = [
+            (1, 0, 90.0, False, False, False),  # shooter 100 → 90%
+            (2, 0, 75.0, False, False, False),  # shooter 200 → 75%
+            (3, 0, 60.0, False, False, False),  # shooter 300 → 60%
+        ]
+        anchor_map: dict[int, int | None] = {1: 100, 2: 200, 3: 300}
+        anchor_div: dict[int, str | None] = {1: "Production", 2: "Production", 3: "Production"}
+
+        algo = ICSAlgorithm()
+        algo.process_match_data(22, "A1", "2025-01-01", anchor_results, anchor_map,
+                                division_map=anchor_div, match_level="l4")
+
+        # Sanity: anchor_perf is populated
+        assert 100 in algo._anchor_perf
+        assert 200 in algo._anchor_perf
+        assert 300 in algo._anchor_perf
+
+        # Regular match: shooters 100, 200 compete (300 absent).
+        reg_results: list[tuple[int, int, float | None, bool, bool, bool]] = [
+            (1, 0, 80.0, False, False, False),
+            (2, 0, 70.0, False, False, False),
+        ]
+        algo.process_match_data(22, "M1", "2025-06-01", reg_results, {1: 100, 2: 200},
+                                division_map={1: "Production", 2: "Production"})
+
+        ratings = algo.get_ratings()
+        # Shooter 100 scored better at the regular match → should rank higher
+        assert ratings[(100, None)].mu > ratings[(200, None)].mu
+
+    def test_anchor_event_self_score(self) -> None:
+        """At the anchor event, each competitor's score equals their normalised pct."""
+        anchor_results: list[tuple[int, int, float | None, bool, bool, bool]] = [
+            (1, 0, 90.0, False, False, False),
+            (2, 0, 60.0, False, False, False),
+        ]
+        anchor_map: dict[int, int | None] = {1: 100, 2: 200}
+        anchor_div: dict[int, str | None] = {1: "Open", 2: "Open"}
+
+        algo = ICSAlgorithm(anchor_percentile=67.0, top_n=3)
+        algo.process_match_data(22, "A1", "2025-01-01", anchor_results, anchor_map,
+                                division_map=anchor_div, match_level="l5")
+
+        # At the anchor event there are no prior reference scores; both
+        # competitors are each other's reference. Since b_comb == b_vm at
+        # the anchor event (same match), contrib(A, B) = a_comb for any B.
+        # Therefore weighted(A) = a_comb = normalised score.
+        ratings = algo.get_ratings()
+        assert ratings[(100, None)].mu > ratings[(200, None)].mu
+
+    def test_top_n_averaging(self) -> None:
+        """Final score is the average of the best top_n results."""
+        algo = ICSAlgorithm(top_n=2)
+        comp_map: dict[int, int | None] = {1: 100}
+
+        # Three matches with decreasing scores (no anchor, direct normalised).
+        for i, score in enumerate([80.0, 60.0, 40.0]):
+            results: list[tuple[int, int, float | None, bool, bool, bool]] = [
+                (1, 0, score, False, False, False),
+            ]
+            algo.process_match_data(22, f"M{i}", f"2026-0{i+1}-01", results, comp_map)
+
+        # top_n=2: average of the two best = (80 + 60) / 2 = 70
+        ratings = algo.get_ratings()
+        assert ratings[(100, None)].mu == pytest.approx(70.0)
+
+    def test_idempotent(self) -> None:
+        algo = ICSAlgorithm()
+        algo.process_match_data(22, "M1", "2026-01-01", STAGE_RESULTS, COMP_MAP)
+        mu1 = algo.get_ratings()[(100, None)].mu
+        algo.process_match_data(22, "M1", "2026-01-01", STAGE_RESULTS, COMP_MAP)
+        assert algo.get_ratings()[(100, None)].mu == mu1
+
+    def test_dnf_excluded(self) -> None:
+        results: list[tuple[int, int, float | None, bool, bool, bool]] = [
+            (1, 0, 80.0, False, False, False),
+            (2, 0, 0.0, False, True, False),  # DNF
+        ]
+        algo = ICSAlgorithm()
+        algo.process_match_data(22, "M1", None, results, COMP_MAP)
+        ratings = algo.get_ratings()
+        assert not any(k[0] == 200 for k in ratings)
+
+    def test_save_load_state(self, tmp_path: Path) -> None:
+        algo = ICSAlgorithm(anchor_percentile=75.0, top_n=2)
+        algo.process_match_data(22, "M1", "2026-01-01", STAGE_RESULTS, COMP_MAP,
+                                match_level="l4")
+        path = tmp_path / "ics_state.json"
+        algo.save_state(path)
+
+        algo2 = ICSAlgorithm()
+        algo2.load_state(path)
+        assert algo2.anchor_percentile == 75.0
+        assert algo2.top_n == 2
+        assert algo.get_ratings()[(100, None)].mu == algo2.get_ratings()[(100, None)].mu
+        assert algo2._anchor_perf == algo._anchor_perf
+
+    def test_save_load_state_none_division_weight(self, tmp_path: Path) -> None:
+        """Division weights with None key round-trip correctly through JSON."""
+        anchor_results: list[tuple[int, int, float | None, bool, bool, bool]] = [
+            (1, 0, 85.0, False, False, False),
+            (2, 0, 70.0, False, False, False),
+        ]
+        # No division_map → division=None for all competitors
+        algo = ICSAlgorithm()
+        algo.process_match_data(22, "A1", "2025-01-01", anchor_results,
+                                {1: 100, 2: 200}, match_level="l4")
+        assert None in algo._div_weights
+
+        path = tmp_path / "ics_none_div.json"
+        algo.save_state(path)
+        algo2 = ICSAlgorithm()
+        algo2.load_state(path)
+        assert None in algo2._div_weights
+        assert algo2._div_weights[None] == pytest.approx(algo._div_weights[None])
 
 
 class TestPerDivisionRatings:


### PR DESCRIPTION
Closes #234

## Summary

- Implements the Swedish IPSC federation's ICS 2.0 national team selection method as a benchmark algorithm (`ICSAlgorithm`) so it can be evaluated head-to-head against the Bayesian approaches using Kendall tau, top-k, and MRR.
- Adds 20 tuning grid configurations (anchor_percentile × top_n) to the `match_pct` sweep.
- Full plain-language + mathematical documentation with a worked numerical example in `docs/algorithms.md`.

## How ICS works (brief)

For each match, ICS asks: *"How would this shooter have performed at the World Shoot, based on how they did here relative to World Shoot participants?"*

1. **Anchor event** — the most recent L4/L5 match becomes the reference. Each competitor's division-normalised score is stored.
2. **Division weighting** — `comb = avg_pct / div_weight * 100`, where the weight is the Nth percentile of scores in that division at the anchor. This collapses Open, Production, Standard onto one scale.
3. **Peer comparison** — `contrib(A, B) = (a_comb_here / b_comb_here) * b_comb_anchor` for each reference competitor B. Averaged across all references to produce a match score.
4. **Final score** — average of the best `top_n` match scores (default 3).

## Files changed

| File | Change |
|---|---|
| `lab/src/algorithms/ics.py` | New algorithm (fully documented inline) |
| `lab/src/algorithms/base.py` | Register `ICSAlgorithm` in `get_algorithms("all")` |
| `lab/src/tuning/sweep.py` | Add ICS to `_make_algo` + `get_search_space` + `_DEFAULT_LABELS` |
| `lab/tests/test_algorithms.py` | 12 new tests |
| `lab/docs/algorithms.md` | Full ICS 2.0 section with worked example, formula, strengths/weaknesses, adaptation notes, attribution |

## Test plan

- [x] `uv run pytest tests/test_algorithms.py` — 45 passed
- [x] `uv run mypy src/algorithms/ics.py src/algorithms/base.py src/tuning/sweep.py` — no issues
- [x] `uv run ruff check src/algorithms/ics.py src/tuning/sweep.py` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)