### PR TITLE
Fix pre-match view logic for multi-day matches with missing end dates

### DIFF
--- a/app/api/pre-match/brief/[ct]/[id]/route.ts
+++ b/app/api/pre-match/brief/[ct]/[id]/route.ts
@@ -67,17 +67,11 @@ export async function GET(
   // Mirror the frontend's pre-match eligibility gate: the brief stays available
   // while the match isn't fully wrapped up, even if early squads have started
   // scoring (e.g. multi-day matches, RO squads shooting the day before).
-  const matchDateMs = match.date ? new Date(match.date).getTime() : null;
-  const matchEndsMs = match.ends ? new Date(match.ends).getTime() : null;
-  const nowMs = Date.now();
-  const daysSinceMatchStart = matchDateMs != null ? (nowMs - matchDateMs) / 86_400_000 : 0;
-  const daysSinceMatchEnd = matchEndsMs != null ? (nowMs - matchEndsMs) / 86_400_000 : null;
   if (
     !isPreMatchEligible({
       scoringPct: match.scoring_completed,
-      daysSinceMatchStart,
-      daysSinceMatchEnd,
       resultsStatus: match.results_status,
+      matchStatus: match.match_status,
     })
   ) {
     return NextResponse.json({ error: "Match no longer in pre-match state" }, { status: 400 });

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -223,13 +223,13 @@ export default function MatchPageClient() {
   const effectiveMode = modeOverride ?? autoMode;
 
   // Pre-match selectability — offered as a manual choice while the match
-  // isn't fully wrapped up.
+  // isn't fully wrapped up. Gated on scoring %, not on dates, so it stays
+  // available for multi-day matches where some squads still haven't shot.
   const preMatchEligible = matchQuery.data
     ? isPreMatchEligible({
         scoringPct: matchQuery.data.scoring_completed,
-        daysSinceMatchStart,
-        daysSinceMatchEnd,
         resultsStatus: matchQuery.data.results_status,
+        matchStatus: matchQuery.data.match_status,
       })
     : false;
 

--- a/lib/mode.ts
+++ b/lib/mode.ts
@@ -27,7 +27,12 @@ export interface DetectMatchViewArgs {
  *   - "live"     — active match with meaningful scoring progress.
  */
 export function detectMatchView(args: DetectMatchViewArgs): MatchView {
-  const daysSinceEnd = args.daysSinceMatchEnd ?? args.daysSinceMatchStart;
+  // When `match.ends` is missing, give a 3-day grace window past the start
+  // date before treating the match as "old". SSI sets `ends=null` for many
+  // matches even when they actually run multiple days, so naively falling
+  // back to `daysSinceMatchStart` would auto-flip Level 3+ matches into
+  // coaching mode while their late squads still haven't shot.
+  const daysSinceEnd = args.daysSinceMatchEnd ?? (args.daysSinceMatchStart - 3);
 
   // Definitively done — always coaching.
   if (args.resultsStatus === "all") return "coaching";
@@ -41,26 +46,44 @@ export function detectMatchView(args: DetectMatchViewArgs): MatchView {
   // No scoring at all — pre-match.
   if (args.scoringPct === 0 && !args.hasActualScores) return "prematch";
 
-  // Early-stage match: < 25% scoring AND match end date is still in the future
-  // (or today). Covers RO squads shooting the day before the main field.
-  if (args.scoringPct < 25 && daysSinceEnd < 1) return "prematch";
+  // Early-stage match: < 25% scoring AND we're still inside the match window
+  // (today is on/before the end date, with a small grace period). Covers
+  // RO squads shooting the day before the main field, as well as morning
+  // scoring on day 1 of a multi-day match. The end-date check is skipped
+  // entirely when match.ends is null — single-day matches set ends=null and
+  // we shouldn't punish that with a date-derived fallback.
+  if (args.scoringPct < 25) {
+    if (args.daysSinceMatchEnd == null) {
+      // No end date: rely on start date — within 1 day of start counts as early.
+      if (args.daysSinceMatchStart < 1) return "prematch";
+    } else if (args.daysSinceMatchEnd < 1) {
+      return "prematch";
+    }
+  }
 
   return "live";
 }
 
 /**
  * Whether the pre-match view is offered as a manual choice in the toggle.
- * Hidden once the match is wrapped up, since pre-match info is no longer useful.
+ *
+ * Rule: pre-match stays available as long as the match isn't done.
+ * "Done" means results are officially published, the match is marked completed,
+ * or scoring has reached 95 % — at that point every squad has shot, so the
+ * "I haven't shot yet" use case no longer applies.
+ *
+ * We deliberately don't gate on dates here: SSI's `match.ends` is often null
+ * (single-day matches) or set to the start date, so a date-based cutoff
+ * misfires for multi-day Level 3+ matches whose `match.date` is several days
+ * in the past while the user's squad still hasn't shot.
  */
 export function isPreMatchEligible(args: {
   scoringPct: number;
-  daysSinceMatchStart: number;
-  daysSinceMatchEnd: number | null;
   resultsStatus: string;
+  matchStatus: string;
 }): boolean {
   if (args.resultsStatus === "all") return false;
+  if (args.matchStatus === "cp") return false;
   if (args.scoringPct >= 95) return false;
-  const daysSinceEnd = args.daysSinceMatchEnd ?? args.daysSinceMatchStart;
-  if (daysSinceEnd > 2) return false;
   return true;
 }

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -30,7 +30,7 @@ export const RELEASES: Release[] = [
       {
         heading: "Improved",
         items: [
-          "Smarter auto-view: pre-match stays the default until scoring is meaningfully underway, and now considers the match end date so multi-day matches don't flip to live too early. Coaching kicks in once results are published, scoring hits 95%, or three days have passed since the match ended.",
+          "Smarter auto-view: pre-match stays the default until scoring is meaningfully underway. Coaching kicks in once results are published, scoring hits 95%, or three days have passed since the match ended. Multi-day matches whose end date isn't published get a 3-day grace window so late squads still see pre-match info.",
           "Live freshness: cache TTL for active matches is now ~30 s (was 5 min), so fresh scorecards appear within seconds of the upstream update — no more waiting after a stage finishes.",
         ],
       },

--- a/tests/unit/mode.test.ts
+++ b/tests/unit/mode.test.ts
@@ -34,10 +34,18 @@ describe("detectMatchView", () => {
     ).toBe("coaching");
   });
 
-  it("falls back to start date when end date is null and start is > 3 days ago", () => {
+  it("requires start > 6 days ago when end date is null (3-day grace buffer)", () => {
+    // No ends date and start 7 days ago → coaching
     expect(
-      detectMatchView({ ...baseArgs, scoringPct: 0, daysSinceMatchStart: 4 }),
+      detectMatchView({ ...baseArgs, scoringPct: 50, daysSinceMatchStart: 7 }),
     ).toBe("coaching");
+  });
+
+  it("does NOT auto-flip to coaching for a multi-day match with ends=null and start 4 days ago", () => {
+    // Buffer keeps multi-day matches in the live tier even when ends is missing.
+    expect(
+      detectMatchView({ ...baseArgs, scoringPct: 50, daysSinceMatchStart: 4 }),
+    ).toBe("live");
   });
 
   // ── Cancelled ─────────────────────────────────────────────────────────────
@@ -65,6 +73,17 @@ describe("detectMatchView", () => {
         scoringPct: 15,
         daysSinceMatchStart: 0,
         daysSinceMatchEnd: -1, // multi-day match, ends tomorrow
+      }),
+    ).toBe("prematch");
+  });
+
+  it("returns 'prematch' early in match with ends=null and start today", () => {
+    expect(
+      detectMatchView({
+        ...baseArgs,
+        scoringPct: 10,
+        daysSinceMatchStart: 0.5,
+        daysSinceMatchEnd: null,
       }),
     ).toBe("prematch");
   });
@@ -109,24 +128,25 @@ describe("detectMatchView", () => {
 describe("isPreMatchEligible", () => {
   const baseEligible = {
     scoringPct: 0,
-    daysSinceMatchStart: 0,
-    daysSinceMatchEnd: null,
     resultsStatus: "stg",
+    matchStatus: "on",
   };
 
   it("offered while match is in progress", () => {
     expect(isPreMatchEligible(baseEligible)).toBe(true);
   });
 
-  it("offered for upcoming match", () => {
+  it("offered with 30% scoring (early squads done, my squad in afternoon)", () => {
     expect(
-      isPreMatchEligible({ ...baseEligible, daysSinceMatchStart: -3 }),
+      isPreMatchEligible({ ...baseEligible, scoringPct: 30 }),
     ).toBe(true);
   });
 
-  it("offered with partial scoring, end date still close", () => {
+  it("offered for old multi-day matches with partial scoring (no date gate)", () => {
+    // The previous date-based gate wrongly hid pre-match for Level 3+ matches
+    // whose match.date is several days in the past while late squads haven't shot.
     expect(
-      isPreMatchEligible({ ...baseEligible, scoringPct: 30, daysSinceMatchEnd: 1 }),
+      isPreMatchEligible({ ...baseEligible, scoringPct: 60 }),
     ).toBe(true);
   });
 
@@ -136,15 +156,15 @@ describe("isPreMatchEligible", () => {
     ).toBe(false);
   });
 
-  it("hidden once scoring reaches 95%", () => {
+  it("hidden once match is marked completed", () => {
     expect(
-      isPreMatchEligible({ ...baseEligible, scoringPct: 95 }),
+      isPreMatchEligible({ ...baseEligible, matchStatus: "cp" }),
     ).toBe(false);
   });
 
-  it("hidden when match ended > 2 days ago", () => {
+  it("hidden once scoring reaches 95%", () => {
     expect(
-      isPreMatchEligible({ ...baseEligible, daysSinceMatchEnd: 3 }),
+      isPreMatchEligible({ ...baseEligible, scoringPct: 95 }),
     ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Refactored the match view detection and pre-match eligibility logic to better handle multi-day matches where SSI doesn't provide an `ends` date. Previously, the code would incorrectly fall back to the start date when calculating whether a match was "old," causing multi-day Level 3+ matches to prematurely flip to coaching mode while late squads were still shooting.

## Key Changes

- **Grace period for missing end dates**: When `match.ends` is null, apply a 3-day grace window past the start date before treating the match as "old" (changed from naive fallback to start date)

- **Simplified pre-match eligibility**: Removed date-based gates from `isPreMatchEligible()` and replaced them with scoring percentage and match status checks:
  - Hidden when results are published (`resultsStatus === "all"`)
  - Hidden when match is marked completed (`matchStatus === "cp"`)
  - Hidden when scoring reaches 95%
  - Otherwise available (no date cutoffs)

- **Improved early-stage detection**: Updated `detectMatchView()` to distinguish between matches with and without end dates:
  - With end date: pre-match if scoring < 25% and end date is today or later
  - Without end date: pre-match if scoring < 25% and start date is within 1 day
  - This prevents single-day matches (which often have `ends=null`) from being incorrectly gated

- **Updated API and client code**: Removed date calculation logic from the pre-match brief endpoint and match page client, passing only `scoringPct`, `resultsStatus`, and `matchStatus` to eligibility checks

## Implementation Details

The core issue was that SSI sets `ends=null` for many matches (including multi-day ones), so the previous logic of falling back to `daysSinceMatchStart` would incorrectly age out matches. The new approach:
- Treats missing end dates as a data quality issue rather than a signal that the match is old
- Applies a 3-day buffer to the start date when end date is missing, giving late squads time to shoot
- Removes all date-based gates from pre-match eligibility, relying instead on scoring progress and explicit match status

This ensures pre-match info remains available for users whose squads haven't shot yet, regardless of how old the match date appears.

https://claude.ai/code/session_014kqDv4hUcUQHU5y4tbAXnW