### PR TITLE
fix(pre-match): prefer tracked shooter over selected competitor for 'you' marker

### DIFF
--- a/components/pre-match-view.tsx
+++ b/components/pre-match-view.tsx
@@ -767,12 +767,15 @@ export function PreMatchView({
   }, [selectedSquadNum, match.squads, match.competitors]);
 
   // Index of the tracked/selected shooter within the squad (-1 if not found).
-  const mySquadIdx = useMemo(
-    () => squadMembers.findIndex(
-      (c) => c.shooterId === myShooterId || selectedIds.includes(c.id),
-    ),
-    [squadMembers, myShooterId, selectedIds],
-  );
+  // Prefer the configured tracked shooter; fall back to a selected competitor only
+  // if the tracked shooter is not in this squad.
+  const mySquadIdx = useMemo(() => {
+    if (myShooterId !== null) {
+      const idx = squadMembers.findIndex((c) => c.shooterId === myShooterId);
+      if (idx !== -1) return idx;
+    }
+    return squadMembers.findIndex((c) => selectedIds.includes(c.id));
+  }, [squadMembers, myShooterId, selectedIds]);
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- Squad list "you" indicator was picking the first competitor that matched either the tracked shooter **or** any selected comparison competitor (`?competitors=...`). When multiple competitors were selected, the earliest one in squad order won — so the marker landed on someone else instead of the configured tracked shooter.
- Fix prefers `myShooterId` and only falls back to `selectedIds` when the tracked shooter isn't in this squad.

## Test plan
- [ ] Open a match with `?competitors=` containing multiple shooters from the same squad
- [ ] Confirm "← you" marker is on the configured tracked shooter, not the first selected competitor
- [ ] If tracked shooter is not in the squad, marker falls back to a selected competitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)