### PR TITLE
chore(ci): add pnpm audit for production dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Audit dependencies
+        run: pnpm audit --prod --audit-level=critical
+
       - run: pnpm lint   # eslint .
 
       - run: pnpm typecheck   # tsc --noEmit


### PR DESCRIPTION
## Summary

- Adds `pnpm audit --prod --audit-level=critical` step to CI, running before lint
- `--prod`: only audits production dependencies (skips devDeps like vite/rollup that have known transitive vulnerabilities we can't fix)
- `--audit-level=critical`: only fails the build on critical-severity issues

Currently passes cleanly — no production dependency vulnerabilities found.

Part of #261 (P2 checklist).

## Test plan

- [x] `pnpm audit --prod --audit-level=critical` exits 0 locally
- [ ] CI pipeline passes with the new step

🤖 Generated with [Claude Code](https://claude.com/claude-code)