### PR TITLE
fix(cache): require 1 day elapsed before marking match complete

### DIFF
--- a/app/api/coaching/[ct]/[id]/[competitorId]/route.ts
+++ b/app/api/coaching/[ct]/[id]/[competitorId]/route.ts
@@ -22,7 +22,7 @@ import {
   computeStageDegradationData,
   type RawScorecard,
 } from "@/app/api/compare/logic";
-import { computeMatchTtl } from "@/lib/match-ttl";
+import { computeMatchTtl, isMatchComplete } from "@/lib/match-ttl";
 import { extractDivision } from "@/lib/divisions";
 import { decodeShooterId } from "@/lib/shooter-index";
 import cache from "@/lib/cache-impl";
@@ -206,7 +206,7 @@ export async function GET(
   const daysSince = matchDate
     ? (Date.now() - matchDate.getTime()) / 86_400_000
     : 0;
-  const isComplete = scoringPct >= 95 || daysSince > 3;
+  const isComplete = isMatchComplete(scoringPct, daysSince);
   const matchName = matchData.event.name ?? "Unknown Match";
 
   // 5. Fetch scorecards (reuses existing Redis cache)

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -3,7 +3,7 @@ import { MAX_COMPETITORS } from "@/lib/constants";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { cachedExecuteQuery, gqlCacheKey, SCORECARDS_QUERY, MATCH_QUERY } from "@/lib/graphql";
 import cache from "@/lib/cache-impl";
-import { computeMatchTtl } from "@/lib/match-ttl";
+import { computeMatchTtl, isMatchComplete } from "@/lib/match-ttl";
 import { persistToMatchStore } from "@/lib/match-data-store";
 import { afterResponse } from "@/lib/background-impl";
 
@@ -124,7 +124,7 @@ export async function GET(req: Request) {
   );
   const matchDate = matchData.event?.starts ? new Date(matchData.event.starts) : null;
   const daysSince = matchDate ? (Date.now() - matchDate.getTime()) / 86_400_000 : 0;
-  const isComplete = scoringPct >= 95 || daysSince > 3;
+  const isComplete = isMatchComplete(scoringPct, daysSince);
   const dataTtl = computeMatchTtl(scoringPct, daysSince, matchData.event?.starts ?? null);
 
   // Upgrade match cache entry TTL based on match state

--- a/app/api/og/match/[ct]/[id]/route.tsx
+++ b/app/api/og/match/[ct]/[id]/route.tsx
@@ -12,6 +12,7 @@ import {
   assignArchetype,
 } from "@/app/api/compare/logic";
 import { PALETTE } from "@/lib/colors";
+import { isMatchComplete } from "@/lib/match-ttl";
 import {
   C,
   OG_W,
@@ -82,7 +83,10 @@ export async function GET(
     });
   }
 
-  const isComplete = match.scoringCompleted >= 95;
+  const daysSince = match.date
+    ? (Date.now() - new Date(match.date).getTime()) / 86_400_000
+    : 0;
+  const isComplete = isMatchComplete(match.scoringCompleted, daysSince);
 
   // Resolve which of the requested IDs actually exist in the match.
   const selectedCompetitors = rawCompetitorIds

--- a/lib/coaching-prompt.ts
+++ b/lib/coaching-prompt.ts
@@ -1,6 +1,7 @@
 // Pure functions — no I/O, no side effects. Fully unit-tested.
 // Extracted following the app/api/compare/logic.ts pattern.
 
