### PR TITLE
Add SSI-style stage-by-stage scorecard view with localStorage persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,7 +367,7 @@ handles new achievements and tiers automatically.
 |---|---|---|---|
 | `SSI_API_KEY` | `lib/graphql.ts` (server-only) | Both | Never use `NEXT_PUBLIC_` prefix |
 | `CACHE_PURGE_SECRET` | `app/api/admin/cache/purge/route.ts`, `app/api/admin/cache/health/route.ts` | Both | Any strong random string; never `NEXT_PUBLIC_` |
-| `MIN_CACHE_TTL_SECONDS` | `lib/match-ttl.ts` (server-only) | Both | Minimum TTL floor for all non-permanent cache entries. Default `300` (5 min). Set to `0` to disable. Never `NEXT_PUBLIC_`. |
+| `MIN_CACHE_TTL_SECONDS` | `lib/match-ttl.ts` (server-only) | Both | Minimum TTL floor for all non-permanent cache entries. Default `30` (s) — keeps active matches near-real-time so courtside polling picks up fresh scorecards within seconds. Raise it to reduce upstream load on shared deployments. Set to `0` to disable. Never `NEXT_PUBLIC_`. |
 | `NEXT_PUBLIC_BUILD_ID` | `components/update-banner.tsx`, `app/api/version/route.ts` | Both | Git SHA baked into the client bundle at Docker build time; powers new-version detection. Auto-injected by `pnpm docker:build`. Unset in `pnpm dev` — version check is skipped. |
 | `REDIS_URL` | `lib/cache-node.ts` | Docker only | `redis://localhost:6379` locally, `rediss://...` for managed Redis. Not needed for CF builds. |
 | `APP_DB_PATH` | `lib/db-sqlite.ts` | Docker only | Path to SQLite database file. Defaults to `./data/shooter-index.db`. Not needed for CF builds. |

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -478,6 +478,20 @@ function ModeToggle({
   );
 }
 
+/**
+ * localStorage key used to remember the user's last comparison-table view
+ * mode. Persisting across reloads matters most courtside on an ongoing
+ * match — the user shouldn't have to re-pick "Stages" every time the page
+ * is refreshed mid-day. The value is intentionally global (not per-match)
+ * because in practice users have a preferred view, not a preference per
+ * specific competition.
+ */
+const VIEW_MODE_STORAGE_KEY = "ssi-comparison-view-mode";
+
+function isViewMode(value: unknown): value is ViewMode {
+  return value === "absolute" || value === "delta" || value === "stages";
+}
+
 const VIEW_MODE_LABELS: Record<ViewMode, string> = {
   absolute: "Absolute",
   delta: "Delta",
@@ -891,7 +905,17 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
   const [mode, setMode] = useState<PctMode>(
     competitors.length < 2 ? "division" : "group"
   );
-  const [viewMode, setViewMode] = useState<ViewMode>("absolute");
+  const [viewMode, setViewModeState] = useState<ViewMode>("absolute");
+  const setViewMode = (m: ViewMode) => {
+    setViewModeState(m);
+    if (typeof window !== "undefined") {
+      try {
+        window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, m);
+      } catch {
+        // localStorage may be unavailable (private mode, quota) — ignore
+      }
+    }
+  };
   const [showConditions, setShowConditions] = useState(false);
   const [showAnalysis, setShowAnalysis] = useState(false);
   const [showWhatIf, setShowWhatIf] = useState(false);
