### PR TITLE
feat(achievements): squad and Swedish recurring competition achievements

### DIFF
--- a/app/api/shooter/[shooterId]/route.ts
+++ b/app/api/shooter/[shooterId]/route.ts
@@ -43,13 +43,20 @@ interface RawCompetitor {
   shooter?: { id: string } | null;
 }
 
+interface RawSquad {
+  id: string;
+  competitors?: Array<{ id: string }> | null;
+}
+
 interface RawMatchEvent {
   name: string;
   venue?: string | null;
   starts?: string | null;
   level?: string | null;
   region?: string | null;
+  get_full_rule_display?: string | null;
   competitors_approved_w_wo_results_not_dnf?: RawCompetitor[];
+  squads?: RawSquad[] | null;
 }
 
 interface RawMatchData {
@@ -304,6 +311,28 @@ export async function GET(
             ).length;
           }
 
+          // Build local-competitor-id → global-shooter-id map for squad lookup
+          const shooterIdByCompetitorId = new Map<string, number>();
+          for (const comp of allCompetitors) {
+            const globalId = decodeShooterId(comp.shooter?.id);
+            if (globalId) shooterIdByCompetitorId.set(comp.id, globalId);
+          }
+
+          // Find which squad the shooter is in and collect squadmates' global IDs
+          let squadmateShooterIds: number[] = [];
+          for (const squad of (ev.squads ?? [])) {
+            const memberIds = (squad.competitors ?? []).map((c) => c.id);
+            if (memberIds.includes(competitor.id)) {
+              squadmateShooterIds = memberIds
+                .filter((id) => id !== competitor.id)
+                .flatMap((id) => {
+                  const gid = shooterIdByCompetitorId.get(id);
+                  return gid != null ? [gid] : [];
+                });
+              break;
+            }
+          }
+
           // Compute stats from scorecards if available
           let stageCount = 0;
           let avgHF: number | null = null;
@@ -354,6 +383,7 @@ export async function GET(
             venue: ev.venue ?? null,
             level: ev.level ?? null,
             region: ev.region ?? null,
+            discipline: ev.get_full_rule_display ?? null,
             division,
             competitorId,
             competitorsInDivision,
@@ -369,6 +399,7 @@ export async function GET(
             dq: wasDQ,
             perfectStages: perfectStagesCount,
             consistencyIndex: consistencyIndexValue,
+            squadmateShooterIds,
           };
           return summary;
         } catch { return null; }

--- a/lib/achievements/definitions.ts
+++ b/lib/achievements/definitions.ts
@@ -16,6 +16,10 @@ const L2_PLUS = new Set([
   "l2", "l3", "l4", "l5",                        // raw Django choice codes
   "Level II", "Level III", "Level IV", "Level V", // display names (legacy)
 ]);
+const L3_PLUS = new Set([
+  "l3", "l4", "l5",
+  "Level III", "Level IV", "Level V",
+]);
 const L4_PLUS = new Set([
   "l4", "l5",                  // raw codes
   "Level IV", "Level V",       // display names (legacy)
@@ -25,8 +29,45 @@ function isL2Plus(m: ShooterMatchSummary): boolean {
   return m.level != null && L2_PLUS.has(m.level);
 }
 
+function isL3Plus(m: ShooterMatchSummary): boolean {
+  return m.level != null && L3_PLUS.has(m.level);
+}
+
 function isL4Plus(m: ShooterMatchSummary): boolean {
   return m.level != null && L4_PLUS.has(m.level);
+}
+
+/**
+ * Normalise a match name to a stable series key for grouping recurring events.
+ *
+ * Handles patterns observed in real SSI data:
+ *   "HFO.10 - The Triggerfreeze (HG & PCC)"   → "hfo"
+ *   "HFO.3 / The Spring Roll - Handgun"        → "hfo"
+ *   "Oden Cup 2021 LvL III"                    → "oden cup"
+ *   "SNO2025 HG"                               → "sno"
+ *   "Chapter III"                              → "chapter"
+ *   "Viking Match 2017 - Production Nationals" → "viking match"
+ *   "Bergen Open - Revitalized 2024"           → "bergen open"
+ *   "13th Helmbrechts-Cup 2023"                → "helmbrechts-cup"
+ */
+function normalizeMatchName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\s*[(\[（][^\)\]）]*[\)\]）]/g, "") // strip parenthesised/bracketed content
+    .replace(/^\d+(?:st|nd|rd|th)\s+/, "")       // strip leading ordinal: "13th "
+    .replace(/\s*\/.*$/, "")                      // strip subtitle after " / "
+    .replace(/\s+-.*$/, "")                       // strip subtitle after " - " (space before dash)
+    .replace(/\.\d+\s*$/, "")                     // strip edition number suffix: ".10"
+    .replace(/\d{4}.*$/, "")                      // strip 4-digit year (with or without space) + everything after
+    .replace(/\s+[ivxlcdm]+\s*$/i, "")            // strip trailing Roman numerals: "Chapter III"
+    .trim()
+    .replace(/\s+/g, " ");                        // collapse any double-spaces left behind
+}
+
+function extractYear(date: string | null): number | null {
+  if (!date) return null;
+  const m = /^(\d{4})/.exec(date);
+  return m ? parseInt(m[1], 10) : null;
 }
 
 // ── Milestone ────────────────────────────────────────────────────────────────
