### PR TITLE
feat(match): make pre-match view selectable while match is in progress

### DIFF
--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -14,7 +14,8 @@ import { BenchmarkPicker } from "@/components/benchmark-picker";
 import { ComparisonTable } from "@/components/comparison-table";
 import { ModeToggle } from "@/components/mode-toggle";
 import { useMatchQuery, useCompareQuery, useCoachingAvailability } from "@/lib/queries";
-import { detectMode } from "@/lib/mode";
+import { detectMatchView, isPreMatchEligible } from "@/lib/mode";
+import type { CompareMode } from "@/lib/types";
 import { CacheInfoBadge } from "@/components/cache-info-badge";
 import { LoadingBar } from "@/components/loading-bar";
 import { Button } from "@/components/ui/button";
@@ -195,17 +196,53 @@ export default function MatchPageClient() {
   // Capture mount timestamp once to avoid impure Date.now() in render path.
   const [mountMs] = useState(() => Date.now());
 
-  // Compute auto mode from match data (defaults to "coaching" until loaded).
+  // Compute auto view from match data (defaults to "coaching" until loaded).
   const matchDateMs = matchQuery.data?.date ? new Date(matchQuery.data.date).getTime() : null;
-  const autoMode = matchQuery.data
-    ? detectMode(
-        matchQuery.data.scoring_completed,
-        matchDateMs != null ? (mountMs - matchDateMs) / 86_400_000 : 0,
-      )
-    : "coaching";
+  const matchEndsMs = matchQuery.data?.ends ? new Date(matchQuery.data.ends).getTime() : null;
+  const daysSinceMatchStart =
+    matchDateMs != null ? (mountMs - matchDateMs) / 86_400_000 : 0;
+  const daysSinceMatchEnd =
+    matchEndsMs != null ? (mountMs - matchEndsMs) / 86_400_000 : null;
+
+  // Auto view is computed from match-only data first, then refined once the
+  // compare response confirms whether any stage already has scores.
+  // (This enables falling back to "live" if `scoring_completed` is still 0
+  // but the API has scores — handles rounding / delayed reporting.)
+  const autoMode = useMemo(() => {
+    if (!matchQuery.data) return "coaching" as const;
+    return detectMatchView({
+      scoringPct: matchQuery.data.scoring_completed,
+      daysSinceMatchStart,
+      daysSinceMatchEnd,
+      resultsStatus: matchQuery.data.results_status,
+      matchStatus: matchQuery.data.match_status,
+      hasActualScores: false,
+    });
+  }, [matchQuery.data, daysSinceMatchStart, daysSinceMatchEnd]);
+
   const effectiveMode = modeOverride ?? autoMode;
 
-  const compareQuery = useCompareQuery(ct, id, selectedIds, effectiveMode);
+  // Pre-match selectability — offered as a manual choice while the match
+  // isn't fully wrapped up.
+  const preMatchEligible = matchQuery.data
+    ? isPreMatchEligible({
+        scoringPct: matchQuery.data.scoring_completed,
+        daysSinceMatchStart,
+        daysSinceMatchEnd,
+        resultsStatus: matchQuery.data.results_status,
+      })
+    : false;
+
+  // Compare query: skipped when in the pre-match view (no scores to fetch).
+  // The mode passed to the API is always "live" or "coaching".
+  const compareMode: CompareMode = effectiveMode === "coaching" ? "coaching" : "live";
+  const compareEnabled = effectiveMode !== "prematch";
+  const compareQuery = useCompareQuery(
+    ct,
+    id,
+    compareEnabled ? selectedIds : EMPTY_IDS,
+    compareMode,
+  );
   const coachingAvailability = useCoachingAvailability();
 
   // ── Stage sort (shared by table + charts) ─────────────────────────────────
@@ -401,18 +438,10 @@ export default function MatchPageClient() {
   const resultsPublished = match.results_status === "all";
   const matchCancelled = match.match_status === "cs";
   const aiAvailable = coachingAvailability.data?.available === true;
-  // Pre-match: no scores yet and match not completed or cancelled.
-  // Also check compare data: if any stage has competitor scores, scoring has
-  // started regardless of what scoring_completed reports (handles rounding
-  // edge cases and delayed API updates for large matches).
-  const hasActualScores = compareQuery.data?.stages.some(
-    (s) => Object.keys(s.competitors).length > 0,
-  ) ?? false;
-  const isPreMatch =
-    match.scoring_completed === 0 &&
-    !hasActualScores &&
-    match.match_status !== "cp" &&
-    match.match_status !== "cs";
+  // The active view drives what's rendered. Auto-detection chooses pre-match
+  // when scoring hasn't really started; the user can override via ModeToggle
+  // (e.g. early squads have finished but their afternoon/day-2 squad hasn't).
+  const isPreMatch = effectiveMode === "prematch";
 
   // Pick the older (more stale) cachedAt between match and compare responses.
   // null means "just fetched live" — prefer non-null if one is cached.
@@ -483,42 +512,48 @@ export default function MatchPageClient() {
         </div>
       )}
 
-      {/* Mode toggle — hidden pre-match (no scores to analyse yet) */}
-      {!isPreMatch && <div className="space-y-1">
+      {/* View toggle — pre-match / live / coaching. Pre-match stays available
+          while the match is in progress so users in late squads can still see
+          squad rotation, weather, and field info. */}
+      <div className="space-y-1">
         <div className="flex items-center gap-1.5">
           <ModeToggle
             autoMode={autoMode}
             effectiveMode={effectiveMode}
+            preMatchEligible={preMatchEligible}
             onModeChange={(mode) => saveModeOverride(ct, id, mode)}
           />
           <Popover>
             <PopoverTrigger asChild>
               <button
                 className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
-                aria-label="About live and coaching modes"
+                aria-label="About pre-match, live, and coaching views"
               >
                 <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
               </button>
             </PopoverTrigger>
             <PopoverContent className="w-80" side="bottom" align="start">
               <PopoverHeader>
-                <PopoverTitle>Live vs Coaching mode</PopoverTitle>
-                <PopoverDescription>The app picks a mode based on match state. You can override it.</PopoverDescription>
+                <PopoverTitle>Pre-match, Live, and Coaching</PopoverTitle>
+                <PopoverDescription>The app picks a view based on match state. You can override it.</PopoverDescription>
               </PopoverHeader>
               <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
+                <p><strong>Pre-match</strong> — squad rotation, weather, registered field, and AI brief. Useful when your squad hasn&apos;t shot yet, even if early squads have finished.</p>
                 <p><strong>Live</strong> — for active matches. Refreshes every 30 seconds. Shows stage results, charts, and core stats only. Skips heavy analytics to keep things fast courtside.</p>
                 <p><strong>Coaching</strong> — for completed matches. Full analysis: style fingerprints, archetype breakdown, course-length splits, constraint performance, and the stage simulator.</p>
-                <p>The mode is auto-detected: matches with ≥ 95% scored or older than 3 days default to Coaching. Tap the other mode to override, or tap the active mode to reset to auto.</p>
+                <p>The view is auto-detected: pre-match before scoring really gets going, live once scoring is underway, and coaching for ≥ 95% scored or matches older than 3 days. Tap any mode to override, or tap the active mode to reset to auto.</p>
               </div>
             </PopoverContent>
           </Popover>
         </div>
         <p className="text-xs text-muted-foreground">
-          {effectiveMode === "live"
+          {effectiveMode === "prematch"
+            ? "Squad rotation, weather, and registered field. No scores shown."
+            : effectiveMode === "live"
             ? "Fast refresh, stage-focused view. Coaching analytics hidden."
             : "Full analysis with style fingerprints, breakdowns, and simulator."}
         </p>
-      </div>}
+      </div>
 
       {/* Competitor picker */}
       <div className="space-y-1">

--- a/components/mode-toggle.tsx
+++ b/components/mode-toggle.tsx
@@ -1,27 +1,41 @@
 "use client";
 
-import { useCallback, useRef } from "react";
-import type { CompareMode } from "@/lib/types";
+import { useCallback, useMemo, useRef } from "react";
+import type { MatchView } from "@/lib/types";
 
 interface ModeToggleProps {
-  /** The mode the system would choose automatically. */
-  autoMode: CompareMode;
-  /** The mode currently in effect (override ?? autoMode). */
-  effectiveMode: CompareMode;
-  /** Called with a mode to set an override, or null to clear the override. */
-  onModeChange: (mode: CompareMode | null) => void;
+  /** The view the system would choose automatically. */
+  autoMode: MatchView;
+  /** The view currently in effect (override ?? auto). */
+  effectiveMode: MatchView;
+  /** Whether the pre-match option is offered (hidden once the match is wrapped up). */
+  preMatchEligible: boolean;
+  /** Called with a view to set an override, or null to clear the override. */
+  onModeChange: (mode: MatchView | null) => void;
 }
 
-const OPTIONS: { value: CompareMode; label: string }[] = [
+const ALL_OPTIONS: { value: MatchView; label: string }[] = [
+  { value: "prematch", label: "Pre-match" },
   { value: "live", label: "Live" },
   { value: "coaching", label: "Coaching" },
 ];
 
-export function ModeToggle({ autoMode, effectiveMode, onModeChange }: ModeToggleProps) {
+export function ModeToggle({ autoMode, effectiveMode, preMatchEligible, onModeChange }: ModeToggleProps) {
   const groupRef = useRef<HTMLDivElement>(null);
 
+  // Always include the pre-match option if it's eligible OR currently active
+  // (so users mid-override can still see/clear it). Otherwise hide it.
+  const options = useMemo(
+    () =>
+      ALL_OPTIONS.filter(
+        (o) =>
+          o.value !== "prematch" || preMatchEligible || effectiveMode === "prematch",
+      ),
+    [preMatchEligible, effectiveMode],
+  );
+
   const handleClick = useCallback(
-    (value: CompareMode) => {
+    (value: MatchView) => {
       if (value === effectiveMode && value === autoMode) {
         // Already on auto — no-op
         return;
@@ -39,22 +53,22 @@ export function ModeToggle({ autoMode, effectiveMode, onModeChange }: ModeToggle
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLButtonElement>) => {
       let nextIdx = -1;
-      const currentIdx = OPTIONS.findIndex((o) => o.value === (e.currentTarget.dataset.value as CompareMode));
+      const currentIdx = options.findIndex((o) => o.value === (e.currentTarget.dataset.value as MatchView));
       if (e.key === "ArrowRight" || e.key === "ArrowDown") {
         e.preventDefault();
-        nextIdx = (currentIdx + 1) % OPTIONS.length;
+        nextIdx = (currentIdx + 1) % options.length;
       } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
         e.preventDefault();
-        nextIdx = (currentIdx - 1 + OPTIONS.length) % OPTIONS.length;
+        nextIdx = (currentIdx - 1 + options.length) % options.length;
       }
       if (nextIdx >= 0) {
-        const next = OPTIONS[nextIdx];
+        const next = options[nextIdx];
         handleClick(next.value);
         const buttons = groupRef.current?.querySelectorAll<HTMLButtonElement>("[role=radio]");
         buttons?.[nextIdx]?.focus();
       }
     },
-    [handleClick],
+    [handleClick, options],
   );
 
   // Whether the user has an active override (effectiveMode !== autoMode)
@@ -64,12 +78,14 @@ export function ModeToggle({ autoMode, effectiveMode, onModeChange }: ModeToggle
     <div
       ref={groupRef}
       role="radiogroup"
-      aria-label="Compare mode"
+      aria-label="Match view"
       className="inline-flex rounded-lg border border-border bg-muted/50 p-0.5"
     >
-      {OPTIONS.map((opt, i) => {
+      {options.map((opt, i) => {
         const isActive = opt.value === effectiveMode;
         const showAuto = opt.value === autoMode && !hasOverride;
+        const isFirst = i === 0;
+        const isLast = i === options.length - 1;
         return (
           <button
             key={opt.value}
@@ -81,13 +97,15 @@ export function ModeToggle({ autoMode, effectiveMode, onModeChange }: ModeToggle
             onClick={() => handleClick(opt.value)}
             onKeyDown={handleKeyDown}
             className={[
-              "relative rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+              "relative px-3 py-1.5 text-sm font-medium transition-colors",
               "min-h-[2.75rem] min-w-[5.5rem]",
               "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
               isActive
                 ? "bg-primary text-primary-foreground shadow-sm"
                 : "bg-transparent text-muted-foreground hover:text-foreground",
-              i === 0 ? "rounded-r-md" : "rounded-l-md",
+              isFirst ? "rounded-l-md" : "",
+              isLast ? "rounded-r-md" : "",
+              !isFirst && !isLast ? "rounded-none" : "",
             ]
               .filter(Boolean)
               .join(" ")}

--- a/lib/competition-store.ts
+++ b/lib/competition-store.ts
@@ -1,4 +1,4 @@
-import type { CompareMode, MatchResponse } from "@/lib/types";
+import type { MatchResponse, MatchView } from "@/lib/types";
 
 export interface StoredCompetition {
   ct: string;
@@ -172,8 +172,8 @@ function modeKey(ct: string, id: string): string {
   return `ssi_mode_${ct}_${id}`;
 }
 
-/** Save a mode override for this match. Pass null to clear (revert to auto). */
-export function saveModeOverride(ct: string, id: string, mode: CompareMode | null): void {
+/** Save a view override for this match. Pass null to clear (revert to auto). */
+export function saveModeOverride(ct: string, id: string, mode: MatchView | null): void {
   if (typeof window === "undefined") return;
   try {
     const key = modeKey(ct, id);
@@ -188,16 +188,17 @@ export function saveModeOverride(ct: string, id: string, mode: CompareMode | nul
   }
 }
 
-/** Stable-reference snapshot cache for mode override. */
-const _modeCache = new Map<string, { raw: string | null; mode: CompareMode | null }>();
+/** Stable-reference snapshot cache for view override. */
+const _modeCache = new Map<string, { raw: string | null; mode: MatchView | null }>();
 
-export function getModeOverrideSnapshot(ct: string, id: string): CompareMode | null {
+export function getModeOverrideSnapshot(ct: string, id: string): MatchView | null {
   if (typeof window === "undefined") return null;
   const key = modeKey(ct, id);
   const raw = localStorage.getItem(key);
   const cached = _modeCache.get(key);
   if (cached && cached.raw === raw) return cached.mode;
-  const mode = raw === "live" || raw === "coaching" ? raw : null;
+  const mode =
+    raw === "live" || raw === "coaching" || raw === "prematch" ? raw : null;
   _modeCache.set(key, { raw, mode });
   return mode;
 }

--- a/lib/mode.ts
+++ b/lib/mode.ts
@@ -1,11 +1,66 @@
-import type { CompareMode } from "./types";
+import type { MatchView } from "./types";
+
+export interface DetectMatchViewArgs {
+  /** Percentage of the match scored, 0-100. */
+  scoringPct: number;
+  /** Days since match.date — 0 = today, positive = past, negative = future. */
+  daysSinceMatchStart: number;
+  /** Days since match.ends — null if no end date set (caller should fall back to start). */
+  daysSinceMatchEnd: number | null;
+  /** SSI results visibility: "org" | "stg" | "cmp" | "all". */
+  resultsStatus: string;
+  /** SSI match lifecycle: "dr" | "on" | "ol" | "pr" | "cp" | "cs". */
+  matchStatus: string;
+  /** Whether any stage already has competitor scores in the compare response. */
+  hasActualScores: boolean;
+}
 
 /**
- * Determine the default compare mode based on match state.
- * "coaching" for completed matches (≥ 95% scored or > 3 days old).
- * "live" for active matches where fast polling matters.
+ * Determine the default match view based on match state.
+ *
+ * Tiers (first match wins):
+ *   - "coaching" — match is definitively done: results published, completed,
+ *     ≥ 95% scored, or > 3 days since end.
+ *   - "prematch" — no scoring yet, OR very early in the match (< 25% with the
+ *     end date still ahead). Captures the day-before RO-squad case and the
+ *     "early squads finished but my squad hasn't shot yet" case.
+ *   - "live"     — active match with meaningful scoring progress.
  */
-export function detectMode(scoringPct: number, daysSinceMatch: number): CompareMode {
-  if (scoringPct >= 95 || daysSinceMatch > 3) return "coaching";
+export function detectMatchView(args: DetectMatchViewArgs): MatchView {
+  const daysSinceEnd = args.daysSinceMatchEnd ?? args.daysSinceMatchStart;
+
+  // Definitively done — always coaching.
+  if (args.resultsStatus === "all") return "coaching";
+  if (args.matchStatus === "cp") return "coaching";
+  if (args.scoringPct >= 95) return "coaching";
+  if (daysSinceEnd > 3) return "coaching";
+
+  // Cancelled but not closed — show whatever partial scores there are.
+  if (args.matchStatus === "cs") return "live";
+
+  // No scoring at all — pre-match.
+  if (args.scoringPct === 0 && !args.hasActualScores) return "prematch";
+
+  // Early-stage match: < 25% scoring AND match end date is still in the future
+  // (or today). Covers RO squads shooting the day before the main field.
+  if (args.scoringPct < 25 && daysSinceEnd < 1) return "prematch";
+
   return "live";
+}
+
+/**
+ * Whether the pre-match view is offered as a manual choice in the toggle.
+ * Hidden once the match is wrapped up, since pre-match info is no longer useful.
+ */
+export function isPreMatchEligible(args: {
+  scoringPct: number;
+  daysSinceMatchStart: number;
+  daysSinceMatchEnd: number | null;
+  resultsStatus: string;
+}): boolean {
+  if (args.resultsStatus === "all") return false;
+  if (args.scoringPct >= 95) return false;
+  const daysSinceEnd = args.daysSinceMatchEnd ?? args.daysSinceMatchStart;
+  if (daysSinceEnd > 2) return false;
+  return true;
 }

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -11,11 +11,31 @@ import type { Release } from "@/lib/types";
  * differs from the value stored in localStorage("whats-new-seen-id").
  */
 /** The `id` of the newest release. Used by e2e tests to suppress the What's New dialog. */
-export const LATEST_RELEASE_ID = "2026-03-17";
+export const LATEST_RELEASE_ID = "2026-04-26";
 
 export const RELEASES: Release[] = [
   {
     id: LATEST_RELEASE_ID,
+    date: "April 26, 2026",
+    title: "Pick Your View",
+    screenshotScenes: ["comparison-table"],
+    sections: [
+      {
+        heading: "New",
+        items: [
+          "Pre-match view is now selectable next to Live and Coaching, even after the match has started. Useful when early squads have finished but yours hasn't shot yet — afternoon squads, day-2 squads, or competitors when RO squads shot the day before.",
+        ],
+      },
+      {
+        heading: "Improved",
+        items: [
+          "Smarter auto-view: pre-match stays the default until scoring is meaningfully underway, and now considers the match end date so multi-day matches don't flip to live too early. Coaching kicks in once results are published, scoring hits 95%, or three days have passed since the match ended.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "2026-03-17",
     date: "March 17, 2026",
     title: "Upcoming Match Actions",
     screenshotScenes: ["shooter-dashboard"],

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -248,6 +248,14 @@ export type PctMode = "group" | "division" | "overall";
 // "coaching" — post-match; full fingerprint, archetype, what-if, etc.
 export type CompareMode = "live" | "coaching";
 
+// View selection for the match page.
+// "prematch" — squad rotation, weather, registered field (no scores yet, or user's squad
+//              hasn't shot yet — useful when early squads have finished but the user is
+//              in an afternoon/second-day squad).
+// "live"     — fast-refresh comparison + charts; no heavy coaching analytics.
+// "coaching" — full post-match analysis (style fingerprint, simulator, etc.).
+export type MatchView = "prematch" | "live" | "coaching";
+
 // View mode for the comparison table.
 // "absolute" — shows raw hit factor, points, and percentage
 // "delta"    — shows gap to the group leader per stage (±X.X pts)

--- a/tests/unit/mode.test.ts
+++ b/tests/unit/mode.test.ts
@@ -1,36 +1,150 @@
 import { describe, it, expect } from "vitest";
-import { detectMode } from "@/lib/mode";
+import { detectMatchView, isPreMatchEligible } from "@/lib/mode";
 
-describe("detectMode", () => {
-  it("returns 'live' for active match (0% scored, day 0)", () => {
-    expect(detectMode(0, 0)).toBe("live");
+const baseArgs = {
+  scoringPct: 0,
+  daysSinceMatchStart: 0,
+  daysSinceMatchEnd: null,
+  resultsStatus: "stg",
+  matchStatus: "on",
+  hasActualScores: false,
+};
+
+describe("detectMatchView", () => {
+  // ── Coaching ──────────────────────────────────────────────────────────────
+  it("returns 'coaching' when results_status === 'all'", () => {
+    expect(detectMatchView({ ...baseArgs, resultsStatus: "all" })).toBe("coaching");
   });
 
-  it("returns 'live' for active match (50% scored, day 1)", () => {
-    expect(detectMode(50, 1)).toBe("live");
-  });
-
-  it("returns 'live' just below threshold (94% scored, day 3)", () => {
-    expect(detectMode(94, 3)).toBe("live");
+  it("returns 'coaching' when match_status === 'cp' (completed)", () => {
+    expect(detectMatchView({ ...baseArgs, matchStatus: "cp", scoringPct: 50 })).toBe("coaching");
   });
 
   it("returns 'coaching' at 95% scored", () => {
-    expect(detectMode(95, 0)).toBe("coaching");
+    expect(detectMatchView({ ...baseArgs, scoringPct: 95 })).toBe("coaching");
   });
 
   it("returns 'coaching' at 100% scored", () => {
-    expect(detectMode(100, 0)).toBe("coaching");
+    expect(detectMatchView({ ...baseArgs, scoringPct: 100 })).toBe("coaching");
   });
 
-  it("returns 'coaching' when > 3 days old even if 0% scored", () => {
-    expect(detectMode(0, 4)).toBe("coaching");
+  it("returns 'coaching' when match ended > 3 days ago", () => {
+    expect(
+      detectMatchView({ ...baseArgs, scoringPct: 0, daysSinceMatchEnd: 4 }),
+    ).toBe("coaching");
   });
 
-  it("returns 'live' at exactly 3 days", () => {
-    expect(detectMode(0, 3)).toBe("live");
+  it("falls back to start date when end date is null and start is > 3 days ago", () => {
+    expect(
+      detectMatchView({ ...baseArgs, scoringPct: 0, daysSinceMatchStart: 4 }),
+    ).toBe("coaching");
   });
 
-  it("returns 'coaching' at 3.01 days", () => {
-    expect(detectMode(0, 3.01)).toBe("coaching");
+  // ── Cancelled ─────────────────────────────────────────────────────────────
+  it("returns 'live' when match cancelled (so partial scores remain visible)", () => {
+    expect(
+      detectMatchView({ ...baseArgs, matchStatus: "cs", scoringPct: 30 }),
+    ).toBe("live");
+  });
+
+  // ── Pre-match ─────────────────────────────────────────────────────────────
+  it("returns 'prematch' when no scores at all and match active", () => {
+    expect(detectMatchView({ ...baseArgs, scoringPct: 0, hasActualScores: false })).toBe("prematch");
+  });
+
+  it("returns 'prematch' for upcoming match (start in future)", () => {
+    expect(
+      detectMatchView({ ...baseArgs, scoringPct: 0, daysSinceMatchStart: -2, daysSinceMatchEnd: -2 }),
+    ).toBe("prematch");
+  });
+
+  it("returns 'prematch' early in match (< 25% scored, end still ahead) — RO-squad case", () => {
+    expect(
+      detectMatchView({
+        ...baseArgs,
+        scoringPct: 15,
+        daysSinceMatchStart: 0,
+        daysSinceMatchEnd: -1, // multi-day match, ends tomorrow
+      }),
+    ).toBe("prematch");
+  });
+
+  it("falls through to 'live' once scoring crosses 25%", () => {
+    expect(
+      detectMatchView({
+        ...baseArgs,
+        scoringPct: 30,
+        daysSinceMatchStart: 0,
+        daysSinceMatchEnd: 0,
+      }),
+    ).toBe("live");
+  });
+
+  // ── Live ──────────────────────────────────────────────────────────────────
+  it("returns 'live' for active match (50% scored, day 1)", () => {
+    expect(
+      detectMatchView({ ...baseArgs, scoringPct: 50, daysSinceMatchStart: 1, daysSinceMatchEnd: 1 }),
+    ).toBe("live");
+  });
+
+  it("returns 'live' just below threshold (94% scored, day 3)", () => {
+    expect(
+      detectMatchView({ ...baseArgs, scoringPct: 94, daysSinceMatchStart: 3, daysSinceMatchEnd: 3 }),
+    ).toBe("live");
+  });
+
+  it("returns 'live' once compare data shows scores even if scoring_completed reports 0", () => {
+    expect(
+      detectMatchView({ ...baseArgs, scoringPct: 0, hasActualScores: true, daysSinceMatchEnd: 1 }),
+    ).toBe("live");
+  });
+
+  it("returns 'coaching' at 3.01 days since end", () => {
+    expect(
+      detectMatchView({ ...baseArgs, scoringPct: 0, daysSinceMatchEnd: 3.01 }),
+    ).toBe("coaching");
+  });
+});
+
+describe("isPreMatchEligible", () => {
+  const baseEligible = {
+    scoringPct: 0,
+    daysSinceMatchStart: 0,
+    daysSinceMatchEnd: null,
+    resultsStatus: "stg",
+  };
+
+  it("offered while match is in progress", () => {
+    expect(isPreMatchEligible(baseEligible)).toBe(true);
+  });
+
+  it("offered for upcoming match", () => {
+    expect(
+      isPreMatchEligible({ ...baseEligible, daysSinceMatchStart: -3 }),
+    ).toBe(true);
+  });
+
+  it("offered with partial scoring, end date still close", () => {
+    expect(
+      isPreMatchEligible({ ...baseEligible, scoringPct: 30, daysSinceMatchEnd: 1 }),
+    ).toBe(true);
+  });
+
+  it("hidden once results are officially published", () => {
+    expect(
+      isPreMatchEligible({ ...baseEligible, resultsStatus: "all" }),
+    ).toBe(false);
+  });
+
+  it("hidden once scoring reaches 95%", () => {
+    expect(
+      isPreMatchEligible({ ...baseEligible, scoringPct: 95 }),
+    ).toBe(false);
+  });
+
+  it("hidden when match ended > 2 days ago", () => {
+    expect(
+      isPreMatchEligible({ ...baseEligible, daysSinceMatchEnd: 3 }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
The pre-match view (squad rotation, weather, registered field, AI brief)
was previously force-hidden as soon as any scoring appeared. This broke
the common case where early squads have finished but the user's squad
hasn't shot yet — afternoon squads, day-2 squads, or main-field
competitors when RO squads shot the day before.

Pre-match is now a third option in the view toggle alongside Live and
Coaching, available while the match isn't fully wrapped up. The auto
heuristic also takes the match end date into account so multi-day
matches don't flip to Live too eagerly, and it stays in pre-match while
scoring is < 25% with the end date still ahead.