@@ -910,6 +934,17 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
     if (!localStorage.getItem("ssi-cell-help-seen")) {
       localStorage.setItem("ssi-cell-help-seen", "1");
       startTransition(() => setHelpOpen(true));
+    }
+  }, []);
+
+  // Restore the user's last-picked view mode (Absolute / Delta / Stages).
+  // Runs once on mount; client-only so SSR isn't affected.
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+      if (isViewMode(stored)) setViewModeState(stored);
+    } catch {
+      // localStorage may be unavailable (private mode, quota) — ignore
     }
   }, []);
 

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -522,27 +522,22 @@ function ViewModeToggle({
       className="w-auto inline-flex rounded-md border text-xs"
     >
       {order.map((m, i, arr) => (
-        <Tooltip key={m}>
-          <TooltipTrigger asChild>
-            <ToggleGroupItem
-              value={m}
-              className={cn(
-                "h-auto min-w-0 gap-0 rounded-none px-2.5 py-1 font-normal text-xs transition-colors",
-                i === 0 ? "rounded-l-md" : "",
-                i === arr.length - 1 ? "rounded-r-md" : "",
-                "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
-                viewMode === m
-                  ? "bg-foreground text-background font-medium"
-                  : "text-muted-foreground hover:bg-muted"
-              )}
-            >
-              {VIEW_MODE_LABELS[m]}
-            </ToggleGroupItem>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" className="max-w-60 text-center text-xs">
-            {VIEW_MODE_TOOLTIPS[m]}
-          </TooltipContent>
-        </Tooltip>
+        <ToggleGroupItem
+          key={m}
+          value={m}
+          title={VIEW_MODE_TOOLTIPS[m]}
+          className={cn(
+            "h-auto min-w-0 gap-0 rounded-none px-2.5 py-1 font-normal text-xs transition-colors",
+            i === 0 ? "rounded-l-md" : "",
+            i === arr.length - 1 ? "rounded-r-md" : "",
+            "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+            viewMode === m
+              ? "bg-foreground text-background font-medium"
+              : "text-muted-foreground hover:bg-muted"
+          )}
+        >
+          {VIEW_MODE_LABELS[m]}
+        </ToggleGroupItem>
       ))}
     </ToggleGroup>
   );
@@ -1077,7 +1072,10 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
       ))}
 
       {/* View mode toggle (Absolute / Delta) + percentage context + help */}
