### PR TITLE
fix: align Discord bot types with actual API responses

### DIFF
--- a/discord/src/commands/leaderboard.ts
+++ b/discord/src/commands/leaderboard.ts
@@ -179,9 +179,9 @@ export async function handleLeaderboard(
   }
 
   const scoringLabel =
-    event.scoring_completed === 100
+    match.scoring_completed === 100
       ? "Completed"
-      : `${event.scoring_completed}% scored`;
+      : `${match.scoring_completed}% scored`;
 
   // Leader highlight
   const leader = shooterStats[0];

--- a/discord/src/commands/match.ts
+++ b/discord/src/commands/match.ts
@@ -18,8 +18,10 @@ export async function handleMatch(
     };
   }
 
-  // Take the top result
-  const match = events[0];
+  // Take the top result and fetch full match data for scoring/counts
+  const event = events[0];
+  const match = await client.getMatch(event.content_type, event.id);
+
   const scoringLabel =
     match.scoring_completed === 100
       ? "Completed"
@@ -27,16 +29,16 @@ export async function handleMatch(
         ? `${match.scoring_completed}% scored`
         : "Not started";
 
-  const matchUrl = `${baseUrl}/match/${match.content_type}/${match.id}`;
+  const matchUrl = `${baseUrl}/match/${event.content_type}/${event.id}`;
 
   const embed: APIEmbed = {
-    title: match.name,
+    title: event.name,
     url: matchUrl,
     color: match.scoring_completed === 100 ? 0x22c55e : 0x3b82f6, // green or blue
     fields: [
-      { name: "Venue", value: match.venue || "—", inline: true },
-      { name: "Date", value: match.date || "—", inline: true },
-      { name: "Level", value: match.level || "—", inline: true },
+      { name: "Venue", value: event.venue || "—", inline: true },
+      { name: "Date", value: event.date || "—", inline: true },
+      { name: "Level", value: event.level || "—", inline: true },
       {
         name: "Stages",
         value: String(match.stages_count),

--- a/discord/src/commands/shooter.ts
+++ b/discord/src/commands/shooter.ts
@@ -25,6 +25,9 @@ export async function handleShooter(
   const dashboard = await client.getShooterDashboard(shooter.shooterId);
   const dashUrl = `${baseUrl}/shooter/${shooter.shooterId}`;
 
+  const profile = dashboard.profile;
+  const displayName = profile?.name ?? shooter.name;
+
   const fields: APIEmbed["fields"] = [
     {
       name: "Matches",
@@ -33,40 +36,42 @@ export async function handleShooter(
     },
     {
       name: "Stages",
-      value: String(dashboard.stageCount),
+      value: String(dashboard.stats?.totalStages ?? 0),
       inline: true,
     },
   ];
 
-  if (dashboard.avgMatchPercent != null) {
+  if (dashboard.stats?.overallMatchPct != null) {
     fields.push({
       name: "Avg Match %",
-      value: `${dashboard.avgMatchPercent.toFixed(1)}%`,
+      value: `${dashboard.stats.overallMatchPct.toFixed(1)}%`,
       inline: true,
     });
   }
 
-  if (dashboard.club) {
+  if (profile?.club) {
     fields.push({
       name: "Club",
-      value: dashboard.club,
+      value: profile.club,
       inline: true,
     });
   }
 
-  if (dashboard.division) {
+  if (profile?.division) {
     fields.push({
       name: "Division",
-      value: dashboard.division,
+      value: profile.division,
       inline: true,
     });
   }
 
   // Show achievements if any
-  if (dashboard.achievements.length > 0) {
-    const achievementText = dashboard.achievements
+  const achievements = dashboard.achievements ?? [];
+  const unlocked = achievements.filter((a) => a.unlockedTiers.length > 0);
+  if (unlocked.length > 0) {
+    const achievementText = unlocked
       .slice(0, 6)
-      .map((a) => `${a.icon} ${a.name} (${a.tier})`)
+      .map((a) => `${a.definition.icon} ${a.definition.name}`)
       .join("\n");
     fields.push({
       name: "Achievements",
@@ -76,12 +81,13 @@ export async function handleShooter(
   }
 
   // Show recent matches
-  if (dashboard.recentMatches.length > 0) {
-    const recentText = dashboard.recentMatches
+  const matches = dashboard.matches ?? [];
+  if (matches.length > 0) {
+    const recentText = matches
       .slice(0, 3)
       .map((m) => {
-        const pct = m.matchPercent != null ? ` — ${m.matchPercent.toFixed(1)}%` : "";
-        return `• ${m.name} (${m.date})${pct}`;
+        const pct = m.matchPct != null ? ` — ${m.matchPct.toFixed(1)}%` : "";
+        return `• ${m.name} (${m.date ?? "?"})${pct}`;
       })
       .join("\n");
     fields.push({
@@ -92,7 +98,7 @@ export async function handleShooter(
   }
 
   const embed: APIEmbed = {
-    title: dashboard.name,
+    title: displayName,
     url: dashUrl,
     color: 0x8b5cf6, // purple
     fields,

--- a/discord/src/commands/summary.ts
+++ b/discord/src/commands/summary.ts
@@ -115,10 +115,10 @@ export async function handleSummary(
 
   const matchUrl = `${baseUrl}/match/${event.content_type}/${event.id}`;
   const scoringLabel =
-    event.scoring_completed === 100
+    match.scoring_completed === 100
       ? "Completed"
-      : event.scoring_completed > 0
-        ? `${event.scoring_completed}% scored`
+      : match.scoring_completed > 0
+        ? `${match.scoring_completed}% scored`
         : "Not started";
 
   const embeds: APIEmbed[] = [];

--- a/discord/src/commands/watch.ts
+++ b/discord/src/commands/watch.ts
@@ -55,14 +55,7 @@ export async function handleWatch(
     };
   }
 
-  const match = events[0];
-
-  if (match.scoring_completed === 100) {
-    return {
-      content: `**${match.name}** is already fully scored. Nothing to watch.`,
-      embeds: [],
-    };
-  }
+  const event = events[0];
 
   // Validate that there are linked shooters competing in this match
   const linkedShooters = await getGuildLinkedShooters(kv, guildId);
@@ -75,8 +68,17 @@ export async function handleWatch(
     };
   }
 
+  // Fetch full match data for scoring status, counts, and competitor resolution
+  const fullMatch = await client.getMatch(event.content_type, event.id);
+
+  if (fullMatch.scoring_completed === 100) {
+    return {
+      content: `**${event.name}** is already fully scored. Nothing to watch.`,
+      embeds: [],
+    };
+  }
+
   // Resolve linked shooters to match competitors
-  const fullMatch = await client.getMatch(match.content_type, match.id);
   const trackedNames: string[] = [];
   for (const linked of linkedShooters) {
     const competitor = fullMatch.competitors.find(
@@ -91,7 +93,7 @@ export async function handleWatch(
     const linkedNames = linkedShooters.map((s) => s.name).join(", ");
     return {
       content:
-        `None of the linked shooters are competing in **${match.name}**.\n` +
+        `None of the linked shooters are competing in **${event.name}**.\n` +
         `Linked in this server: ${linkedNames}\n\n` +
         `If someone is missing, they can use \`/link <name>\` to connect their account.`,
       embeds: [],
@@ -99,31 +101,31 @@ export async function handleWatch(
   }
 
   const state: WatchState = {
-    matchCt: match.content_type,
-    matchId: match.id,
-    matchName: match.name,
+    matchCt: event.content_type,
+    matchId: event.id,
+    matchName: event.name,
     channelId,
-    lastScoringPct: match.scoring_completed,
+    lastScoringPct: fullMatch.scoring_completed,
     notifiedStages: {},
     createdAt: new Date().toISOString(),
   };
 
   await kv.put(watchKey(guildId), JSON.stringify(state));
 
-  const matchUrl = `${baseUrl}/match/${match.content_type}/${match.id}`;
+  const matchUrl = `${baseUrl}/match/${event.content_type}/${event.id}`;
   const statusLabel =
-    match.scoring_completed > 0
-      ? `${match.scoring_completed}% scored`
+    fullMatch.scoring_completed > 0
+      ? `${fullMatch.scoring_completed}% scored`
       : "Not started yet";
 
   const embed: APIEmbed = {
-    title: `Now watching: ${match.name}`,
+    title: `Now watching: ${event.name}`,
     url: matchUrl,
     color: 0xf59e0b, // amber
     fields: [
       { name: "Status", value: statusLabel, inline: true },
-      { name: "Stages", value: String(match.stages_count), inline: true },
-      { name: "Competitors", value: String(match.competitors_count), inline: true },
+      { name: "Stages", value: String(fullMatch.stages_count), inline: true },
+      { name: "Competitors", value: String(fullMatch.competitors_count), inline: true },
       { name: "Tracking", value: trackedNames.join(", "), inline: false },
     ],
     footer: {

--- a/discord/src/scoreboard-client.ts
+++ b/discord/src/scoreboard-client.ts
@@ -50,29 +50,13 @@ export class ScoreboardClient {
     id: number,
     competitorIds: number[],
   ): Promise<CompareResult> {
-    const resp = await this.post("/api/compare", {
-      ct,
-      id,
-      competitors: competitorIds,
-      mode: "live",
+    const params = new URLSearchParams({
+      ct: String(ct),
+      id: String(id),
+      competitor_ids: competitorIds.join(","),
     });
+    const resp = await this.fetch(`/api/compare?${params}`);
     return resp.json();
-  }
-
-  private async post(path: string, body: unknown): Promise<Response> {
-    const url = `${this.baseUrl}${path}`;
-    const resp = await globalThis.fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify(body),
-    });
-    if (!resp.ok) {
-      throw new Error(`Scoreboard API error: ${resp.status} ${resp.statusText} (${path})`);
-    }
-    return resp;
   }
 
   private async fetch(path: string): Promise<Response> {

--- a/discord/src/types.ts
+++ b/discord/src/types.ts
@@ -13,25 +13,41 @@ export interface Env {
 }
 
 // --- Scoreboard API response types (subset of what we need) ---
+// These must match the actual API responses from the Next.js app.
 
+/** GET /api/events?q=... — event search results. */
 export interface EventSearchResult {
   id: number;
   content_type: number;
   name: string;
-  venue: string;
+  venue: string | null;
   date: string;
   level: string;
+  status: string;
+  region: string;
+  discipline: string;
+}
+
+/** GET /api/match/{ct}/{id} — full match data. */
+export interface MatchResponse {
+  name: string;
+  venue: string | null;
+  date: string | null;
+  level: string | null;
   scoring_completed: number;
   competitors_count: number;
   stages_count: number;
+  stages: MatchStage[];
+  competitors: MatchCompetitor[];
+  squads: SquadInfo[];
 }
 
 export interface MatchCompetitor {
   id: number;
-  shooterId: number;
+  shooterId: number | null;
   name: string;
-  division: string;
-  club: string;
+  division: string | null;
+  club: string | null;
   category: string | null;
   region: string | null;
 }
@@ -40,9 +56,8 @@ export interface MatchStage {
   id: number;
   stage_number: number;
   name: string;
-  scoring_type: string;
   max_points: number;
-  min_rounds: number;
+  min_rounds: number | null;
 }
 
 export interface SquadInfo {
@@ -51,40 +66,33 @@ export interface SquadInfo {
   competitorIds: number[];
 }
 
-export interface MatchResponse {
-  id: number;
-  content_type: number;
-  name: string;
-  venue: string;
-  date: string;
-  level: string;
-  scoring_completed: number;
-  competitors: MatchCompetitor[];
-  stages: MatchStage[];
-  squads: SquadInfo[];
-}
-
+/** GET /api/shooter/{shooterId} — dashboard response. */
 export interface ShooterDashboardResponse {
   shooterId: number;
-  name: string;
-  club: string | null;
-  division: string | null;
+  profile: {
+    name: string;
+    club: string | null;
+    division: string | null;
+    lastSeen: string;
+  } | null;
   matchCount: number;
-  stageCount: number;
-  avgMatchPercent: number | null;
-  achievements: Array<{
-    id: string;
+  matches: Array<{
     name: string;
-    tier: string;
-    icon: string;
+    date: string | null;
+    matchPct: number | null;
+    stageCount: number;
   }>;
-  recentMatches: Array<{
-    name: string;
-    date: string;
-    matchPercent: number | null;
+  stats: {
+    totalStages: number;
+    overallMatchPct: number | null;
+  };
+  achievements?: Array<{
+    definition: { id: string; name: string; icon: string };
+    unlockedTiers: Array<{ level: number }>;
   }>;
 }
 
+/** GET /api/shooter/search?q=... — shooter search results. */
 export interface ShooterSearchResult {
   shooterId: number;
   name: string;
@@ -94,6 +102,8 @@ export interface ShooterSearchResult {
 
 // Subset of CompareResponse needed for stage-scored notifications.
 // We only care about per-competitor per-stage results.
+
+/** GET /api/compare?ct=...&id=...&competitor_ids=... */
 export interface CompareResult {
   stages: Array<{
     stage_id: number;
@@ -106,8 +116,8 @@ export interface CompareResult {
   competitors: Array<{
     id: number;
     name: string;
-    division: string;
-    club: string;
+    division: string | null;
+    club: string | null;
   }>;
 }
 

--- a/discord/tests/commands.test.ts
+++ b/discord/tests/commands.test.ts
@@ -6,6 +6,7 @@ import { handleHelp, WELCOME_EMBED } from "../src/commands/help";
 import type { ScoreboardClient } from "../src/scoreboard-client";
 import type {
   EventSearchResult,
+  MatchResponse,
   ShooterSearchResult,
   ShooterDashboardResponse,
 } from "../src/types";
@@ -15,9 +16,10 @@ import type {
 function mockClient(overrides: Partial<ScoreboardClient> = {}): ScoreboardClient {
   return {
     searchEvents: vi.fn().mockResolvedValue([]),
-    getMatch: vi.fn().mockResolvedValue({}),
+    getMatch: vi.fn().mockResolvedValue(makeMatchResponse()),
     searchShooters: vi.fn().mockResolvedValue([]),
     getShooterDashboard: vi.fn().mockResolvedValue({}),
+    compare: vi.fn().mockResolvedValue({ stages: [], competitors: [] }),
     ...overrides,
   } as unknown as ScoreboardClient;
 }
@@ -42,9 +44,25 @@ function makeEvent(overrides: Partial<EventSearchResult> = {}): EventSearchResul
     venue: "Gothenburg",
     date: "2026-06-15",
     level: "Level III",
+    status: "cp",
+    region: "Sweden",
+    discipline: "IPSC Handgun",
+    ...overrides,
+  };
+}
+
+function makeMatchResponse(overrides: Partial<MatchResponse> = {}): MatchResponse {
+  return {
+    name: "Swedish Handgun Championship 2026",
+    venue: "Gothenburg",
+    date: "2026-06-15",
+    level: "Level III",
     scoring_completed: 100,
     competitors_count: 120,
     stages_count: 16,
+    stages: [],
+    competitors: [],
+    squads: [],
     ...overrides,
   };
 }
@@ -62,14 +80,18 @@ function makeShooterResult(overrides: Partial<ShooterSearchResult> = {}): Shoote
 function makeDashboard(overrides: Partial<ShooterDashboardResponse> = {}): ShooterDashboardResponse {
   return {
     shooterId: 42,
-    name: "Jane Doe",
-    club: "Gothenburg PSK",
-    division: "Production",
+    profile: {
+      name: "Jane Doe",
+      club: "Gothenburg PSK",
+      division: "Production",
+      lastSeen: "2026-03-01",
+    },
     matchCount: 15,
-    stageCount: 180,
-    avgMatchPercent: 72.5,
-    achievements: [],
-    recentMatches: [],
+    matches: [],
+    stats: {
+      totalStages: 180,
+      overallMatchPct: 72.5,
+    },
     ...overrides,
   };
 }
@@ -97,9 +119,10 @@ describe("handleMatch", () => {
   });
 
   it("shows completed status with green color", async () => {
-    const event = makeEvent({ scoring_completed: 100 });
+    const event = makeEvent();
     const client = mockClient({
       searchEvents: vi.fn().mockResolvedValue([event]),
+      getMatch: vi.fn().mockResolvedValue(makeMatchResponse({ scoring_completed: 100 })),
     });
     const result = await handleMatch(client, BASE_URL, "Swedish");
     const statusField = result.embeds[0].fields?.find((f) => f.name === "Status");
@@ -108,9 +131,10 @@ describe("handleMatch", () => {
   });
 
   it("shows scoring percentage for in-progress matches", async () => {
-    const event = makeEvent({ scoring_completed: 45 });
+    const event = makeEvent();
     const client = mockClient({
       searchEvents: vi.fn().mockResolvedValue([event]),
+      getMatch: vi.fn().mockResolvedValue(makeMatchResponse({ scoring_completed: 45 })),
     });
     const result = await handleMatch(client, BASE_URL, "Swedish");
     const statusField = result.embeds[0].fields?.find((f) => f.name === "Status");
@@ -119,9 +143,10 @@ describe("handleMatch", () => {
   });
 
   it("shows 'Not started' for zero scoring", async () => {
-    const event = makeEvent({ scoring_completed: 0 });
+    const event = makeEvent();
     const client = mockClient({
       searchEvents: vi.fn().mockResolvedValue([event]),
+      getMatch: vi.fn().mockResolvedValue(makeMatchResponse({ scoring_completed: 0 })),
     });
     const result = await handleMatch(client, BASE_URL, "Swedish");
     const statusField = result.embeds[0].fields?.find((f) => f.name === "Status");
@@ -179,7 +204,9 @@ describe("handleShooter", () => {
   it("omits avg match % when null", async () => {
     const client = mockClient({
       searchShooters: vi.fn().mockResolvedValue([makeShooterResult()]),
-      getShooterDashboard: vi.fn().mockResolvedValue(makeDashboard({ avgMatchPercent: null })),
+      getShooterDashboard: vi.fn().mockResolvedValue(
+        makeDashboard({ stats: { totalStages: 0, overallMatchPct: null } }),
+      ),
     });
     const result = await handleShooter(client, BASE_URL, "Jane");
     const fields = result.embeds[0].fields!;
@@ -189,7 +216,10 @@ describe("handleShooter", () => {
   it("shows achievements when present", async () => {
     const dashboard = makeDashboard({
       achievements: [
-        { id: "competitor", name: "Competitor", tier: "Bronze", icon: "medal" },
+        {
+          definition: { id: "competitor", name: "Competitor", icon: "medal" },
+          unlockedTiers: [{ level: 1 }],
+        },
       ],
     });
     const client = mockClient({
@@ -199,13 +229,13 @@ describe("handleShooter", () => {
     const result = await handleShooter(client, BASE_URL, "Jane");
     const achField = result.embeds[0].fields!.find((f) => f.name === "Achievements");
     expect(achField?.value).toContain("Competitor");
-    expect(achField?.value).toContain("Bronze");
+    expect(achField?.value).toContain("medal");
   });
 
   it("shows recent matches when present", async () => {
     const dashboard = makeDashboard({
-      recentMatches: [
-        { name: "Regional Match", date: "2026-03-01", matchPercent: 68.2 },
+      matches: [
+        { name: "Regional Match", date: "2026-03-01", matchPct: 68.2, stageCount: 12 },
       ],
     });
     const client = mockClient({

--- a/discord/tests/watch.test.ts
+++ b/discord/tests/watch.test.ts
@@ -46,9 +46,9 @@ function makeEvent(overrides: Partial<EventSearchResult> = {}): EventSearchResul
     venue: "Gothenburg",
     date: "2026-06-15",
     level: "Level III",
-    scoring_completed: 30,
-    competitors_count: 120,
-    stages_count: 16,
+    status: "on",
+    region: "Sweden",
+    discipline: "IPSC Handgun",
     ...overrides,
   };
 }
@@ -61,6 +61,9 @@ describe("handleWatch", () => {
     const client = mockClient({
       searchEvents: vi.fn().mockResolvedValue([event]),
       getMatch: vi.fn().mockResolvedValue({
+        scoring_completed: 30,
+        competitors_count: 120,
+        stages_count: 16,
         competitors: [
           { id: 1, shooterId: 42, name: "Jane Doe", division: "Production", club: "PSK" },
         ],
@@ -103,6 +106,9 @@ describe("handleWatch", () => {
     const client = mockClient({
       searchEvents: vi.fn().mockResolvedValue([event]),
       getMatch: vi.fn().mockResolvedValue({
+        scoring_completed: 30,
+        competitors_count: 120,
+        stages_count: 16,
         competitors: [
           { id: 1, shooterId: 999, name: "Other Person", division: "Open", club: "ABC" },
         ],
@@ -142,11 +148,22 @@ describe("handleWatch", () => {
   });
 
   it("rejects fully scored matches", async () => {
-    const event = makeEvent({ scoring_completed: 100 });
+    const event = makeEvent();
     const client = mockClient({
       searchEvents: vi.fn().mockResolvedValue([event]),
+      getMatch: vi.fn().mockResolvedValue({
+        scoring_completed: 100,
+        competitors_count: 120,
+        stages_count: 16,
+        competitors: [],
+        stages: [],
+        squads: [],
+      }),
     });
-    const kv = mockKV();
+    const store: Record<string, string> = {
+      "g:guild-1:link:user-1": JSON.stringify({ shooterId: 42, name: "Jane Doe" }),
+    };
+    const kv = mockKV(store);
 
     const result = await handleWatch(client, kv, BASE_URL, "guild-1", "channel-1", "Swedish");
     expect(result.content).toContain("already fully scored");


### PR DESCRIPTION
## Summary
- **`/me` crash** — `ShooterDashboardResponse` type was completely wrong (flat `name`/`club`/`division` vs nested `profile`, `recentMatches` vs `matches`, `stageCount` vs `stats.totalStages`). Fixed to match real API shape.
- **`/summary` 405** — compare endpoint only accepts GET, but the bot was POSTing. Switched to `GET /api/compare?ct=X&id=Y&competitor_ids=1,2,3`.
- **`/match` missing data** — `EventSearchResult` type had `scoring_completed`/`competitors_count`/`stages_count` which don't exist on `/api/events`. Now fetches full match data via `getMatch()`.
- **`/watch` and `/leaderboard`** — same `scoring_completed` issue; now reads from match data instead of event search results.
- All 42 tests updated and passing.

## Test plan
- [ ] Deploy and test `/me` — should show shooter dashboard
- [ ] Test `/summary <match>` — should return stage breakdown
- [ ] Test `/match <query>` — should show scoring status and counts
- [ ] Test `/shooter <name>` — should show dashboard embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)