### PR TITLE
fix: show scores during early match scoring instead of pre-match view

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -119,8 +119,8 @@ export async function GET(req: Request) {
   }
 
   // Determine match state and compute TTL
-  const scoringPct = Math.round(
-    parseFloat(String(matchData.event?.scoring_completed ?? 0))
+  const scoringPct = parseFloat(
+    String(matchData.event?.scoring_completed ?? 0)
   );
   const matchDate = matchData.event?.starts ? new Date(matchData.event.starts) : null;
   const daysSince = matchDate ? (Date.now() - matchDate.getTime()) / 86_400_000 : 0;

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -402,8 +402,15 @@ export default function MatchPageClient() {
   const matchCancelled = match.match_status === "cs";
   const aiAvailable = coachingAvailability.data?.available === true;
   // Pre-match: no scores yet and match not completed or cancelled.
+  // Also check compare data: if any stage has competitor scores, scoring has
+  // started regardless of what scoring_completed reports (handles rounding
+  // edge cases and delayed API updates for large matches).
+  const hasActualScores = compareQuery.data?.stages.some(
+    (s) => Object.keys(s.competitors).length > 0,
+  ) ?? false;
   const isPreMatch =
     match.scoring_completed === 0 &&
+    !hasActualScores &&
     match.match_status !== "cp" &&
     match.match_status !== "cs";
 

--- a/components/recent-competitions.tsx
+++ b/components/recent-competitions.tsx
@@ -61,7 +61,7 @@ export function CompetitionCard({
         <div className="flex items-start justify-between gap-2 pr-6">
           <span className="font-semibold leading-snug">{comp.name}</span>
           <span className="text-sm font-medium text-muted-foreground shrink-0">
-            {comp.scoring_completed}%
+            {Math.round(comp.scoring_completed)}%
           </span>
         </div>
 
@@ -74,7 +74,7 @@ export function CompetitionCard({
         <Progress
           value={comp.scoring_completed}
           className="mt-3 h-1.5"
-          aria-label={`${comp.scoring_completed}% scored`}
+          aria-label={`${Math.round(comp.scoring_completed)}% scored`}
         />
       </button>
     </div>

--- a/lib/match-data.ts
+++ b/lib/match-data.ts
@@ -144,7 +144,7 @@ export async function fetchMatchData(
 
   const ev = raw.event;
 
-  const scoringPct = Math.round(parseFloat(String(ev.scoring_completed ?? 0)));
+  const scoringPct = parseFloat(String(ev.scoring_completed ?? 0));
   const matchDate = ev.starts ? new Date(ev.starts) : null;
   const daysSince = matchDate ? (Date.now() - matchDate.getTime()) / 86_400_000 : 0;
   const resultsPublished = ev.results === "all";
@@ -276,7 +276,7 @@ export async function fetchMatchData(
     max_competitors: ev.max_competitors ?? null,
     scoring_completed:
       ev.scoring_completed != null
-        ? Math.round(parseFloat(String(ev.scoring_completed)))
+        ? parseFloat(String(ev.scoring_completed))
         : 0,
     match_status: ev.status ?? "on",
     results_status: ev.results ?? "org",


### PR DESCRIPTION
Math.round() on scoring_completed rounded small percentages (< 0.5%) to
0, which triggered the pre-match view and hid all scores — common at the
start of large matches. Preserve the raw float so any value > 0 signals
active scoring. Also add a compare-data fallback: if stage scorecard
data exists, override isPreMatch even if scoring_completed is still 0.

https://claude.ai/code/session_01Uh7VMGJ4HaUapawAfyMHmE