### PR TITLE
feat(discord): personal DM reminders for match milestones

### DIFF
--- a/discord/src/commands/autocomplete.ts
+++ b/discord/src/commands/autocomplete.ts
@@ -10,7 +10,7 @@
 import type { ScoreboardClient } from "../scoreboard-client";
 
 /** Commands whose query option searches for events. */
-const EVENT_COMMANDS = new Set(["match", "watch", "summary", "leaderboard"]);
+const EVENT_COMMANDS = new Set(["match", "watch", "summary", "leaderboard", "remind"]);
 
 /** Commands whose name option searches for shooters. */
 const SHOOTER_COMMANDS = new Set(["shooter", "link"]);

--- a/discord/src/commands/definitions.ts
+++ b/discord/src/commands/definitions.ts
@@ -196,4 +196,29 @@ export const COMMANDS = [
       },
     ],
   },
+  {
+    name: "remind",
+    description: "Set personal DM reminders for a specific match",
+    type: ApplicationCommandType.ChatInput,
+    options: [
+      {
+        name: "action",
+        description: "set = add reminder, list = view active, cancel = remove",
+        type: ApplicationCommandOptionType.String,
+        required: true,
+        choices: [
+          { name: "set \u2014 remind me about a match", value: "set" },
+          { name: "list \u2014 show my active reminders", value: "list" },
+          { name: "cancel \u2014 remove a reminder", value: "cancel" },
+        ],
+      },
+      {
+        name: "query",
+        description: "Match name to search for (required for set/cancel)",
+        type: ApplicationCommandOptionType.String,
+        required: false,
+        autocomplete: true,
+      },
+    ],
+  },
 ] as const;