@@ -247,6 +288,102 @@ const versatile: AchievementEntry = {
   },
 };
 
+// ── Squad ─────────────────────────────────────────────────────────────────────
+
+const socialShooter: AchievementEntry = {
+  definition: {
+    id: "social-shooter",
+    name: "Social Shooter",
+    description: "Share a squad with many different competitors across all your matches.",
+    category: "variety",
+    icon: "users",
+    tiers: [
+      { level: 1, name: "Friendly",     threshold: 10,  label: "10 unique squadmates" },
+      { level: 2, name: "Networker",    threshold: 25,  label: "25 unique squadmates" },
+      { level: 3, name: "Well-Known",   threshold: 50,  label: "50 unique squadmates" },
+      { level: 4, name: "Community Pillar", threshold: 100, label: "100 unique squadmates" },
+    ],
+  },
+  evaluate: (ctx) => {
+    const seen = new Set<number>();
+    for (const m of ctx.matches) {
+      for (const id of (m.squadmateShooterIds ?? [])) {
+        seen.add(id);
+      }
+    }
+    return seen.size;
+  },
+};
+
+const usualSuspects: AchievementEntry = {
+  definition: {
+    id: "usual-suspects",
+    name: "Usual Suspects",
+    description: "Keep ending up in the same squad as the same competitor across different matches.",
+    category: "variety",
+    icon: "user-check",
+    tiers: [
+      { level: 1, name: "Familiar Face",  threshold: 2, label: "2 matches with same squadmate" },
+      { level: 2, name: "Squad Regular",  threshold: 3, label: "3 matches with same squadmate" },
+      { level: 3, name: "Inseparable",    threshold: 5, label: "5 matches with same squadmate" },
+    ],
+  },
+  evaluate: (ctx) => {
+    const counts = new Map<number, number>();
+    for (const m of ctx.matches) {
+      for (const id of (m.squadmateShooterIds ?? [])) {
+        counts.set(id, (counts.get(id) ?? 0) + 1);
+      }
+    }
+    let max = 0;
+    for (const count of counts.values()) {
+      if (count > max) max = count;
+    }
+    return max;
+  },
+};
+
+// ── Recurring competition ─────────────────────────────────────────────────────
+
+const traditionalist: AchievementEntry = {
+  definition: {
+    id: "traditionalist",
+    name: "Swedish Regular",
+    description: "Return to the same Swedish Level III+ competition year after year.",
+    category: "milestone",
+    icon: "calendar",
+    tiers: [
+      { level: 1, name: "Returning",  threshold: 2, label: "2 years at same event" },
+      { level: 2, name: "Dedicated",  threshold: 3, label: "3 years at same event" },
+      { level: 3, name: "Legendary",  threshold: 5, label: "5 years at same event" },
+    ],
+  },
+  evaluate: (ctx) => {
+    // Group Swedish L3+ matches by (normalized name, discipline) and count distinct years.
+    const groups = new Map<string, Set<number>>();
+    for (const m of ctx.matches) {
+      if (!isL3Plus(m)) continue;
+      if (m.region !== "SWE") continue;
+      const year = extractYear(m.date);
+      if (!year) continue;
+      const name = normalizeMatchName(m.name);
+      if (!name) continue;
+      const key = `${name}|||${m.discipline ?? ""}`;
+      const existing = groups.get(key);
+      if (existing) {
+        existing.add(year);
+      } else {
+        groups.set(key, new Set([year]));
+      }
+    }
+    let max = 0;
+    for (const years of groups.values()) {
+      if (years.size > max) max = years.size;
+    }
+    return max;
+  },
+};
+
 // ── Export ────────────────────────────────────────────────────────────────────
 
 export const ACHIEVEMENT_ENTRIES: AchievementEntry[] = [
@@ -260,6 +397,9 @@ export const ACHIEVEMENT_ENTRIES: AchievementEntry[] = [
   dqClub,
   globeTrotter,
   versatile,
+  socialShooter,
+  usualSuspects,
+  traditionalist,
 ];
 
 export const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] =

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -627,6 +627,10 @@ export interface ShooterMatchSummary {
    * Null when fewer than 2 valid stages or mean HF is zero.
    */
   consistencyIndex?: number | null;
+  /** Global shooter IDs of competitors who shared a squad with this shooter. Empty if squad data unavailable or shooter was unassigned. */
+  squadmateShooterIds?: number[];
+  /** Human-readable discipline string, e.g. "IPSC Rifle", "IPSC Shotgun", "IPSC Handgun & PCC". Null if unavailable. */
+  discipline?: string | null;
 }
 
 // Cross-match aggregate statistics for the shooter dashboard.

