### PR TITLE
feat: rate limiting on /api/events and /api/compare

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { MAX_COMPETITORS } from "@/lib/constants";
+import { checkRateLimit } from "@/lib/rate-limit";
 import { cachedExecuteQuery, gqlCacheKey, SCORECARDS_QUERY, MATCH_QUERY } from "@/lib/graphql";
 import cache from "@/lib/cache-impl";
 import { computeMatchTtl } from "@/lib/match-ttl";
@@ -63,6 +64,14 @@ interface RawMatchData {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export async function GET(req: Request) {
+  const rl = await checkRateLimit(req, { prefix: "compare", limit: 30, windowSeconds: 60 });
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": String(rl.retryAfter) } },
+    );
+  }
+
   const t0 = performance.now();
 
   const { searchParams } = new URL(req.url);

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { executeQuery, EVENTS_QUERY } from "@/lib/graphql";
+import { checkRateLimit } from "@/lib/rate-limit";
 
 import type { EventSummary } from "@/lib/types";
 
@@ -57,6 +58,14 @@ function buildSubWindows(
 }
 
 export async function GET(req: Request) {
+  const rl = await checkRateLimit(req, { prefix: "events", limit: 30, windowSeconds: 60 });
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": String(rl.retryAfter) } },
+    );
+  }
+
   const t0 = performance.now();
   const { searchParams } = new URL(req.url);
   const q = searchParams.get("q") ?? "";

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,61 @@
+// Server-only — sliding window rate limiter backed by the cache adapter.
+// Uses a simple fixed-window counter per IP + route (one cache key per window).
+// Fails open: if the cache is unavailable, the request is allowed through.
+
+import cache from "@/lib/cache-impl";
+
+interface RateLimitOptions {
+  /** Unique prefix for the rate limit bucket (e.g. "events", "compare"). */
+  prefix: string;
+  /** Maximum number of requests per window. */
+  limit: number;
+  /** Window size in seconds. */
+  windowSeconds: number;
+}
+
+/**
+ * Extract client IP from request headers.
+ * Checks CF-Connecting-IP (Cloudflare), X-Forwarded-For (reverse proxy),
+ * then falls back to a generic key.
+ */
+function getClientIp(req: Request): string {
+  return (
+    req.headers.get("cf-connecting-ip") ??
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    "unknown"
+  );
+}
+
+/**
+ * Check and increment the rate limit counter for a request.
+ * Returns { allowed: true } if under the limit, or { allowed: false, retryAfter }
+ * with the number of seconds until the window resets.
+ *
+ * Fails open: cache errors result in { allowed: true }.
+ */
+export async function checkRateLimit(
+  req: Request,
+  opts: RateLimitOptions,
+): Promise<{ allowed: true } | { allowed: false; retryAfter: number }> {
+  const ip = getClientIp(req);
+  const window = Math.floor(Date.now() / 1000 / opts.windowSeconds);
+  const key = `rl:${opts.prefix}:${ip}:${window}`;
+
+  try {
+    const current = await cache.get(key);
+    const count = current ? parseInt(current, 10) : 0;
+
+    if (count >= opts.limit) {
+      const windowEnd = (window + 1) * opts.windowSeconds;
+      const retryAfter = windowEnd - Math.floor(Date.now() / 1000);
+      return { allowed: false, retryAfter: Math.max(1, retryAfter) };
+    }
+
+    // Increment counter. Set TTL to windowSeconds so it auto-expires.
+    await cache.set(key, String(count + 1), opts.windowSeconds);
+    return { allowed: true };
+  } catch {
+    // Fail open — don't block requests if cache is unavailable
+    return { allowed: true };
+  }
+}


### PR DESCRIPTION
## Summary

- New `lib/rate-limit.ts` — cache-backed fixed-window rate limiter using the existing Redis/Upstash adapter
- 30 requests/minute per IP on `/api/events` and `/api/compare`
- Returns **429 Too Many Requests** with `Retry-After` header when exceeded
- Fails open if cache is unavailable (no blocking on Redis downtime)
- Works on both Docker (ioredis) and Cloudflare (Upstash HTTP) deployments
- Client IP detected via `CF-Connecting-IP` > `X-Forwarded-For` > fallback

Part of #261 (P1 rate limiting).

## Test plan

- [ ] Typecheck, tests (833), lint all pass
- [ ] Normal usage unaffected (30 req/min is generous for real users)
- [ ] Rapid requests to `/api/events` return 429 after 30th request in a minute
- [ ] `Retry-After` header present on 429 responses
- [ ] Cache unavailable → requests pass through (fail-open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)