### PR TITLE
feat(pre-match): load AI coaching brief on demand

### DIFF
--- a/components/pre-match-view.tsx
+++ b/components/pre-match-view.tsx
@@ -209,7 +209,8 @@ function PreMatchBriefCard({
   id: string;
   shooterId: number | null;
 }) {
-  const briefQuery = usePreMatchBriefQuery(ct, id, shooterId, true);
+  const [requested, setRequested] = useState(false);
+  const briefQuery = usePreMatchBriefQuery(ct, id, shooterId, requested);
 
   return (
     <div className="rounded-lg border p-4 space-y-3">
@@ -259,6 +260,15 @@ function PreMatchBriefCard({
         )}
       </div>
 
+      {!requested && !briefQuery.data && (
+        <button
+          className="text-sm text-primary hover:text-primary/80 font-medium flex items-center gap-1.5 focus-visible:outline-2 focus-visible:outline-ring rounded transition-colors"
+          onClick={() => setRequested(true)}
+        >
+          <Sparkles className="w-3.5 h-3.5" aria-hidden="true" />
+          Generate personalised brief
+        </button>
+      )}
       {briefQuery.isLoading && (
         <div className="space-y-2">
           <Skeleton className="h-4 w-full" />


### PR DESCRIPTION
## Summary
- The pre-match AI coaching brief no longer auto-fetches on page load
- A "Generate personalised brief" button is shown instead — clicking it triggers the AI call
- Avoids unnecessary AI API calls when users only want to check stages, squads, or weather

## Test plan
- [ ] Open a pre-match page with AI configured and a tracked shooter — verify the brief card shows the generate button, not a loading skeleton
- [ ] Click "Generate personalised brief" — verify the skeleton appears then the brief loads
- [ ] After the brief loads, verify the "Refresh" button still works
- [ ] If the brief was previously cached (within 30min stale window), clicking generate should return instantly from TanStack Query cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)