### PR TITLE
feat(ui): discipline badge in match header for Rifle/Shotgun matches

### DIFF
--- a/components/match-header.tsx
+++ b/components/match-header.tsx
@@ -34,6 +34,14 @@ export function MatchHeader({ match }: MatchHeaderProps) {
   const pct = match.scoring_completed ?? 0;
   const isComplete = match.results_status === "all" || pct >= 100;
 
+  // For Handgun matches the sub_rule badge (Standard / PCC) is the meaningful
+  // differentiator. For all other disciplines (Rifle, Shotgun, …) show the
+  // discipline name instead — sub_rule adds no further info there.
+  const isHandgun = match.discipline?.includes("Handgun") ?? true;
+  const disciplineBadge = !isHandgun && match.discipline
+    ? match.discipline.replace(/^IPSC /, "")
+    : null;
+
   return (
     <div className="space-y-3">
       <div className="flex flex-wrap items-start gap-2">
@@ -44,10 +52,14 @@ export function MatchHeader({ match }: MatchHeaderProps) {
               {LEVEL_LABELS[match.level] ?? match.level.toUpperCase()}
             </Badge>
           )}
-          {match.sub_rule && (
-            <Badge variant="outline">
-              {SUBRULE_LABELS[match.sub_rule] ?? match.sub_rule.toUpperCase()}
-            </Badge>
+          {disciplineBadge ? (
+            <Badge variant="outline">{disciplineBadge}</Badge>
+          ) : (
+            match.sub_rule && (
+              <Badge variant="outline">
+                {SUBRULE_LABELS[match.sub_rule] ?? match.sub_rule.toUpperCase()}
+              </Badge>
+            )
           )}
           {match.region && (
             <Badge variant="outline">{match.region}</Badge>

--- a/tests/components/match-header.test.tsx
+++ b/tests/components/match-header.test.tsx
@@ -74,6 +74,40 @@ describe("MatchHeader", () => {
     expect(screen.getByText(/105 competitors/)).toBeInTheDocument();
   });
 
+  it("shows sub_rule badge for Handgun matches", () => {
+    render(<MatchHeader match={baseMatch} />);
+    expect(screen.getByText("Standard")).toBeInTheDocument();
+  });
+
+  it("shows discipline badge for Rifle matches instead of sub_rule", () => {
+    render(
+      <MatchHeader
+        match={{ ...baseMatch, discipline: "IPSC Rifle", sub_rule: "rifle" }}
+      />
+    );
+    expect(screen.getByText("Rifle")).toBeInTheDocument();
+    expect(screen.queryByText("Standard")).not.toBeInTheDocument();
+  });
+
+  it("shows discipline badge for Shotgun matches", () => {
+    render(
+      <MatchHeader
+        match={{ ...baseMatch, discipline: "IPSC Shotgun", sub_rule: "shotgun" }}
+      />
+    );
+    expect(screen.getByText("Shotgun")).toBeInTheDocument();
+  });
+
+  it("strips 'IPSC ' prefix from discipline badge", () => {
+    render(
+      <MatchHeader
+        match={{ ...baseMatch, discipline: "IPSC Mini Rifle", sub_rule: null }}
+      />
+    );
+    expect(screen.getByText("Mini Rifle")).toBeInTheDocument();
+    expect(screen.queryByText("IPSC Mini Rifle")).not.toBeInTheDocument();
+  });
+
   it("renders SSI link when ssi_url is provided", () => {
     render(<MatchHeader match={baseMatch} />);
     const link = screen.getByRole("link", { name: /ShootNScoreIt/i });


### PR DESCRIPTION
## Summary

- For non-Handgun matches (Rifle, Shotgun, Mini Rifle, …) the match header now shows a **discipline badge** ("Rifle", "Shotgun", etc.) so users immediately know what discipline they're looking at
- For Handgun matches the existing **sub_rule badge** (Standard / PCC) is unchanged — it carries the meaningful differentiation there
- Badge strips the "IPSC " prefix: "IPSC Rifle" → "Rifle"
- 4 new component tests covering Rifle, Shotgun, Mini Rifle, and Handgun behaviour

## Context

Part of the multi-discipline rollout (#231). The core pipeline changes (correct division extraction via `get_division_display`, `discipline` field on `MatchResponse`, lab discipline filters) landed in the previous commit on `main`. This PR adds the one visible UX gap: a user opening a Rifle match had no indication in the header of what discipline they were viewing.

## Test plan

- [x] `pnpm -w test` — 702 tests pass
- [x] `pnpm -w run typecheck` — zero errors
- [ ] Open a live Rifle match and confirm "Rifle" badge appears
- [ ] Open a Handgun match and confirm "Standard"/"PCC" badge unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)