### PR TITLE
fix(discord): disable achievement announcements temporarily

### DIFF
--- a/discord/src/index.ts
+++ b/discord/src/index.ts
@@ -97,7 +97,7 @@ const worker: ExportedHandler<Env> = {
       pollRegistrationReminders(env),
       pollSquadReminders(env),
       pollPersonalReminders(env),
-      pollAchievements(env),
+      // pollAchievements(env), // disabled: spamming channel — re-enable after fixing
     ]);
     for (const result of results) {
       if (result.status === "rejected") {


### PR DESCRIPTION
## Summary
- Disables the `pollAchievements` cron poller that is spamming the Discord channel with repeated achievement announcements
- Other notification pollers (stage-scored, registration, squad, personal reminders) are unaffected
- Re-enable after root cause is identified and fixed

## Test plan
- [ ] Deploy to Cloudflare Workers and verify no more achievement spam in the channel
- [ ] Confirm other notifications (stage scored, reminders) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)