-      <div className="flex items-center gap-2">
+      {/* Toolbar wraps on narrow screens — at 390px the three view-mode
+          toggles + percentage-context toggle + help icon don't fit on one
+          row without overflowing the window. */}
+      <div className="flex flex-wrap items-center gap-2">
         <ViewModeToggle viewMode={viewMode} onChange={setViewMode} />
         {viewMode === "absolute" && (
           <ModeToggle mode={mode} onChange={setMode} competitorCount={competitors.length} />

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -478,6 +478,19 @@ function ModeToggle({
   );
 }
 
+const VIEW_MODE_LABELS: Record<ViewMode, string> = {
+  absolute: "Absolute",
+  delta: "Delta",
+  stages: "Stages",
+};
+
+const VIEW_MODE_TOOLTIPS: Record<ViewMode, string> = {
+  absolute: "Hit factor, points, and HF % per stage (default)",
+  delta: "Gap to the group leader per stage (±X.X pts heatmap)",
+  stages:
+    "One scorecard table per stage — rows are the selected competitors, columns are time, HF, A, C, D, NS, M, P (SSI-style)",
+};
+
 function ViewModeToggle({
   viewMode,
   onChange,
@@ -485,6 +498,7 @@ function ViewModeToggle({
   viewMode: ViewMode;
   onChange: (m: ViewMode) => void;
 }) {
+  const order: ViewMode[] = ["absolute", "delta", "stages"];
   return (
     <ToggleGroup
       type="single"
@@ -493,22 +507,28 @@ function ViewModeToggle({
       aria-label="Table view mode"
       className="w-auto inline-flex rounded-md border text-xs"
     >
-      {(["absolute", "delta"] as ViewMode[]).map((m, i, arr) => (
-        <ToggleGroupItem
-          key={m}
-          value={m}
-          className={cn(
-            "h-auto min-w-0 gap-0 rounded-none px-2.5 py-1 font-normal text-xs transition-colors capitalize",
-            i === 0 ? "rounded-l-md" : "",
-            i === arr.length - 1 ? "rounded-r-md" : "",
-            "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
-            viewMode === m
-              ? "bg-foreground text-background font-medium"
-              : "text-muted-foreground hover:bg-muted"
-          )}
-        >
-          {m === "absolute" ? "Absolute" : "Delta"}
-        </ToggleGroupItem>
+      {order.map((m, i, arr) => (
+        <Tooltip key={m}>
+          <TooltipTrigger asChild>
+            <ToggleGroupItem
+              value={m}
+              className={cn(
+                "h-auto min-w-0 gap-0 rounded-none px-2.5 py-1 font-normal text-xs transition-colors",
+                i === 0 ? "rounded-l-md" : "",
+                i === arr.length - 1 ? "rounded-r-md" : "",
+                "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+                viewMode === m
+                  ? "bg-foreground text-background font-medium"
+                  : "text-muted-foreground hover:bg-muted"
+              )}
+            >
+              {VIEW_MODE_LABELS[m]}
+            </ToggleGroupItem>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="max-w-60 text-center text-xs">
+            {VIEW_MODE_TOOLTIPS[m]}
+          </TooltipContent>
+        </Tooltip>
       ))}
     </ToggleGroup>
   );
@@ -577,6 +597,288 @@ function ArchetypePill({ archetype, color }: { archetype: ShooterArchetype; colo
         }[archetype]}
       </TooltipContent>
     </Tooltip>
+  );
+}
+
+/**
+ * SSI-style stage-by-stage view: one mini-table per stage, with the selected
+ * competitors as rows and the base scoring fields as columns
+ * (Time, HF, Pts, A, C, D, NS, M, P). Sorted by hit factor descending.
+ *
+ * Optimised for live comparison during an active match — values are raw
+ * scorecard data, no derived analytics. DQ / DNF / zeroed runs sink to the
+ * bottom and render their status in place of the numeric columns.
+ */
+function StageByStageView({
+  stages,
+  competitors,
+  colorMap,
+  ct,
+  matchId,
+}: {
+  stages: StageComparison[];
+  competitors: CompetitorInfo[];
+  colorMap: Record<number, string>;
+  ct?: string;
+  matchId?: string;
+}) {
+  return (
+    <div className="space-y-4">
+      {stages.map((stage) => (
+        <StageScorecardTable
+          key={stage.stage_id}
+          stage={stage}
+          competitors={competitors}
+          colorMap={colorMap}
+          ct={ct}
+          matchId={matchId}
+        />
+      ))}
+    </div>
+  );
+}
+
+function StageScorecardTable({
+  stage,
+  competitors,
+  colorMap,
+  ct,
+  matchId,
+}: {
+  stage: StageComparison;
+  competitors: CompetitorInfo[];
+  colorMap: Record<number, string>;
+  ct?: string;
+  matchId?: string;
+}) {
+  // Sort: fired runs by hit factor desc; non-fired (DQ/DNF/zeroed/missing) at the bottom.
+  const sorted = [...competitors].sort((a, b) => {
+    const sa = stage.competitors[a.id];
+    const sb = stage.competitors[b.id];
+    const aFired = sa && !sa.dq && !sa.dnf && !sa.zeroed && sa.hit_factor != null;
+    const bFired = sb && !sb.dq && !sb.dnf && !sb.zeroed && sb.hit_factor != null;
+    if (aFired && !bFired) return -1;
+    if (!aFired && bFired) return 1;
+    if (aFired && bFired) return (sb!.hit_factor ?? 0) - (sa!.hit_factor ?? 0);
+    return 0;
+  });
+
+  const headingId = `stage-scorecard-${stage.stage_id}`;
+  const targetSummary = [
+    stage.min_rounds != null ? `${stage.min_rounds} rds` : null,
+    stage.paper_targets != null ? `${stage.paper_targets} paper` : null,
+    stage.steel_targets != null && stage.steel_targets > 0
+      ? `${stage.steel_targets} steel`
+      : null,
+  ].filter(Boolean).join(" · ");
+
+  return (
+    <section
+      role="region"
+      aria-labelledby={headingId}
+      className="rounded-lg border border-border bg-card overflow-hidden"
+    >
+      <header className="flex flex-wrap items-baseline gap-x-3 gap-y-1 px-3 py-2 border-b border-border bg-muted/40">
+        <h3 id={headingId} className="text-sm font-semibold inline-flex items-center gap-1.5">
+          {stage.ssi_url ? (
+            <a
+              href={stage.ssi_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-0.5 hover:underline"
+              aria-label={`Open ${stage.stage_name} on ShootNScoreIt (opens in new tab)`}
+            >
+              <span>Stage {stage.stage_num}</span>
+              <ExternalLink className="w-3 h-3 text-muted-foreground" aria-hidden="true" />
+            </a>
+          ) : (
+            <span>Stage {stage.stage_num}</span>
+          )}
+          <span className="font-normal text-muted-foreground truncate max-w-[12rem] sm:max-w-xs">
+            {stage.stage_name}
+          </span>
+        </h3>
+        {targetSummary && (
+          <span className="text-xs text-muted-foreground tabular-nums">{targetSummary}</span>
+        )}
+        <span className="text-xs text-muted-foreground tabular-nums ml-auto">
+          {`max ${stage.max_points} pts`}
+        </span>
+      </header>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm border-collapse">
+          <caption className="sr-only">{`Stage ${stage.stage_num} ${stage.stage_name} scorecards for the selected competitors`}</caption>
+          <thead>
+            <tr className="border-b border-border text-xs text-muted-foreground">
+              <th scope="col" className="text-left py-1.5 pl-3 pr-2 font-medium">
+                Competitor
+              </th>
+              <th scope="col" className="text-right py-1.5 px-2 font-medium tabular-nums">
+                Time
+              </th>
+              <th scope="col" className="text-right py-1.5 px-2 font-medium tabular-nums">
+                HF
+              </th>
+              <th scope="col" className="text-right py-1.5 px-2 font-medium tabular-nums">
+                Pts
+              </th>
+              <th scope="col" className="text-right py-1.5 px-1.5 font-medium tabular-nums" title="Alpha hits">
+                A
+              </th>
+              <th scope="col" className="text-right py-1.5 px-1.5 font-medium tabular-nums" title="Charlie hits">
+                C
+              </th>
+              <th scope="col" className="text-right py-1.5 px-1.5 font-medium tabular-nums" title="Delta hits">
+                D
+              </th>
+              <th scope="col" className="text-right py-1.5 px-1.5 font-medium tabular-nums" title="No-shoots">
+                NS
+              </th>
+              <th scope="col" className="text-right py-1.5 px-1.5 font-medium tabular-nums" title="Misses">
+                M
+              </th>
+              <th scope="col" className="text-right py-1.5 pl-1.5 pr-3 font-medium tabular-nums" title="Procedural penalties">
+                P
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((comp) => (
+              <StageScorecardRow
+                key={comp.id}
+                comp={comp}
+                sc={stage.competitors[comp.id]}
+                color={colorMap[comp.id]}
+                ct={ct}
+                matchId={matchId}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function StageScorecardRow({
+  comp,
+  sc,
+  color,
+  ct,
+  matchId,
+}: {
+  comp: CompetitorInfo;
+  sc: CompetitorSummary | undefined;
+  color: string;
+  ct?: string;
+  matchId?: string;
+}) {
+  const status = !sc
+    ? "Not shot"
+    : sc.dq
+      ? "DQ"
+      : sc.dnf
+        ? "DNF"
+        : sc.zeroed
+          ? "Zero"
+          : null;
+
+  const numCell = (value: number | null | undefined, formatted: string, highlight?: "penalty") =>
+    value != null && value > 0 ? (
+      <span
+        className={cn(
+          "tabular-nums",
+          highlight === "penalty" && "text-red-600 dark:text-red-400 font-medium",
+        )}
+      >
+        {formatted}
+      </span>
+    ) : value === 0 ? (
+      <span className="text-muted-foreground tabular-nums">{formatted}</span>
+    ) : (
+      <span className="text-muted-foreground" aria-label="no data">
+        —
+      </span>
+    );
+
+  const nameCell = (
+    <span className="inline-flex items-center gap-2 min-w-0">
+      <span
+        className="inline-block w-2 h-2 rounded-full shrink-0"
+        style={{ backgroundColor: color }}
+        aria-hidden="true"
+      />
+      <span className="flex flex-col min-w-0">
+        <span className="inline-flex items-center gap-1.5 min-w-0">
+          {comp.shooterId != null ? (
+            <Link
+              href={`/shooter/${comp.shooterId}${ct && matchId ? `?from=/match/${ct}/${matchId}` : ""}`}
+              className="truncate font-medium hover:underline"
+              aria-label={`View ${comp.name}'s stats`}
+            >
+              {comp.name}
+            </Link>
+          ) : (
+            <span className="truncate font-medium">{comp.name}</span>
+          )}
+          <span className="font-mono text-xs text-muted-foreground shrink-0">
+            #{comp.competitor_number}
+          </span>
+        </span>
+        {comp.division && (
+          <span className="text-xs text-muted-foreground uppercase tracking-wide truncate">
+            {comp.division}
+          </span>
+        )}
+      </span>
+    </span>
+  );
+
+  if (status) {
+    return (
+      <tr className="border-b border-border/40 last:border-0">
+        <td className="py-1.5 pl-3 pr-2 align-middle">{nameCell}</td>
+        <td colSpan={9} className="py-1.5 px-2 text-center text-xs text-muted-foreground">
+          <Badge variant="outline" className="font-medium">
+            {status}
+          </Badge>
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <tr className="border-b border-border/40 last:border-0 hover:bg-muted/30">
+      <td className="py-1.5 pl-3 pr-2 align-middle">{nameCell}</td>
+      <td className="py-1.5 px-2 text-right tabular-nums">
+        {sc?.time != null ? formatTime(sc.time) : <span className="text-muted-foreground">—</span>}
+      </td>
+      <td className="py-1.5 px-2 text-right tabular-nums font-semibold">
+        {sc?.hit_factor != null ? formatHF(sc.hit_factor) : <span className="text-muted-foreground font-normal">—</span>}
+      </td>
+      <td className="py-1.5 px-2 text-right tabular-nums">
+        {sc?.points != null ? sc.points.toFixed(0) : <span className="text-muted-foreground">—</span>}
+      </td>
+      <td className="py-1.5 px-1.5 text-right">
+        {numCell(sc?.a_hits, sc?.a_hits != null ? String(sc.a_hits) : "—")}
+      </td>
+      <td className="py-1.5 px-1.5 text-right">
+        {numCell(sc?.c_hits, sc?.c_hits != null ? String(sc.c_hits) : "—")}
+      </td>
+      <td className="py-1.5 px-1.5 text-right">
+        {numCell(sc?.d_hits, sc?.d_hits != null ? String(sc.d_hits) : "—")}
+      </td>
+      <td className="py-1.5 px-1.5 text-right">
+        {numCell(sc?.no_shoots, sc?.no_shoots != null ? String(sc.no_shoots) : "—", "penalty")}
+      </td>
+      <td className="py-1.5 px-1.5 text-right">
+        {numCell(sc?.miss_count, sc?.miss_count != null ? String(sc.miss_count) : "—", "penalty")}
+      </td>
+      <td className="py-1.5 pl-1.5 pr-3 text-right">
+        {numCell(sc?.procedurals, sc?.procedurals != null ? String(sc.procedurals) : "—", "penalty")}
+      </td>
+    </tr>
   );
 }
 
@@ -801,6 +1103,15 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
         </div>
       )}
 
+      {viewMode === "stages" ? (
+        <StageByStageView
+          stages={sortedStages}
+          competitors={competitors}
+          colorMap={colorMap}
+          ct={ct}
+          matchId={matchId}
+        />
+      ) : (
       <div className="overflow-x-auto">
         <table className="w-full text-sm border-collapse">
           <thead>
@@ -1321,6 +1632,7 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
           </tbody>
         </table>
       </div>
+      )}
 
       {/* Points on the table panel — collapsible, hidden by default */}
       {competitors.some((c) => {

--- a/lib/match-ttl.ts
+++ b/lib/match-ttl.ts
@@ -12,11 +12,13 @@
  *   fallback (unknown state)                  → 30 s
  *
  * All non-null results are clamped to at least MIN_CACHE_TTL_SECONDS
- * (default 300 s / 5 min; override via the MIN_CACHE_TTL_SECONDS env var).
+ * (default 30 s; override via the MIN_CACHE_TTL_SECONDS env var). The
+ * default lets active matches stay near-real-time courtside — fresh
+ * scorecards become visible within ~30 s of the upstream update.
  */
 
 const DEFAULT_MIN_TTL = parseInt(
-  process.env.MIN_CACHE_TTL_SECONDS ?? "300",
+  process.env.MIN_CACHE_TTL_SECONDS ?? "30",
   10,
 );
 

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -24,12 +24,14 @@ export const RELEASES: Release[] = [
         heading: "New",
         items: [
           "Pre-match view is now selectable next to Live and Coaching, even after the match has started. Useful when early squads have finished but yours hasn't shot yet — afternoon squads, day-2 squads, or competitors when RO squads shot the day before.",
+          "Stages view: a new SSI-style toggle on the comparison table renders one mini scorecard per stage, with selected competitors as rows and Time, HF, Pts, A, C, D, NS, M, P as columns — quick to read right after a stage is scored.",
         ],
       },
       {
         heading: "Improved",
         items: [
           "Smarter auto-view: pre-match stays the default until scoring is meaningfully underway, and now considers the match end date so multi-day matches don't flip to live too early. Coaching kicks in once results are published, scoring hits 95%, or three days have passed since the match ended.",
+          "Live freshness: cache TTL for active matches is now ~30 s (was 5 min), so fresh scorecards appear within seconds of the upstream update — no more waiting after a stage finishes.",
         ],
       },
     ],

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -259,7 +259,9 @@ export type MatchView = "prematch" | "live" | "coaching";
 // View mode for the comparison table.
 // "absolute" — shows raw hit factor, points, and percentage
 // "delta"    — shows gap to the group leader per stage (±X.X pts)
-export type ViewMode = "absolute" | "delta";
+// "stages"   — one mini-table per stage (SSI-style): each selected competitor
+//              on its own row showing time, HF, A, C, D, NS, M, P
+export type ViewMode = "absolute" | "delta" | "stages";
 
 export interface CompetitorPenaltyStats {
   totalPenalties: number;        // total miss + no_shoot + procedural count across all fired stages

--- a/tests/components/comparison-table.test.tsx
+++ b/tests/components/comparison-table.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ComparisonTable } from "@/components/comparison-table";
@@ -113,6 +113,18 @@ const baseData: CompareResponse = {
     },
   ],
 };
+
+// View-mode preference is now persisted in localStorage. Without resetting
+// it between tests, a click on the "Delta" toggle in one test would carry
+// over and break "Absolute is the default" expectations in the next test.
+// We do NOT call localStorage.clear() because the component also reads
+// "ssi-cell-help-seen" — clearing it would auto-open the help dialog on
+// mount, whose focus trap marks the rest of the page aria-hidden and
+// breaks every getByRole query.
+beforeEach(() => {
+  window.localStorage.removeItem("ssi-comparison-view-mode");
+  window.localStorage.setItem("ssi-cell-help-seen", "1");
+});
 
 describe("ComparisonTable", () => {
   it("renders competitor names", () => {
@@ -614,5 +626,39 @@ describe("ComparisonTable — stages (per-stage scorecard) view", () => {
     fireEvent.click(screen.getByRole("radio", { name: "Stages" }));
     // It should disappear once stages mode is active
     expect(screen.queryByRole("radio", { name: "Group" })).not.toBeInTheDocument();
+  });
+});
+
+describe("ComparisonTable — view mode persistence", () => {
+  it("restores the previously selected view mode on remount (page reload)", () => {
+    const { unmount } = renderWithProviders(
+      <ComparisonTable scoringCompleted={100} data={baseData} />,
+    );
+    fireEvent.click(screen.getByRole("radio", { name: "Stages" }));
+    expect(screen.getByRole("radio", { name: "Stages" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    unmount();
+
+    // Simulating a fresh page load — same localStorage, new component tree.
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
+    expect(screen.getByRole("radio", { name: "Stages" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.getByRole("radio", { name: "Absolute" })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+  });
+
+  it("falls back to Absolute when localStorage holds an unknown value", () => {
+    window.localStorage.setItem("ssi-comparison-view-mode", "bogus");
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
+    expect(screen.getByRole("radio", { name: "Absolute" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
   });
 });

--- a/tests/components/comparison-table.test.tsx
+++ b/tests/components/comparison-table.test.tsx
@@ -551,3 +551,68 @@ describe("ComparisonTable — delta view mode", () => {
     expect(screen.getAllByText("±0.0 pts").length).toBeGreaterThanOrEqual(2);
   });
 });
+
+describe("ComparisonTable — stages (per-stage scorecard) view", () => {
+  it("offers a Stages toggle alongside Absolute and Delta", () => {
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
+    expect(screen.getByRole("radio", { name: "Stages" })).toBeInTheDocument();
+  });
+
+  it("renders one section per stage in stages mode with the SSI-style column headers", () => {
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
+    fireEvent.click(screen.getByRole("radio", { name: "Stages" }));
+
+    // Section heading per stage (region with stage label)
+    const region = screen.getByRole("region", { name: /Stage One/i });
+    expect(region).toBeInTheDocument();
+
+    // Required scorecard columns
+    const headers = ["Time", "HF", "Pts", "A", "C", "D", "NS", "M", "P"];
+    for (const h of headers) {
+      expect(screen.getByRole("columnheader", { name: h })).toBeInTheDocument();
+    }
+  });
+
+  it("shows per-competitor time and hit factor in stages mode", () => {
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
+    fireEvent.click(screen.getByRole("radio", { name: "Stages" }));
+    expect(screen.getByText("14.34s")).toBeInTheDocument();
+    expect(screen.getByText("13.49s")).toBeInTheDocument();
+    // Hit factors render in the rows (and may also appear in table caption metadata)
+    expect(screen.getAllByText("5.02").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("5.63").length).toBeGreaterThan(0);
+  });
+
+  it("renders a status badge for non-fired runs (DNF) in stages mode", () => {
+    const data: CompareResponse = {
+      ...baseData,
+      stages: [
+        {
+          ...baseData.stages[0],
+          competitors: {
+            1: {
+              ...baseData.stages[0].competitors[1],
+              dnf: true,
+              hit_factor: null,
+              points: null,
+              time: null,
+            },
+            2: baseData.stages[0].competitors[2],
+          },
+        },
+      ],
+    };
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={data} />);
+    fireEvent.click(screen.getByRole("radio", { name: "Stages" }));
+    expect(screen.getByText("DNF")).toBeInTheDocument();
+  });
+
+  it("hides the percentage-context (Group/Div/Overall) toggle in stages mode", () => {
+    renderWithProviders(<ComparisonTable scoringCompleted={100} data={baseData} />);
+    // Group toggle is visible in absolute mode
+    expect(screen.getByRole("radio", { name: "Group" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("radio", { name: "Stages" }));
+    // It should disappear once stages mode is active
+    expect(screen.queryByRole("radio", { name: "Group" })).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/match-ttl.test.ts
+++ b/tests/unit/match-ttl.test.ts
@@ -62,10 +62,10 @@ describe("computeMatchTtl", () => {
     expect(rawTtl(94, 1, isoHoursFromNow(-24))).toBe(30);
   });
 
-  it("active scoring is clamped to minTtl (default 300s)", () => {
-    // raw = 30, minTtl default = 300 → result = 300
-    expect(computeMatchTtl(1, 1, isoHoursFromNow(-24))).toBe(300);
-    expect(computeMatchTtl(50, 1, isoHoursFromNow(-24))).toBe(300);
+  it("active scoring uses the 30s tier under the default 30s floor", () => {
+    // raw = 30, minTtl default = 30 → result = 30 (kept near-real-time for live matches)
+    expect(computeMatchTtl(1, 1, isoHoursFromNow(-24))).toBe(30);
+    expect(computeMatchTtl(50, 1, isoHoursFromNow(-24))).toBe(30);
   });
 
   it("active scoring respects an explicit minTtl above the raw tier", () => {
@@ -127,10 +127,10 @@ describe("computeMatchTtl", () => {
     expect(rawTtl(0, 0, null)).toBe(30);
   });
 
-  it("fallback is clamped to minTtl (default 300s) when dateStr is null", () => {
-    expect(computeMatchTtl(0, 0, null)).toBe(300);
-    expect(computeMatchTtl(0, -1, null)).toBe(300);
-    expect(computeMatchTtl(0, 1, null)).toBe(300);
+  it("fallback uses the 30s tier under the default 30s floor when dateStr is null", () => {
+    expect(computeMatchTtl(0, 0, null)).toBe(30);
+    expect(computeMatchTtl(0, -1, null)).toBe(30);
+    expect(computeMatchTtl(0, 1, null)).toBe(30);
   });
 
   // ── Minimum TTL floor ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR adds a new "Stages" view mode to the comparison table that displays one mini-table per stage with raw scorecard data (Time, HF, Pts, A, C, D, NS, M, P), optimized for live match comparison. The view mode preference is now persisted in localStorage so users don't have to re-select their preferred view on page reload.

## Key Changes

- **New "Stages" view mode**: Added `StageByStageView` and `StageScorecardTable` components that render SSI-style per-stage scorecards with competitors as rows sorted by hit factor descending. Non-fired runs (DQ/DNF/zeroed) sink to the bottom with status badges.

- **View mode persistence**: Implemented localStorage-backed state management for the view mode toggle. The selected mode is saved to `ssi-comparison-view-mode` and restored on component mount, with graceful fallback to "Absolute" if the stored value is invalid or localStorage is unavailable.

- **Enhanced ViewModeToggle**: 
  - Extended toggle to include all three modes (Absolute, Delta, Stages)
  - Added tooltips via `VIEW_MODE_LABELS` and `VIEW_MODE_TOOLTIPS` constants
  - Removed hardcoded "capitalize" class to use the new labels map

- **Type system updates**: Extended `ViewMode` type from `"absolute" | "delta"` to include `"stages"`, with a type guard function `isViewMode()` for localStorage validation.

- **UI/UX improvements**:
  - Stage headers show stage number, name, target summary (rounds, paper, steel), and max points
  - Links to ShootNScoreIt when `ssi_url` is available
  - Competitor names link to shooter stats with proper back-navigation
  - Penalty columns (NS, M, P) highlighted in red when non-zero
  - Proper accessibility: ARIA labels, semantic HTML, screen reader support

- **Cache TTL adjustment**: Reduced default `MIN_CACHE_TTL_SECONDS` from 300s to 30s to keep active matches near-real-time courtside, with updated documentation explaining the rationale.

- **Test coverage**: Added comprehensive tests for the new Stages view, view mode persistence, and localStorage fallback behavior. Fixed test setup to properly isolate view mode preference between tests.

## Implementation Details

- The `setViewMode` wrapper function handles both state updates and localStorage persistence with try-catch to handle private mode/quota errors gracefully.
- A separate `useEffect` hook restores the persisted view mode on mount (client-only, doesn't affect SSR).
- The percentage-context toggle (Group/Div/Overall) is conditionally hidden in Stages mode since it's not applicable to raw scorecard data.
- Sorted competitors by hit factor descending within each stage, with non-fired runs grouped at the bottom for quick visual scanning.

https://claude.ai/code/session_01VHyNBGLcb7b31zRks5gZMg