--- a/tests/unit/achievements.test.ts
+++ b/tests/unit/achievements.test.ts
@@ -56,7 +56,7 @@ function makeCtx(overrides: Partial<AchievementEvalContext> = {}): AchievementEv
   };
 }
 
-const TOTAL_ACHIEVEMENTS = 10;
+const TOTAL_ACHIEVEMENTS = 13;
 
 describe("evaluateAchievements", () => {
   it("returns no unlocks for zero matches", () => {
@@ -369,5 +369,209 @@ describe("evaluateAchievements", () => {
     const vAch = achievements.find((a) => a.definition.id === "versatile")!;
     expect(vAch.currentValue).toBe(1);
     expect(vAch.unlockedTiers).toHaveLength(0);
+  });
+
+  // ── Social Shooter ───────────────────────────────────────────────────────
+
+  it("counts unique squadmates across all matches", () => {
+    const ctx = makeCtx({
+      matches: [
+        makeMatch({ matchId: "1", squadmateShooterIds: [10, 11, 12] }),
+        makeMatch({ matchId: "2", squadmateShooterIds: [11, 13, 14] }), // 11 is a repeat
+        makeMatch({ matchId: "3", squadmateShooterIds: [] }),
+      ],
+    });
+    const { achievements } = evaluateAchievements(ctx, []);
+
+    const ach = achievements.find((a) => a.definition.id === "social-shooter")!;
+    expect(ach.currentValue).toBe(5); // 10, 11, 12, 13, 14
+    expect(ach.unlockedTiers).toHaveLength(0); // first tier at 10
+  });
+
+  it("unlocks social-shooter tier at 10 unique squadmates", () => {
+    const ids = Array.from({ length: 10 }, (_, i) => i + 1);
+    const ctx = makeCtx({
+      matches: [makeMatch({ squadmateShooterIds: ids })],
+    });
+    const { achievements } = evaluateAchievements(ctx, []);
+
+    const ach = achievements.find((a) => a.definition.id === "social-shooter")!;
+    expect(ach.currentValue).toBe(10);
+    expect(ach.unlockedTiers).toHaveLength(1);
+    expect(ach.nextTier?.threshold).toBe(25);
+  });
+
+  it("returns 0 for social-shooter when no squad data", () => {
+    const ctx = makeCtx({
+      matches: [makeMatch(), makeMatch({ matchId: "2" })],
+    });
+    const { achievements } = evaluateAchievements(ctx, []);
+
+    const ach = achievements.find((a) => a.definition.id === "social-shooter")!;
+    expect(ach.currentValue).toBe(0);
+    expect(ach.unlockedTiers).toHaveLength(0);
+  });
+
+  // ── Usual Suspects ───────────────────────────────────────────────────────
+
+  it("returns max recurrence count for usual-suspects", () => {
+    const ctx = makeCtx({
+      matches: [
+        makeMatch({ matchId: "1", squadmateShooterIds: [10, 20] }),
+        makeMatch({ matchId: "2", squadmateShooterIds: [10, 30] }),
+        makeMatch({ matchId: "3", squadmateShooterIds: [10, 20] }),
+        makeMatch({ matchId: "4", squadmateShooterIds: [20] }),
+      ],
+    });
+    const { achievements } = evaluateAchievements(ctx, []);
+
+    const ach = achievements.find((a) => a.definition.id === "usual-suspects")!;
+    // Shooter 10 appears in matches 1, 2, 3 → count 3; shooter 20 in 1, 3, 4 → count 3
+    expect(ach.currentValue).toBe(3);
+    expect(ach.unlockedTiers).toHaveLength(2); // thresholds 2 and 3
+  });
+
+  it("unlocks first usual-suspects tier at 2 shared matches", () => {
+    const ctx = makeCtx({
+      matches: [
+        makeMatch({ matchId: "1", squadmateShooterIds: [99] }),
+        makeMatch({ matchId: "2", squadmateShooterIds: [99] }),
+      ],
+    });
+    const { achievements } = evaluateAchievements(ctx, []);
+
+    const ach = achievements.find((a) => a.definition.id === "usual-suspects")!;
+    expect(ach.currentValue).toBe(2);
+    expect(ach.unlockedTiers).toHaveLength(1);
+    expect(ach.nextTier?.threshold).toBe(3);
+  });
+
+  it("returns 0 for usual-suspects when no squad data", () => {
+    const ctx = makeCtx({ matches: [makeMatch(), makeMatch({ matchId: "2" })] });
+    const { achievements } = evaluateAchievements(ctx, []);
+
+    const ach = achievements.find((a) => a.definition.id === "usual-suspects")!;
+    expect(ach.currentValue).toBe(0);
+  });
+
+  // ── Traditionalist ───────────────────────────────────────────────────────
+
+  it("counts distinct years at same Swedish L3+ event — year in name", () => {
+    const ctx = makeCtx({
+      matches: [
+        makeMatch({ matchId: "1", level: "l3", region: "SWE", name: "Oden Cup 2021 LvL III", date: "2021-06-01T00:00:00Z", discipline: "IPSC Handgun" }),
+        makeMatch({ matchId: "2", level: "l3", region: "SWE", name: "Oden Cup 2023",         date: "2023-06-01T00:00:00Z", discipline: "IPSC Handgun" }),
+        makeMatch({ matchId: "3", level: "l3", region: "SWE", name: "Oden Cup 2024",         date: "2024-06-01T00:00:00Z", discipline: "IPSC Handgun" }),
+        makeMatch({ matchId: "4", level: "l2", region: "SWE", name: "Club Match 2024",        date: "2024-03-01T00:00:00Z", discipline: "IPSC Handgun" }),
+      ],
+    });
+    const { achievements } = evaluateAchievements(ctx, []);
+
+    const ach = achievements.find((a) => a.definition.id === "traditionalist")!;
+    expect(ach.currentValue).toBe(3); // 3 L3+ years
+    expect(ach.unlockedTiers).toHaveLength(2); // thresholds 2 and 3
+  });
+
+  it("normalises HFO edition-number names to the same series key", () => {
+    const ctx = makeCtx({
+      matches: [
+        makeMatch({ matchId: "1", level: "l3", region: "SWE", name: "HFO.6 - HG & PCC - Accidental Discharge", date: "2023-06-01T00:00:00Z", discipline: "IPSC Handgun & PCC" }),
+        makeMatch({ matchId: "2", level: "l3", region: "SWE", name: "HFO.9 - PCC, Love & Handguns",            date: "2024-06-01T00:00:00Z", discipline: "IPSC Handgun & PCC" }),
+        makeMatch({ matchId: "3", level: "l3", region: "SWE", name: "HFO.10 - The Triggerfreeze (HG & PCC)",   date: "2025-06-01T00:00:00Z", discipline: "IPSC Handgun & PCC" }),
+      ],
+    });
+    const { achievements } = evaluateAchievements(ctx, []);
+
+    const ach = achievements.find((a) => a.definition.id === "traditionalist")!;
+    expect(ach.currentValue).toBe(3); // all three normalise to "hfo"
+    expect(ach.unlockedTiers).toHaveLength(2);
+  });
+
+  it("normalises Roman-numeral chapter series", () => {
+    const ctx = makeCtx({
+      matches: [
+        makeMatch({ matchId: "1", level: "l3", region: "SWE", name: "Chapter II",  date: "2023-06-01T00:00:00Z", discipline: "IPSC Handgun" }),
+        makeMatch({ matchId: "2", level: "l3", region: "SWE", name: "Chapter III", date: "2024-06-01T00:00:00Z", discipline: "IPSC Handgun" }),
+        makeMatch({ matchId: "3", level: "l3", region: "SWE", name: "Chapter IV",  date: "2025-06-01T00:00:00Z", discipline: "IPSC Handgun" }),
+      ],
+    });
+    const { achievements } = evaluateAchievements(ctx, []);
+
+    const ach = achievements.find((a) => a.definition.id === "traditionalist")!;
+    expect(ach.currentValue).toBe(3); // all three normalise to "chapter"
+  });
+
+  it("normalises year-embedded name (SNO2025)", () => {
+    const ctx = makeCtx({
+      matches: [
+        makeMatch({ matchId: "1", level: "l3", region: "SWE", name: "SNO 2023",   date: "2023-06-01T00:00:00Z", discipline: "IPSC Handgun" }),
+        makeMatch({ matchId: "2", level: "l3", region: "SWE", name: "SNO2025 HG", date: "2025-06-01T00:00:00Z", discipline: "IPSC Handgun" }),
+      ],
+    });
+    const { achievements } = evaluateAchievements(ctx, []);
+
+    const ach = achievements.find((a) => a.definition.id === "traditionalist")!;
+    expect(ach.currentValue).toBe(2); // both normalise to "sno"
+  });
+
+  it("ignores non-Swedish L3+ matches for traditionalist", () => {
+    const ctx = makeCtx({
+      matches: [
+        makeMatch({ matchId: "1", level: "l3", region: "NOR", name: "Oden Cup 2023", date: "2023-06-01T00:00:00Z", discipline: "IPSC Handgun" }),
+        makeMatch({ matchId: "2", level: "l3", region: "NOR", name: "Oden Cup 2024", date: "2024-06-01T00:00:00Z", discipline: "IPSC Handgun" }),
+        makeMatch({ matchId: "3", level: "l3", region: "SWE", name: "HFO.9 - PCC, Love & Handguns", date: "2024-06-01T00:00:00Z", discipline: "IPSC Handgun & PCC" }),
+      ],
+    });
+    const { achievements } = evaluateAchievements(ctx, []);
+
+    const ach = achievements.find((a) => a.definition.id === "traditionalist")!;
+    // Norwegian matches excluded; only 1 Swedish L3+ match → max = 1
+    expect(ach.currentValue).toBe(1);
+    expect(ach.unlockedTiers).toHaveLength(0);
+  });
+
+  it("treats same event name in different discipline as separate series", () => {
+    const ctx = makeCtx({
+      matches: [
+        makeMatch({ matchId: "1", level: "l3", region: "SWE", name: "Oden Cup 2023", date: "2023-05-01T00:00:00Z", discipline: "IPSC Handgun" }),
+        makeMatch({ matchId: "2", level: "l3", region: "SWE", name: "Oden Cup 2024", date: "2024-05-01T00:00:00Z", discipline: "IPSC Shotgun" }),
+        makeMatch({ matchId: "3", level: "l3", region: "SWE", name: "Oden Cup 2025", date: "2025-05-01T00:00:00Z", discipline: "IPSC Shotgun" }),
+      ],
+    });
+    const { achievements } = evaluateAchievements(ctx, []);
+
+    const ach = achievements.find((a) => a.definition.id === "traditionalist")!;
+    // Handgun: 1 year; Shotgun: 2 years → max = 2
+    expect(ach.currentValue).toBe(2);
+    expect(ach.unlockedTiers).toHaveLength(1);
+  });
+
+  it("does not count the same year twice for traditionalist", () => {
+    const ctx = makeCtx({
+      matches: [
+        makeMatch({ matchId: "1", level: "l3", region: "SWE", name: "HFO.3 / The Spring Roll - Handgun", date: "2022-08-10T00:00:00Z", discipline: "IPSC Handgun" }),
+        makeMatch({ matchId: "2", level: "l3", region: "SWE", name: "HFO.3 / The Spring Roll - PCC",     date: "2022-08-11T00:00:00Z", discipline: "IPSC Handgun & PCC" }),
+      ],
+    });
+    const { achievements } = evaluateAchievements(ctx, []);
+
+    const ach = achievements.find((a) => a.definition.id === "traditionalist")!;
+    // Both in 2022 but different disciplines → each group has 1 year → max = 1
+    expect(ach.currentValue).toBe(1);
+    expect(ach.unlockedTiers).toHaveLength(0);
+  });
+
+  it("returns 0 for traditionalist with only L2 Swedish matches", () => {
+    const ctx = makeCtx({
+      matches: [
+        makeMatch({ matchId: "1", level: "l2", region: "SWE", name: "HFO.6 - Accidental Discharge", date: "2023-06-01T00:00:00Z" }),
+        makeMatch({ matchId: "2", level: "l2", region: "SWE", name: "HFO.9 - PCC, Love & Handguns", date: "2024-06-01T00:00:00Z" }),
+      ],
+    });
+    const { achievements } = evaluateAchievements(ctx, []);
+
+    const ach = achievements.find((a) => a.definition.id === "traditionalist")!;
+    expect(ach.currentValue).toBe(0);
+    expect(ach.unlockedTiers).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- **Social Shooter** — counts unique competitors you've ever shared a squad with (tiers: 10 / 25 / 50 / 100)
- **Usual Suspects** — max number of matches where the same competitor appeared in your squad (tiers: 2 / 3 / 5)
- **Swedish Regular** — return to the same Swedish L3+ event across multiple calendar years, grouped by normalised name + discipline (tiers: 2 / 3 / 5 years)

## Data pipeline

`ShooterMatchSummary` gains two new optional fields:
- `squadmateShooterIds?: number[]` — global shooter IDs of squad members, extracted from the already-cached match response by mapping local competitor IDs through the competitor list
- `discipline?: string | null` — from `get_full_rule_display`, used as a grouping key to distinguish e.g. Handgun vs Shotgun editions of the same named event

No GraphQL query changes or cache schema bump needed — both fields come from data that was already fetched and stored.

## Name normalisation

The recurring-event evaluator normalises match names to a stable series key before grouping, handling real SSI naming patterns:

| Raw name | Normalised |
|---|---|
| `HFO.10 - The Triggerfreeze (HG & PCC)` | `hfo` |
| `HFO.3 / The Spring Roll - Handgun` | `hfo` |
| `Oden Cup 2021 LvL III` | `oden cup` |
| `SNO2025 HG` | `sno` |
| `Chapter III` | `chapter` |
| `13th Helmbrechts-Cup 2023` | `helmbrechts-cup` |
| `Viking Match 2017 - Production Nationals` | `viking match` |

## Test plan

- [ ] All 805 unit tests pass (`pnpm -w test`)
- [ ] Zero type errors (`pnpm -w run typecheck`)
- [ ] Achievement section visible on shooter dashboard (preview feature enabled)
- [ ] Verify Social Shooter / Usual Suspects show non-zero values for a shooter with multiple squad-tracked matches
- [ ] Verify Swedish Regular shows correct year count for a shooter with Oden Cup / HFO history

🤖 Generated with [Claude Code](https://claude.com/claude-code)