+import { isMatchComplete } from "@/lib/match-ttl";
 import type {
   CompetitorInfo,
   StageComparison,
@@ -405,8 +406,8 @@ export function checkCoachingEligibility(
   stages: StageComparison[],
   competitorId: number,
 ): string | null {
-  const isComplete = scoringCompleted >= 95 || daysSince > 3;
-  if (!isComplete) return "Match scoring is not yet complete";
+  if (!isMatchComplete(scoringCompleted, daysSince))
+    return "Match scoring is not yet complete";
 
   const missingStages = stages.filter((s) => !s.competitors[competitorId]);
   if (missingStages.length > 0) return "Missing scorecards on some stages";

--- a/lib/match-data.ts
+++ b/lib/match-data.ts
@@ -5,7 +5,7 @@
 import { cache } from "react";
 import { cachedExecuteQuery, gqlCacheKey, MATCH_QUERY } from "@/lib/graphql";
 import cacheAdapter from "@/lib/cache-impl";
-import { computeMatchTtl } from "@/lib/match-ttl";
+import { computeMatchTtl, isMatchComplete } from "@/lib/match-ttl";
 import { extractDivision } from "@/lib/divisions";
 import { decodeShooterId, indexMatchShooters } from "@/lib/shooter-index";
 import { afterResponse } from "@/lib/background-impl";
@@ -153,7 +153,7 @@ export async function fetchMatchData(
   const ttl = (resultsPublished || cancelled)
     ? null
     : computeMatchTtl(scoringPct, daysSince, ev.starts ?? null);
-  const isComplete = resultsPublished || scoringPct >= 95 || daysSince > 3;
+  const isComplete = resultsPublished || isMatchComplete(scoringPct, daysSince);
 
   try {
     if (ttl === null) {

--- a/lib/match-ttl.ts
+++ b/lib/match-ttl.ts
@@ -3,7 +3,7 @@
  * Returns null for permanent (no expiry).
  *
  * TTL tiers:
- *   completed (scoring ≥95% OR >3 days old)  → null (permanent)
+ *   completed (see isMatchComplete)           → null (permanent)
  *   active scoring (scoring > 0%)             → 30 s
  *   pre-match, start > 7 days away            → 4 h
  *   pre-match, start 2–7 days away            → 1 h
@@ -20,13 +20,31 @@ const DEFAULT_MIN_TTL = parseInt(
   10,
 );
 
+/**
+ * Is a match "done" from our caching/UI perspective?
+ *
+ * A high `scoring_completed` value on its own is not enough — during an
+ * active match day the upstream percentage can cross 95% while some
+ * squads still have unscored stages, so we also require at least one full
+ * day has passed since the match start. Matches more than 3 days old are
+ * considered complete regardless of scoring (handles users viewing
+ * historical matches where scoring_completed was never finalised).
+ */
+export function isMatchComplete(
+  scoringPct: number,
+  daysSince: number,
+): boolean {
+  if (daysSince > 3) return true;
+  return scoringPct >= 95 && daysSince >= 1;
+}
+
 export function computeMatchTtl(
   scoringPct: number,
   daysSince: number, // negative = future match
   dateStr: string | null,
   minTtl = DEFAULT_MIN_TTL,
 ): number | null {
-  if (scoringPct >= 95 || daysSince > 3) return null; // permanent
+  if (isMatchComplete(scoringPct, daysSince)) return null; // permanent
 
   let ttl: number;
 

--- a/tests/unit/coaching-prompt.test.ts
+++ b/tests/unit/coaching-prompt.test.ts
@@ -839,10 +839,18 @@ describe("checkCoachingEligibility", () => {
     ).toBeNull();
   });
 
-  it("accepts match at exactly 95% scoring", () => {
+  it("accepts match at exactly 95% scoring once a day has passed", () => {
     expect(
-      checkCoachingEligibility(95, 0, stagesWithCompetitor(), competitorId),
+      checkCoachingEligibility(95, 1, stagesWithCompetitor(), competitorId),
     ).toBeNull();
+  });
+
+  it("rejects 95%+ scoring while match is still on the first day", () => {
+    // Regression: during an active match day the scoring_completed can
+    // climb past 95% before all scorecards are in — coaching should wait.
+    expect(
+      checkCoachingEligibility(98, 0.5, stagesWithCompetitor(), competitorId),
+    ).toBe("Match scoring is not yet complete");
   });
 
   it("accepts match at boundary daysSince = 3.1", () => {

--- a/tests/unit/match-ttl.test.ts
+++ b/tests/unit/match-ttl.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { computeMatchTtl } from "@/lib/match-ttl";
+import { computeMatchTtl, isMatchComplete } from "@/lib/match-ttl";
 
 const NOW = new Date("2025-06-15T12:00:00Z").getTime();
 
@@ -28,18 +28,30 @@ function rawTtl(
 describe("computeMatchTtl", () => {
   // ── Completed matches ──────────────────────────────────────────────────────
 
-  it("returns null (permanent) when scoring >= 95%", () => {
+  it("returns null (permanent) when scoring >= 95% AND daysSince >= 1", () => {
     expect(computeMatchTtl(95, 1, isoHoursFromNow(-24))).toBeNull();
     expect(computeMatchTtl(100, 1, isoHoursFromNow(-24))).toBeNull();
   });
 
-  it("returns null (permanent) when daysSince > 3", () => {
+  it("returns null (permanent) when daysSince > 3 regardless of scoring", () => {
     expect(computeMatchTtl(0, 3.1, null)).toBeNull();
     expect(computeMatchTtl(50, 10, isoHoursFromNow(-240))).toBeNull();
   });
 
-  it("returns null at boundary: scoring exactly 95, daysSince 0", () => {
-    expect(computeMatchTtl(95, 0, isoHoursFromNow(0))).toBeNull();
+  // Regression: during an active match day the upstream scoring_completed
+  // can climb past 95% before all squads' scorecards are in. If we flipped
+  // the cache to permanent at that point, the last scorecards would never
+  // be fetched. Require at least 1 day since start before trusting the
+  // scoring threshold.
+  it("stays in active-scoring tier when scoring >= 95% but match started same day", () => {
+    // 95% scored, match started 6 hours ago → NOT complete
+    expect(computeMatchTtl(95, 0.25, isoHoursFromNow(-6))).not.toBeNull();
+    expect(computeMatchTtl(98, 0.5, isoHoursFromNow(-12))).not.toBeNull();
+    expect(rawTtl(99, 0.9, isoHoursFromNow(-21))).toBe(30);
+  });
+
+  it("returns null at boundary: scoring exactly 95, daysSince exactly 1", () => {
+    expect(computeMatchTtl(95, 1, isoHoursFromNow(-24))).toBeNull();
   });
 
   // ── Active scoring ─────────────────────────────────────────────────────────
@@ -149,5 +161,34 @@ describe("computeMatchTtl", () => {
 
     const soon = isoHoursFromNow(24);
     expect(computeMatchTtl(0, -1, soon)).toBe(30 * 60);
+  });
+});
+
+describe("isMatchComplete", () => {
+  it("true when daysSince > 3, regardless of scoring", () => {
+    expect(isMatchComplete(0, 3.1)).toBe(true);
+    expect(isMatchComplete(50, 10)).toBe(true);
+  });
+
+  it("true when scoring >= 95% AND daysSince >= 1", () => {
+    expect(isMatchComplete(95, 1)).toBe(true);
+    expect(isMatchComplete(100, 2)).toBe(true);
+  });
+
+  it("false when scoring >= 95% but match started same day", () => {
+    // Primary regression: high scoring % mid-match-day must not mark complete
+    expect(isMatchComplete(95, 0)).toBe(false);
+    expect(isMatchComplete(98, 0.5)).toBe(false);
+    expect(isMatchComplete(100, 0.99)).toBe(false);
+  });
+
+  it("false when scoring low and match is recent", () => {
+    expect(isMatchComplete(50, 1)).toBe(false);
+    expect(isMatchComplete(0, 0)).toBe(false);
+  });
+
+  it("false for future matches", () => {
+    expect(isMatchComplete(0, -1)).toBe(false);
+    expect(isMatchComplete(0, -10)).toBe(false);
   });
 });

--- a/tests/unit/og-image.test.ts
+++ b/tests/unit/og-image.test.ts
@@ -37,10 +37,14 @@ const MOCK_MATCH: OgMatchData = {
   ],
 };
 
+// Active match: recent date + low scoring so isMatchComplete() is false.
+// (A completed-but-recent match would also need to be within 3 days, so we
+// set date to a few hours ago — mirrors the real "match in progress" case.)
 const ACTIVE_MATCH: OgMatchData = {
   ...MOCK_MATCH,
   name: "Active Match",
   scoringCompleted: 40,
+  date: new Date(Date.now() - 6 * 3_600_000).toISOString(),
 };
 
 function makeRequest(path: string): Request {


### PR DESCRIPTION
## Summary

- `computeMatchTtl` / `isMatchComplete` flipped a match to permanent as soon as `scoring_completed >= 95%`. During an active match day the upstream percentage can cross 95% while some squads still have unscored stages — at that point both `GetMatch` and `GetMatchScorecards` were `persist()`-ed (and written to D1 via `persistToMatchStore`), so scorecards that landed after the flip were never refetched.
- Introduce a shared `isMatchComplete(scoringPct, daysSince)` helper in `lib/match-ttl.ts`: requires **both** `scoring >= 95%` AND `daysSince >= 1`, or `daysSince > 3` on its own. `results=all` / `status=cs` still short-circuit to permanent as before.
- Replace the ad-hoc `scoring >= 95 || daysSince > 3` checks across `lib/match-data.ts`, `app/api/compare/route.ts`, `app/api/coaching/[ct]/[id]/[competitorId]/route.ts`, `lib/coaching-prompt.ts`, and `app/api/og/match/[ct]/[id]/route.tsx` so all call sites stay in sync.

## Effect

During a live match, even when `scoring_completed` briefly crosses 95%, both `GetMatch` and `GetMatchScorecards` stay on the 30s/300s TTL tier and keep refreshing until ≥1 day has passed — so the last scorecards of the day do get picked up instead of being frozen out by an early `persist()`. No behaviour change for matches visited days later (daysSince > 3 branch is unchanged) or for matches with officially published results.

## Test plan

- [x] `pnpm -w run typecheck` — clean
- [x] `pnpm -w test` — 841/841 passing
- [x] `pnpm -w run lint` — no new warnings (3 pre-existing in `discord/`)
- [x] New unit tests in `tests/unit/match-ttl.test.ts`: regression case (95%+ on match day stays active) + dedicated `isMatchComplete` describe block
- [x] Updated `tests/unit/coaching-prompt.test.ts` + `tests/unit/og-image.test.ts` fixtures for the stricter rule
- [ ] Manual: next live match, watch a stage score come in after the match-level % crosses 95 and confirm the scorecard refresh still lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)