### PR TITLE
fix(pre-match): allow brief generation while match is in progress

### DIFF
--- a/app/api/pre-match/brief/[ct]/[id]/route.ts
+++ b/app/api/pre-match/brief/[ct]/[id]/route.ts
@@ -10,6 +10,7 @@ import { createAIProvider } from "@/lib/ai-provider";
 import { buildPreMatchBriefPrompt, computeSquadContext, PRE_MATCH_PROMPT_VERSION } from "@/lib/pre-match-prompt";
 import { fetchMatchData } from "@/lib/match-data";
 import { getShooterDashboard } from "@/lib/api-data";
+import { isPreMatchEligible } from "@/lib/mode";
 import cache from "@/lib/cache-impl";
 import type { ShooterDashboardResponse } from "@/lib/types";
 import type { CoachingTipResponse } from "@/lib/types";
@@ -63,9 +64,23 @@ export async function GET(
   }
   const match = matchResult.data;
 
-  // Only generate briefs for pre-match state.
-  if (match.scoring_completed > 0 || match.match_status === "cp" || match.match_status === "cs") {
-    return NextResponse.json({ error: "Match already has results" }, { status: 400 });
+  // Mirror the frontend's pre-match eligibility gate: the brief stays available
+  // while the match isn't fully wrapped up, even if early squads have started
+  // scoring (e.g. multi-day matches, RO squads shooting the day before).
+  const matchDateMs = match.date ? new Date(match.date).getTime() : null;
+  const matchEndsMs = match.ends ? new Date(match.ends).getTime() : null;
+  const nowMs = Date.now();
+  const daysSinceMatchStart = matchDateMs != null ? (nowMs - matchDateMs) / 86_400_000 : 0;
+  const daysSinceMatchEnd = matchEndsMs != null ? (nowMs - matchEndsMs) / 86_400_000 : null;
+  if (
+    !isPreMatchEligible({
+      scoringPct: match.scoring_completed,
+      daysSinceMatchStart,
+      daysSinceMatchEnd,
+      resultsStatus: match.results_status,
+    })
+  ) {
+    return NextResponse.json({ error: "Match no longer in pre-match state" }, { status: 400 });
   }
 
   // Build a cache key that encodes the prompt version and model.


### PR DESCRIPTION
## Summary
- Triggered by https://scoreboard.urdr.dev/match/22/26298?competitors=711833 - this match has started but the pre-match view is still relevant (early squads finished, viewing user's squad hasn't shot yet).
- PR #315 made the pre-match view selectable while a match is in progress, but the brief route at \`app/api/pre-match/brief/[ct]/[id]/route.ts\` still bailed out the moment \`scoring_completed > 0\`. The UI showed "Brief unavailable -- AI service may be unreachable."
- The route now mirrors \`isPreMatchEligible()\` from \`lib/mode.ts\` (results not fully published, scoring < 95%, < 2 days since end), so the gate matches the frontend's pre-match selectability.

## Test plan
- [x] \`pnpm -w run typecheck\` passes
- [x] \`pnpm -w test\` 854 / 854 pass
- [ ] After deploy, hit the brief on https://scoreboard.urdr.dev/match/22/26298?competitors=711833 and confirm a tip is generated (rather than "Brief unavailable")

🤖 Generated with [Claude Code](https://claude.com/claude-code)