### PR TITLE
feat: retention policy with admin purge endpoint

### DIFF
--- a/app/api/admin/retention/route.ts
+++ b/app/api/admin/retention/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import db from "@/lib/db-impl";
+
+/** Default retention period: 2 years (in days). */
+const DEFAULT_RETENTION_DAYS = 730;
+
+/**
+ * POST /api/admin/retention
+ * Purges shooter profiles inactive for longer than the retention period.
+ * Requires Authorization: Bearer <CACHE_PURGE_SECRET>
+ *
+ * Optional query param: ?days=730 (override retention period)
+ *
+ * Does NOT purge suppressed shooters — those are kept for GDPR compliance.
+ */
+export async function POST(req: Request) {
+  const secret = process.env.CACHE_PURGE_SECRET;
+  const auth = req.headers.get("Authorization");
+  if (!secret || auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const daysParam = searchParams.get("days");
+  const days = daysParam ? parseInt(daysParam, 10) : DEFAULT_RETENTION_DAYS;
+  if (isNaN(days) || days < 1) {
+    return NextResponse.json({ error: "Invalid days parameter" }, { status: 400 });
+  }
+
+  const cutoff = new Date(Date.now() - days * 86_400_000).toISOString();
+  const purged = await db.purgeInactiveShooters(cutoff);
+
+  console.log(JSON.stringify({
+    route: "admin-retention",
+    days,
+    cutoff,
+    purged,
+  }));
+
+  return NextResponse.json({ purged, days, cutoff });
+}

--- a/lib/db-d1.ts
+++ b/lib/db-d1.ts
@@ -461,6 +461,31 @@ const db: AppDatabase = {
       .all<{ shooter_id: number; suppressed_at: string }>();
     return result.results.map((r) => ({ shooterId: r.shooter_id, suppressedAt: r.suppressed_at }));
   },
+
+  // ── Retention ──────────────────────────────────────────────────────────
+
+  async purgeInactiveShooters(olderThan) {
+    const db = getDb();
+    const result = await db
+      .prepare(
+        `SELECT shooter_id FROM shooter_profiles
+         WHERE last_seen < ?
+           AND shooter_id NOT IN (SELECT shooter_id FROM shooter_suppressions)`,
+      )
+      .bind(olderThan)
+      .all<{ shooter_id: number }>();
+
+    const ids = result.results.map((r) => r.shooter_id);
+    if (ids.length === 0) return 0;
+
+    const stmts = ids.flatMap((id) => [
+      db.prepare(`DELETE FROM shooter_profiles WHERE shooter_id = ?`).bind(id),
+      db.prepare(`DELETE FROM shooter_matches WHERE shooter_id = ?`).bind(id),
+      db.prepare(`DELETE FROM shooter_achievements WHERE shooter_id = ?`).bind(id),
+    ]);
+    await db.batch(stmts);
+    return ids.length;
+  },
 };
 
 export default db;

--- a/lib/db-sqlite.ts
+++ b/lib/db-sqlite.ts
@@ -455,6 +455,29 @@ export function createSqliteDatabase(
         .all() as { shooter_id: number; suppressed_at: string }[];
       return rows.map((r) => ({ shooterId: r.shooter_id, suppressedAt: r.suppressed_at }));
     },
+
+    // ── Retention ──────────────────────────────────────────────────────────
+
+    async purgeInactiveShooters(olderThan) {
+      const d = getDb();
+      const rows = d.prepare(
+        `SELECT shooter_id FROM shooter_profiles
+         WHERE last_seen < ?
+           AND shooter_id NOT IN (SELECT shooter_id FROM shooter_suppressions)`,
+      ).all(olderThan) as { shooter_id: number }[];
+
+      if (rows.length === 0) return 0;
+
+      const ids = rows.map((r) => r.shooter_id);
+      const placeholders = ids.map(() => "?").join(",");
+      const tx = d.transaction(() => {
+        d.prepare(`DELETE FROM shooter_profiles WHERE shooter_id IN (${placeholders})`).run(...ids);
+        d.prepare(`DELETE FROM shooter_matches WHERE shooter_id IN (${placeholders})`).run(...ids);
+        d.prepare(`DELETE FROM shooter_achievements WHERE shooter_id IN (${placeholders})`).run(...ids);
+      });
+      tx();
+      return ids.length;
+    },
   };
 }
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -139,4 +139,14 @@ export interface AppDatabase {
 
   /** Return all suppressed shooter IDs with their suppression timestamps. */
   listSuppressedShooters(): Promise<Array<{ shooterId: number; suppressedAt: string }>>;
+
+  // ── Retention ───────────────────────────────────────────────────────────
+
+  /**
+   * Delete shooter profiles (and their match index + achievements) where
+   * last_seen is older than the given ISO timestamp. Returns the number of
+   * profiles purged. Does NOT purge suppressed shooters — those are kept
+   * intentionally.
+   */
+  purgeInactiveShooters(olderThan: string): Promise<number>;
 }


### PR DESCRIPTION
## Summary

- Defines a **2-year retention policy** for shooter profiles — profiles not seen in >730 days are eligible for purging
- `POST /api/admin/retention` — admin-protected endpoint to run the purge
  - Optional `?days=730` query param to override the retention period
  - Returns `{ purged, days, cutoff }` with the number of profiles removed
  - Suppressed shooters are excluded (GDPR suppression list takes precedence)
- New `purgeInactiveShooters(olderThan)` method on `AppDatabase` (both SQLite and D1)
- Atomically deletes `shooter_profiles` + `shooter_matches` + `shooter_achievements` for inactive shooters

Callable from:
- Admin page (add a button in a future PR)
- GitHub Actions workflow (scheduled cron)
- `curl -X POST -H "Authorization: Bearer $SECRET" https://host/api/admin/retention`

Part of #261 (P1 retention policy).

## Test plan

- [ ] Typecheck, tests (833), lint all pass
- [ ] `POST /api/admin/retention` with valid token returns `{ purged: 0, days: 730, cutoff: "..." }`
- [ ] `POST /api/admin/retention` without token returns 401
- [ ] `POST /api/admin/retention?days=1` purges profiles not seen in the last day
- [ ] Suppressed shooters are NOT purged even if inactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)