--- a/discord/src/commands/remind.ts
+++ b/discord/src/commands/remind.ts
@@ -1,0 +1,347 @@
+// Handler for /remind — personal DM reminders for specific matches.
+//
+// Users pick a match and get DM reminders for key milestones:
+// - Registration opening
+// - Squadding opening
+// - Match day
+//
+// Config is stored per-user per-guild in KV at g:{guildId}:remind:{userId}.
+// The cron trigger scans these keys daily and sends DMs for triggered milestones.
+
+import type { APIEmbed } from "discord-api-types/v10";
+import type { ScoreboardClient } from "../scoreboard-client";
+import type { EventSearchResult } from "../types";
+import { parseEventRef } from "./autocomplete";
+
+/** A single match the user wants reminders for. */
+export interface PersonalReminder {
+  matchCt: number;
+  matchId: number;
+  matchName: string;
+  matchDate: string | null;
+  registrationStarts: string | null;
+  squaddingStarts: string | null;
+  createdAt: string;
+}
+
+/** Per-user reminder config stored in KV. */
+export interface PersonalReminderConfig {
+  matches: PersonalReminder[];
+  /**
+   * Track which milestones have been notified to prevent duplicates.
+   * Map of "ct:matchId" → array of trigger types
+   * ("registration-open" | "squadding-open" | "match-day").
+   */
+  notifiedEvents: Record<string, string[]>;
+}
+
+const MAX_REMINDERS = 20;
+
+/** KV key for a user's personal reminders in a guild. */
+export function personalReminderKey(guildId: string, userId: string): string {
+  return `g:${guildId}:remind:${userId}`;
+}
+
+export async function handleRemind(
+  client: ScoreboardClient,
+  kv: KVNamespace,
+  baseUrl: string,
+  guildId: string,
+  userId: string,
+  action: string | undefined,
+  query: string | undefined,
+): Promise<{ content: string; embeds: APIEmbed[] }> {
+  switch (action) {
+    case "list":
+      return handleList(kv, baseUrl, guildId, userId);
+    case "cancel":
+      return handleCancel(kv, guildId, userId, query);
+    case "set":
+    default:
+      return handleSet(client, kv, baseUrl, guildId, userId, query);
+  }
+}
+
+async function handleSet(
+  client: ScoreboardClient,
+  kv: KVNamespace,
+  baseUrl: string,
+  guildId: string,
+  userId: string,
+  query: string | undefined,
+): Promise<{ content: string; embeds: APIEmbed[] }> {
+  if (!query) {
+    return {
+      content: "Please provide a match name to search for.\nUsage: `/remind set <match name>`",
+      embeds: [],
+    };
+  }
+
+  // Load existing config
+  const key = personalReminderKey(guildId, userId);
+  const raw = await kv.get(key);
+  const config: PersonalReminderConfig = raw
+    ? JSON.parse(raw)
+    : { matches: [], notifiedEvents: {} };
+
+  if (config.matches.length >= MAX_REMINDERS) {
+    return {
+      content: `You already have ${MAX_REMINDERS} active reminders. Use \`/remind cancel\` to remove one first.`,
+      embeds: [],
+    };
+  }
+
+  // Resolve the event — either from autocomplete or search
+  let event: EventSearchResult | null = null;
+  const ref = parseEventRef(query);
+  if (ref) {
+    // Pre-resolved from autocomplete — search to get full event data
+    const events = await client.searchEvents("");
+    // searchEvents with empty query won't help, use getMatch instead
+    try {
+      const match = await client.getMatch(ref.ct, ref.id);
+      event = {
+        id: ref.id,
+        content_type: ref.ct,
+        name: match.name,
+        venue: match.venue,
+        date: match.date ?? "",
+        ends: null,
+        level: match.level ?? "",
+        status: "",
+        region: "",
+        discipline: "",
+        registration_status: "",
+        registration_starts: null,
+        registration_closes: null,
+        is_registration_possible: false,
+        squadding_starts: match.squadding_starts,
+        squadding_closes: null,
+        is_squadding_possible: match.is_squadding_possible,
+        max_competitors: null,
+      };
+    } catch {
+      return { content: "Could not load that match. Please try again.", embeds: [] };
+    }
+  } else {
+    // Search by name
+    const events = await client.searchEvents(query);
+    if (events.length === 0) {
+      return {
+        content: `No matches found for "${query}". Try a different search term.`,
+        embeds: [],
+      };
+    }
+    event = events[0];
+  }
+
+  // Check for duplicate
+  const matchRef = `${event.content_type}:${event.id}`;
+  const alreadyTracked = config.matches.some(
+    (m) => m.matchCt === event!.content_type && m.matchId === event!.id,
+  );
+  if (alreadyTracked) {
+    return {
+      content: `You already have a reminder set for **${event.name}**.`,
+      embeds: [],
+    };
+  }
+
+  // Add the reminder
+  const reminder: PersonalReminder = {
+    matchCt: event.content_type,
+    matchId: event.id,
+    matchName: event.name,
+    matchDate: event.date || null,
+    registrationStarts: event.registration_starts,
+    squaddingStarts: event.squadding_starts,
+    createdAt: new Date().toISOString(),
+  };
+
+  config.matches.push(reminder);
+  await kv.put(key, JSON.stringify(config));
+
+  // Build confirmation embed
+  const matchUrl = `${baseUrl}/match/${event.content_type}/${event.id}`;
+  const milestones: string[] = [];
+
+  if (reminder.registrationStarts) {
+    const regDate = reminder.registrationStarts.slice(0, 10);
+    const isPast = regDate <= new Date().toISOString().slice(0, 10);
+    if (isPast) {
+      milestones.push("~~Registration opening~~ (already open)");
+    } else {
+      milestones.push(`Registration opening: **${formatDate(reminder.registrationStarts)}**`);
+    }
+  }
+
+  if (reminder.squaddingStarts) {
+    const sqDate = reminder.squaddingStarts.slice(0, 10);
+    const isPast = sqDate <= new Date().toISOString().slice(0, 10);
+    if (isPast) {
+      milestones.push("~~Squadding opening~~ (already open)");
+    } else {
+      milestones.push(`Squadding opening: **${formatDate(reminder.squaddingStarts)}**`);
+    }
+  }
+
+  if (reminder.matchDate) {
+    milestones.push(`Match day: **${formatDate(reminder.matchDate)}**`);
+  }
+
+  const description = milestones.length > 0
+    ? `I'll DM you when these milestones arrive:\n${milestones.map((m) => `\u2022 ${m}`).join("\n")}\n\n[View on Scoreboard](${matchUrl})`
+    : `No milestone dates available yet \u2014 I'll check daily and DM you if dates appear.\n\n[View on Scoreboard](${matchUrl})`;
+
+  const embed: APIEmbed = {
+    title: `Reminder set: ${event.name}`,
+    color: 0x22c55e, // green
+    description,
+    footer: {
+      text: `${config.matches.length}/${MAX_REMINDERS} reminders active. Make sure your DMs are open!`,
+    },
+  };
+
+  return { content: "", embeds: [embed] };
+}
+
+async function handleList(
+  kv: KVNamespace,
+  baseUrl: string,
+  guildId: string,
+  userId: string,
+): Promise<{ content: string; embeds: APIEmbed[] }> {
+  const key = personalReminderKey(guildId, userId);
+  const raw = await kv.get(key);
+  if (!raw) {
+    return {
+      content: "You don't have any active reminders.\nUse `/remind set <match name>` to set one up.",
+      embeds: [],
+    };
+  }
+
+  const config: PersonalReminderConfig = JSON.parse(raw);
+  if (config.matches.length === 0) {
+    return {
+      content: "You don't have any active reminders.\nUse `/remind set <match name>` to set one up.",
+      embeds: [],
+    };
+  }
+
+  const todayStr = new Date().toISOString().slice(0, 10);
+  const notified = config.notifiedEvents;
+
+  const fields: NonNullable<APIEmbed["fields"]> = config.matches.map((m) => {
+    const matchRef = `${m.matchCt}:${m.matchId}`;
+    const matchUrl = `${baseUrl}/match/${m.matchCt}/${m.matchId}`;
+    const firedTriggers = notified[matchRef] ?? [];
+    const lines: string[] = [];
+
+    if (m.matchDate) lines.push(`Match: ${formatDate(m.matchDate)}`);
+    if (m.registrationStarts) {
+      const done = firedTriggers.includes("registration-open") ||
+        m.registrationStarts.slice(0, 10) <= todayStr;
+      lines.push(done ? "~~Registration opening~~" : `Reg opens: ${formatDate(m.registrationStarts)}`);
+    }
+    if (m.squaddingStarts) {
+      const done = firedTriggers.includes("squadding-open") ||
+        m.squaddingStarts.slice(0, 10) <= todayStr;
+      lines.push(done ? "~~Squadding opening~~" : `Squadding opens: ${formatDate(m.squaddingStarts)}`);
+    }
+    if (m.matchDate) {
+      const done = firedTriggers.includes("match-day") || m.matchDate.slice(0, 10) < todayStr;
+      if (done) lines.push("~~Match day~~");
+    }
+
+    lines.push(`[Scoreboard](${matchUrl})`);
+
+    return {
+      name: m.matchName,
+      value: lines.join("\n"),
+      inline: false,
+    };
+  });
+
+  const embed: APIEmbed = {
+    title: "Your match reminders",
+    color: 0x5865f2, // blurple
+    fields,
+    footer: { text: `${config.matches.length}/${MAX_REMINDERS} reminders active` },
+  };
+
+  return { content: "", embeds: [embed] };
+}
+
+async function handleCancel(
+  kv: KVNamespace,
+  guildId: string,
+  userId: string,
+  query: string | undefined,
+): Promise<{ content: string; embeds: APIEmbed[] }> {
+  if (!query) {
+    return {
+      content: "Please provide the match name to cancel.\nUsage: `/remind cancel <match name>`",
+      embeds: [],
+    };
+  }
+
+  const key = personalReminderKey(guildId, userId);
+  const raw = await kv.get(key);
+  if (!raw) {
+    return { content: "You don't have any active reminders.", embeds: [] };
+  }
+
+  const config: PersonalReminderConfig = JSON.parse(raw);
+  if (config.matches.length === 0) {
+    return { content: "You don't have any active reminders.", embeds: [] };
+  }
+
+  // Try exact match by autocomplete-resolved ref
+  const ref = parseEventRef(query);
+  let idx = -1;
+  if (ref) {
+    idx = config.matches.findIndex(
+      (m) => m.matchCt === ref.ct && m.matchId === ref.id,
+    );
+  } else {
+    // Fuzzy match by name (case-insensitive substring)
+    const lower = query.toLowerCase();
+    idx = config.matches.findIndex((m) =>
+      m.matchName.toLowerCase().includes(lower),
+    );
+  }
+
+  if (idx === -1) {
+    const names = config.matches.map((m) => `\u2022 ${m.matchName}`).join("\n");
+    return {
+      content: `No reminder found matching "${query}".\n\nYour active reminders:\n${names}`,
+      embeds: [],
+    };
+  }
+
+  const removed = config.matches.splice(idx, 1)[0];
+  // Clean up notified events for this match
+  const matchRef = `${removed.matchCt}:${removed.matchId}`;
+  delete config.notifiedEvents[matchRef];
+
+  if (config.matches.length === 0) {
+    await kv.delete(key);
+  } else {
+    await kv.put(key, JSON.stringify(config));
+  }
+
+  return {
+    content: `Reminder cancelled for **${removed.matchName}**.`,
+    embeds: [],
+  };
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-GB", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}

--- a/discord/src/discord-api.ts
+++ b/discord/src/discord-api.ts
@@ -32,3 +32,36 @@ export async function postChannelMessage(
 
   return true;
 }
+
+/**
+ * Send a direct message to a user via the bot.
+ * Creates (or retrieves) a DM channel, then posts to it.
+ * Returns false silently if the user has DMs disabled.
+ */
+export async function sendDirectMessage(
+  botToken: string,
+  userId: string,
+  content: string,
+  embeds?: APIEmbed[],
+): Promise<boolean> {
+  // Step 1: Create/get DM channel
+  const dmResp = await fetch(`${DISCORD_API}/users/@me/channels`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bot ${botToken}`,
+    },
+    body: JSON.stringify({ recipient_id: userId }),
+  });
+
+  if (!dmResp.ok) {
+    // User has DMs disabled or bot cannot reach them — skip silently
+    console.warn(`Could not open DM channel for user ${userId}: ${dmResp.status}`);
+    return false;
+  }
+
+  const { id: channelId } = (await dmResp.json()) as { id: string };
+
+  // Step 2: Post message to the DM channel
+  return postChannelMessage(botToken, channelId, content, embeds);
+}

--- a/discord/src/index.ts
+++ b/discord/src/index.ts
@@ -28,11 +28,13 @@ import { handleSummary } from "./commands/summary";
 import { handleWatch, handleUnwatch } from "./commands/watch";
 import { handleRemindRegistrations } from "./commands/remind-registrations";
 import { handleRemindSquads } from "./commands/remind-squads";
+import { handleRemind } from "./commands/remind";
 import { handleAutocomplete } from "./commands/autocomplete";
 import { pollWatchedMatches } from "./notifications/stage-scored";
 import { pollRegistrationReminders } from "./notifications/registration-reminder";
 import { landingPage, privacyPage, tosPage } from "./pages";
 import { pollSquadReminders } from "./notifications/squad-reminder";
+import { pollPersonalReminders } from "./notifications/personal-reminder";
 
 const worker: ExportedHandler<Env> = {
   async fetch(request, env, ctx): Promise<Response> {
@@ -89,6 +91,7 @@ const worker: ExportedHandler<Env> = {
       pollWatchedMatches(env),
       pollRegistrationReminders(env),
       pollSquadReminders(env),
+      pollPersonalReminders(env),
     ]);
     for (const result of results) {
       if (result.status === "rejected") {
@@ -130,7 +133,7 @@ async function maybeWelcome(
 }
 
 // Commands where the response is only visible to the caller
-const EPHEMERAL_COMMANDS = new Set(["help", "link", "unlink", "me"]);
+const EPHEMERAL_COMMANDS = new Set(["help", "link", "unlink", "me", "remind"]);
 
 /**
  * Edit the original deferred response via the Discord webhook API.
@@ -417,6 +420,30 @@ async function handleDeferredCommand(
         );
         content = reminderResult.content;
         embeds = reminderResult.embeds;
+        break;
+      }
+
+      case "remind": {
+        if (!guildId) {
+          content = "This command can only be used in a server, not in DMs.";
+          break;
+        }
+        const remindUserId = getUserId(interaction);
+        if (!remindUserId) {
+          content = "Could not determine your Discord user ID.";
+          break;
+        }
+        const remindResult = await handleRemind(
+          client,
+          env.BOT_KV,
+          baseUrl,
+          guildId,
+          remindUserId,
+          options.action as string | undefined,
+          options.query as string | undefined,
+        );
+        content = remindResult.content;
+        embeds = remindResult.embeds;
         break;
       }
 

--- a/discord/src/notifications/personal-reminder.ts
+++ b/discord/src/notifications/personal-reminder.ts
@@ -1,0 +1,259 @@
+// Cron-triggered personal DM reminders.
+// Scans all KV keys matching g:*:remind:* (but NOT remind-registrations or remind-squads),
+// checks each user's tracked matches for milestones, and sends DMs.
+//
+// Triggers:
+// - registration-open: registration_starts date is today
+// - squadding-open: squadding_starts date is today
+// - match-day: match start date is today
+//
+// After all milestones for a match have fired, the match is auto-removed.
+
+import type { APIEmbed } from "discord-api-types/v10";
+import type { Env } from "../types";
+import { sendDirectMessage } from "../discord-api";
+import {
+  personalReminderKey,
+  type PersonalReminderConfig,
+  type PersonalReminder,
+} from "../commands/remind";
+
+// Matches keys like g:{guildId}:remind:{userId}
+// Does NOT match g:{guildId}:remind-registrations or g:{guildId}:remind-squads
+const PERSONAL_REMIND_RE = /^g:([^:]+):remind:([^:]+)$/;
+
+export async function pollPersonalReminders(env: Env): Promise<void> {
+  const todayStr = new Date().toISOString().slice(0, 10);
+  const listed = await env.BOT_KV.list({ prefix: "g:" });
+
+  for (const key of listed.keys) {
+    const match = PERSONAL_REMIND_RE.exec(key.name);
+    if (!match) continue;
+
+    const guildId = match[1];
+    const userId = match[2];
+
+    try {
+      await processUserReminders(env, guildId, userId, todayStr);
+    } catch (err) {
+      console.error(
+        `Error processing personal reminders for user ${userId} in guild ${guildId}:`,
+        err,
+      );
+    }
+  }
+}
+
+async function processUserReminders(
+  env: Env,
+  guildId: string,
+  userId: string,
+  todayStr: string,
+): Promise<void> {
+  const key = personalReminderKey(guildId, userId);
+  const raw = await env.BOT_KV.get(key);
+  if (!raw) return;
+
+  const config: PersonalReminderConfig = JSON.parse(raw);
+  if (config.matches.length === 0) return;
+
+  let changed = false;
+  const baseUrl = env.SCOREBOARD_BASE_URL;
+
+  for (const reminder of config.matches) {
+    const matchRef = `${reminder.matchCt}:${reminder.matchId}`;
+    const firedTriggers = config.notifiedEvents[matchRef] ?? [];
+
+    const triggers: Array<{
+      type: string;
+      embed: APIEmbed;
+    }> = [];
+
+    // Registration opening
+    if (
+      reminder.registrationStarts &&
+      reminder.registrationStarts.slice(0, 10) === todayStr &&
+      !firedTriggers.includes("registration-open")
+    ) {
+      triggers.push({
+        type: "registration-open",
+        embed: buildRegistrationEmbed(reminder, baseUrl),
+      });
+    }
+
+    // Squadding opening
+    if (
+      reminder.squaddingStarts &&
+      reminder.squaddingStarts.slice(0, 10) === todayStr &&
+      !firedTriggers.includes("squadding-open")
+    ) {
+      triggers.push({
+        type: "squadding-open",
+        embed: buildSquaddingEmbed(reminder, baseUrl),
+      });
+    }
+
+    // Match day
+    if (
+      reminder.matchDate &&
+      reminder.matchDate.slice(0, 10) === todayStr &&
+      !firedTriggers.includes("match-day")
+    ) {
+      triggers.push({
+        type: "match-day",
+        embed: buildMatchDayEmbed(reminder, baseUrl),
+      });
+    }
+
+    // Send DMs for triggered milestones
+    for (const trigger of triggers) {
+      await sendDirectMessage(
+        env.DISCORD_BOT_TOKEN,
+        userId,
+        "",
+        [trigger.embed],
+      );
+
+      if (!config.notifiedEvents[matchRef]) {
+        config.notifiedEvents[matchRef] = [];
+      }
+      config.notifiedEvents[matchRef].push(trigger.type);
+      changed = true;
+    }
+  }
+
+  // Auto-remove matches whose date has passed
+  const before = config.matches.length;
+  config.matches = config.matches.filter((m) => {
+    if (!m.matchDate) return true;
+    return m.matchDate.slice(0, 10) >= todayStr;
+  });
+  if (config.matches.length !== before) {
+    changed = true;
+    // Clean up notifiedEvents for removed matches
+    const activeRefs = new Set(
+      config.matches.map((m) => `${m.matchCt}:${m.matchId}`),
+    );
+    for (const ref of Object.keys(config.notifiedEvents)) {
+      if (!activeRefs.has(ref)) {
+        delete config.notifiedEvents[ref];
+      }
+    }
+  }
+
+  if (changed) {
+    if (config.matches.length === 0) {
+      await env.BOT_KV.delete(personalReminderKey(guildId, userId));
+    } else {
+      await env.BOT_KV.put(
+        personalReminderKey(guildId, userId),
+        JSON.stringify(config),
+      );
+    }
+  }
+}
+
+// ── Embed builders ──────────────────────────────────────────────────────────
+
+function buildRegistrationEmbed(
+  reminder: PersonalReminder,
+  baseUrl: string,
+): APIEmbed {
+  const matchUrl = `${baseUrl}/match/${reminder.matchCt}/${reminder.matchId}`;
+  const ssiUrl = `https://shootnscoreit.com/event/${reminder.matchCt}/${reminder.matchId}/`;
+
+  const lines: string[] = [
+    `Registration opens **today** for **${reminder.matchName}**!`,
+    "",
+  ];
+
+  if (reminder.registrationStarts) {
+    const unixTs = Math.floor(
+      new Date(reminder.registrationStarts).getTime() / 1000,
+    );
+    lines.push(`Opens at: <t:${unixTs}:t> (<t:${unixTs}:R>)`);
+    lines.push("");
+  }
+
+  if (reminder.matchDate) {
+    lines.push(`Match date: ${formatDate(reminder.matchDate)}`);
+    lines.push("");
+  }
+
+  lines.push(`[Register on SSI](${ssiUrl}) \u00b7 [View on Scoreboard](${matchUrl})`);
+
+  return {
+    title: "Registration opens today!",
+    color: 0xf59e0b, // amber
+    description: lines.join("\n"),
+    footer: { text: "Personal match reminder" },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function buildSquaddingEmbed(
+  reminder: PersonalReminder,
+  baseUrl: string,
+): APIEmbed {
+  const matchUrl = `${baseUrl}/match/${reminder.matchCt}/${reminder.matchId}`;
+  const ssiUrl = `https://shootnscoreit.com/event/${reminder.matchCt}/${reminder.matchId}/`;
+
+  const lines: string[] = [
+    `Squadding opens **today** for **${reminder.matchName}**!`,
+    "",
+  ];
+
+  if (reminder.squaddingStarts) {
+    const unixTs = Math.floor(
+      new Date(reminder.squaddingStarts).getTime() / 1000,
+    );
+    lines.push(`Opens at: <t:${unixTs}:t> (<t:${unixTs}:R>)`);
+    lines.push("");
+  }
+
+  lines.push(
+    "Squads are first-come-first-serve \u2014 be ready to pick your squad!",
+  );
+  lines.push("");
+  lines.push(`[Squad on SSI](${ssiUrl}) \u00b7 [View on Scoreboard](${matchUrl})`);
+
+  return {
+    title: "Squadding opens today!",
+    color: 0xef4444, // red — urgent
+    description: lines.join("\n"),
+    footer: { text: "Personal match reminder" },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function buildMatchDayEmbed(
+  reminder: PersonalReminder,
+  baseUrl: string,
+): APIEmbed {
+  const matchUrl = `${baseUrl}/match/${reminder.matchCt}/${reminder.matchId}`;
+  const ssiUrl = `https://shootnscoreit.com/event/${reminder.matchCt}/${reminder.matchId}/`;
+
+  const lines: string[] = [
+    `**${reminder.matchName}** starts today!`,
+    "",
+    `[SSI](${ssiUrl}) \u00b7 [Scoreboard](${matchUrl})`,
+  ];
+
+  return {
+    title: "Match day!",
+    color: 0x22c55e, // green
+    description: lines.join("\n"),
+    footer: { text: "Good luck and shoot safe!" },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-GB", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `/remind` command (set/list/cancel) for users to track specific matches and receive DM reminders for registration opening, squadding opening, and match day
- Adds `sendDirectMessage()` to `discord-api.ts` for DM delivery (fails silently if user has DMs disabled)
- Adds daily cron poller (`pollPersonalReminders`) that scans per-user KV configs and fires milestone DMs
- Auto-cleans expired matches; caps at 20 reminders per user

Closes #278

## Test plan
- [ ] Deploy and register commands (`pnpm register`)
- [ ] `/remind set Swedish Handgun` — should search, store, confirm with milestone dates
- [ ] `/remind list` — should show active reminders with dates and strikethrough for past milestones
- [ ] `/remind cancel Swedish Handgun` — should remove and confirm
- [ ] Verify DMs arrive by setting a reminder for a match whose date/registration/squadding is today
- [ ] Verify cron fires correctly via `wrangler tail` logs
- [ ] Verify users with DMs disabled don't cause errors (silent skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)