### PR TITLE
fix: events query missing inline fragment for registration fields

### DIFF
--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -241,14 +241,16 @@ export const EVENTS_QUERY = `
       region
       get_full_rule_display
       get_full_level_display
-      registration_starts
-      registration_closes
-      squadding_starts
-      squadding_closes
-      is_registration_possible
-      is_squadding_possible
-      max_competitors
-      registration
+      ... on IpscMatchNode {
+        registration_starts
+        registration_closes
+        squadding_starts
+        squadding_closes
+        is_registration_possible
+        is_squadding_possible
+        max_competitors
+        registration
+      }
     }
   }
 `;


### PR DESCRIPTION
## Summary
- The `EVENTS_QUERY` in `lib/graphql.ts` was requesting `registration_starts`, `registration_closes`, `is_registration_possible`, `squadding_starts`, `squadding_closes`, `is_squadding_possible`, `max_competitors`, and `registration` at the **top level** of the events query
- These fields only exist on `IpscMatchNode` (not the base event type), so the SSI GraphQL API was returning `null` for all of them
- This caused the Discord bot's registration reminder digest to show "Registration dates not announced" for every match, even those with open or upcoming registration
- **Fix:** wrap these fields in `... on IpscMatchNode { }`, matching the pattern used by `MATCH_QUERY`

## Audit
Reviewed all 3 GraphQL queries (`MATCH_QUERY`, `EVENTS_QUERY`, `SCORECARDS_QUERY`):
- `MATCH_QUERY` — correct, all IPSC-specific fields properly inside inline fragments
- `SCORECARDS_QUERY` — correct, all fragments properly structured
- `EVENTS_QUERY` — **this was the only one with the bug**

No cache version bump needed — events use Next.js ISR cache (1h TTL), not the Redis match cache.

## Test plan
- [x] `pnpm -w run typecheck` — zero errors
- [x] `pnpm -w test` — 834 tests pass
- [ ] Deploy and verify `/api/events?q=Tallmilan` returns non-null `registration_starts` and `is_registration_possible`
- [ ] Discord bot digest shows correct registration status (OPEN / opens on date / closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)