### PR TITLE
fix(cache): don't pin still-active matches to permanent storage

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -24,5 +24,8 @@ export const MAX_COMPETITORS = 12;
  *  11 → added registration/squadding fields (ends, registration_starts, registration_closes,
  *       squadding_starts, squadding_closes, is_registration_possible, is_squadding_possible,
  *       max_competitors, registration) to MATCH_QUERY and EVENTS_QUERY
+ *  12 → no shape change; bump invalidates D1 entries written under the old
+ *       "results=all OR scoring>=95 + 1 day" permanent-cache rule, which
+ *       could pin a still-active match's snapshot to the durable store.
  */
-export const CACHE_SCHEMA_VERSION = 11;
+export const CACHE_SCHEMA_VERSION = 12;

--- a/lib/match-data.ts
+++ b/lib/match-data.ts
@@ -149,14 +149,19 @@ export async function fetchMatchData(
   const daysSince = matchDate ? (Date.now() - matchDate.getTime()) / 86_400_000 : 0;
   const resultsPublished = ev.results === "all";
   const cancelled = ev.status === "cs";
-  // results=all or cancelled are definitive — cache permanently regardless of scoring %.
-  // For non-permanent entries we use the SWR-aware TTL (≥ 5min) so live-match
-  // entries outlive their 30s freshness window, leaving room for the background
-  // refresh below to land before Redis evicts.
-  const ttl = (resultsPublished || cancelled)
+  // Cache permanently only when we're sure the match is truly done:
+  // cancelled, or `isMatchComplete()` returns true (scoring=100 or >7 days
+  // old). `results === "all"` alone is not enough — organizers sometimes
+  // flip it before every RO has submitted scorecards, which used to pin a
+  // mid-match snapshot to D1 with no way to refresh.
+  const trulyDone = cancelled || isMatchComplete(scoringPct, daysSince);
+  const ttl = trulyDone
     ? null
     : computeMatchSwrTtl(scoringPct, daysSince, ev.starts ?? null);
-  const isComplete = resultsPublished || isMatchComplete(scoringPct, daysSince);
+  // `isComplete` flag (returned to callers / used for UI badges) stays
+  // lenient — once results are published or scoring is high we treat the
+  // match as "done enough" to display, even if we keep refreshing.
+  const isComplete = trulyDone || resultsPublished;
 
   try {
     if (ttl === null) {

--- a/lib/match-ttl.ts
+++ b/lib/match-ttl.ts
@@ -23,21 +23,27 @@ const DEFAULT_MIN_TTL = parseInt(
 );
 
 /**
- * Is a match "done" from our caching/UI perspective?
+ * Is a match definitively "done" — safe to cache permanently and stop
+ * hitting the upstream API?
  *
- * A high `scoring_completed` value on its own is not enough — during an
- * active match day the upstream percentage can cross 95% while some
- * squads still have unscored stages, so we also require at least one full
- * day has passed since the match start. Matches more than 3 days old are
- * considered complete regardless of scoring (handles users viewing
- * historical matches where scoring_completed was never finalised).
+ * `scoring_completed` can cross 95% mid-match while squads still have
+ * unscored stages, and `results === "all"` can flip true on the SSI side
+ * before every RO has submitted scorecards. Neither is reliable on its
+ * own. We require either:
+ *   - 100% scoring (literally every stage scored for every approved
+ *     competitor), or
+ *   - more than 7 days since match start — covers 2-3 day matches plus
+ *     extra margin for late scorecard submissions, and still pins
+ *     historical matches that finished at 98%.
+ *
+ * Cancelled matches (`status === "cs"`) are handled separately by callers.
  */
 export function isMatchComplete(
   scoringPct: number,
   daysSince: number,
 ): boolean {
-  if (daysSince > 3) return true;
-  return scoringPct >= 95 && daysSince >= 1;
+  if (daysSince > 7) return true;
+  return scoringPct >= 100;
 }
 
 /**

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -24,10 +24,17 @@ export function useMatchQuery(ct: string, id: string) {
     refetchInterval: (query) => {
       const data = query.state.data;
       if (!data) return false;
+      // Stop polling only when the match is unambiguously over: SSI status
+      // marks it completed/cancelled, or 100% scored. `results_status === "all"`
+      // and `scoring_completed >= 95` were both false-positive triggers — the
+      // organizer can publish results before all scorecards are submitted, and
+      // the scoring percentage can sit at 95-99% mid-match while squads still
+      // have unscored stages. Keep polling in those cases so late scorecards
+      // surface.
       const isComplete =
-        data.results_status === "all" ||
         data.match_status === "cp" ||
-        data.scoring_completed >= 95;
+        data.match_status === "cs" ||
+        data.scoring_completed >= 100;
       return isComplete ? false : 30_000;
     },
     enabled: Boolean(ct && id),

--- a/tests/unit/coaching-prompt.test.ts
+++ b/tests/unit/coaching-prompt.test.ts
@@ -798,19 +798,19 @@ describe("checkCoachingEligibility", () => {
     ];
   }
 
-  it("returns null for eligible competitor in complete match (scoring >= 95)", () => {
+  it("returns null for eligible competitor in complete match (scoring = 100)", () => {
     expect(
-      checkCoachingEligibility(95, 1, stagesWithCompetitor(), competitorId),
+      checkCoachingEligibility(100, 0.5, stagesWithCompetitor(), competitorId),
     ).toBeNull();
   });
 
-  it("returns null for eligible competitor in complete match (daysSince > 3)", () => {
+  it("returns null for eligible competitor in complete match (daysSince > 7)", () => {
     expect(
-      checkCoachingEligibility(50, 4, stagesWithCompetitor(), competitorId),
+      checkCoachingEligibility(50, 8, stagesWithCompetitor(), competitorId),
     ).toBeNull();
   });
 
-  it("rejects incomplete match (scoring < 95 and daysSince <= 3)", () => {
+  it("rejects incomplete match (scoring < 100 and daysSince <= 7)", () => {
     const result = checkCoachingEligibility(
       80,
       2,
@@ -839,30 +839,34 @@ describe("checkCoachingEligibility", () => {
     ).toBeNull();
   });
 
-  it("accepts match at exactly 95% scoring once a day has passed", () => {
+  it("accepts match at exactly 100% scoring even within 7 days", () => {
     expect(
-      checkCoachingEligibility(95, 1, stagesWithCompetitor(), competitorId),
+      checkCoachingEligibility(100, 1, stagesWithCompetitor(), competitorId),
     ).toBeNull();
   });
 
-  it("rejects 95%+ scoring while match is still on the first day", () => {
-    // Regression: during an active match day the scoring_completed can
-    // climb past 95% before all scorecards are in — coaching should wait.
+  it("rejects 95-99% scoring while match is within 7 days", () => {
+    // Regression: scoring_completed can climb past 95% mid-match while
+    // squads still have unscored stages (especially on multi-day matches).
+    // Coaching must wait for true 100% or 7+ days post-match.
     expect(
       checkCoachingEligibility(98, 0.5, stagesWithCompetitor(), competitorId),
     ).toBe("Match scoring is not yet complete");
+    expect(
+      checkCoachingEligibility(99, 3, stagesWithCompetitor(), competitorId),
+    ).toBe("Match scoring is not yet complete");
   });
 
-  it("accepts match at boundary daysSince = 3.1", () => {
+  it("accepts match at boundary daysSince = 7.1", () => {
     expect(
-      checkCoachingEligibility(0, 3.1, stagesWithCompetitor(), competitorId),
+      checkCoachingEligibility(0, 7.1, stagesWithCompetitor(), competitorId),
     ).toBeNull();
   });
 
-  it("rejects at boundary daysSince = 3.0 with low scoring", () => {
+  it("rejects at boundary daysSince = 7.0 with low scoring", () => {
     const result = checkCoachingEligibility(
       50,
-      3.0,
+      7.0,
       stagesWithCompetitor(),
       competitorId,
     );

--- a/tests/unit/match-ttl.test.ts
+++ b/tests/unit/match-ttl.test.ts
@@ -28,30 +28,34 @@ function rawTtl(
 describe("computeMatchTtl", () => {
   // ── Completed matches ──────────────────────────────────────────────────────
 
-  it("returns null (permanent) when scoring >= 95% AND daysSince >= 1", () => {
-    expect(computeMatchTtl(95, 1, isoHoursFromNow(-24))).toBeNull();
+  it("returns null (permanent) when scoring is 100%", () => {
+    expect(computeMatchTtl(100, 0.5, isoHoursFromNow(-12))).toBeNull();
     expect(computeMatchTtl(100, 1, isoHoursFromNow(-24))).toBeNull();
+    expect(computeMatchTtl(100, 30, null)).toBeNull();
   });
 
-  it("returns null (permanent) when daysSince > 3 regardless of scoring", () => {
-    expect(computeMatchTtl(0, 3.1, null)).toBeNull();
+  it("returns null (permanent) when daysSince > 7 regardless of scoring", () => {
+    expect(computeMatchTtl(0, 7.1, null)).toBeNull();
     expect(computeMatchTtl(50, 10, isoHoursFromNow(-240))).toBeNull();
+    expect(computeMatchTtl(98, 365, null)).toBeNull();
   });
 
-  // Regression: during an active match day the upstream scoring_completed
-  // can climb past 95% before all squads' scorecards are in. If we flipped
-  // the cache to permanent at that point, the last scorecards would never
-  // be fetched. Require at least 1 day since start before trusting the
-  // scoring threshold.
-  it("stays in active-scoring tier when scoring >= 95% but match started same day", () => {
-    // 95% scored, match started 6 hours ago → NOT complete
+  // Regression: during an active multi-day match the upstream scoring_completed
+  // can climb past 95% on day 1 while squads still have unscored stages on
+  // day 2. The previous "scoring >= 95% AND daysSince >= 1" rule pinned a
+  // mid-match snapshot to the durable store. Now we require either truly
+  // 100% scoring or > 7 days since start.
+  it("stays in active-scoring tier when scoring >= 95% but match is recent", () => {
     expect(computeMatchTtl(95, 0.25, isoHoursFromNow(-6))).not.toBeNull();
     expect(computeMatchTtl(98, 0.5, isoHoursFromNow(-12))).not.toBeNull();
+    expect(computeMatchTtl(95, 1, isoHoursFromNow(-24))).not.toBeNull();
+    expect(computeMatchTtl(98, 3, isoHoursFromNow(-72))).not.toBeNull();
     expect(rawTtl(99, 0.9, isoHoursFromNow(-21))).toBe(30);
   });
 
-  it("returns null at boundary: scoring exactly 95, daysSince exactly 1", () => {
-    expect(computeMatchTtl(95, 1, isoHoursFromNow(-24))).toBeNull();
+  it("returns null at boundary: scoring exactly 100, any daysSince", () => {
+    expect(computeMatchTtl(100, 0, isoHoursFromNow(0))).toBeNull();
+    expect(computeMatchTtl(100, 0.1, isoHoursFromNow(-2))).toBeNull();
   });
 
   // ── Active scoring ─────────────────────────────────────────────────────────
@@ -166,8 +170,8 @@ describe("computeMatchTtl", () => {
 
 describe("computeMatchFreshness", () => {
   it("returns null for completed matches", () => {
-    expect(computeMatchFreshness(95, 1, isoHoursFromNow(-24))).toBeNull();
-    expect(computeMatchFreshness(0, 4, null)).toBeNull();
+    expect(computeMatchFreshness(100, 0.5, isoHoursFromNow(-12))).toBeNull();
+    expect(computeMatchFreshness(0, 8, null)).toBeNull();
   });
 
   it("returns 30s for active scoring (raw, unclamped)", () => {
@@ -217,21 +221,27 @@ describe("computeMatchFreshness", () => {
 });
 
 describe("isMatchComplete", () => {
-  it("true when daysSince > 3, regardless of scoring", () => {
-    expect(isMatchComplete(0, 3.1)).toBe(true);
+  it("true when daysSince > 7, regardless of scoring", () => {
+    expect(isMatchComplete(0, 7.1)).toBe(true);
     expect(isMatchComplete(50, 10)).toBe(true);
+    expect(isMatchComplete(98, 365)).toBe(true);
   });
 
-  it("true when scoring >= 95% AND daysSince >= 1", () => {
-    expect(isMatchComplete(95, 1)).toBe(true);
-    expect(isMatchComplete(100, 2)).toBe(true);
+  it("true when scoring is 100%, regardless of daysSince", () => {
+    expect(isMatchComplete(100, 0)).toBe(true);
+    expect(isMatchComplete(100, 0.5)).toBe(true);
+    expect(isMatchComplete(100, 5)).toBe(true);
   });
 
-  it("false when scoring >= 95% but match started same day", () => {
-    // Primary regression: high scoring % mid-match-day must not mark complete
+  // Primary regression: high scoring % mid-match must not flip the cache to
+  // permanent. Multi-day matches with pre-match day can run 2-3 days while
+  // late scorecards trickle in — keep refreshing until 100% or > 7 days old.
+  it("false when scoring >= 95% but match is within 7 days", () => {
     expect(isMatchComplete(95, 0)).toBe(false);
     expect(isMatchComplete(98, 0.5)).toBe(false);
-    expect(isMatchComplete(100, 0.99)).toBe(false);
+    expect(isMatchComplete(99, 1)).toBe(false);
+    expect(isMatchComplete(98, 3)).toBe(false);
+    expect(isMatchComplete(95, 7)).toBe(false);
   });
 
   it("false when scoring low and match is recent", () => {

--- a/tests/unit/og-image.test.ts
+++ b/tests/unit/og-image.test.ts
@@ -42,7 +42,7 @@ const MOCK_MATCH: OgMatchData = {
 };
 
 // Active match: recent date + low scoring so isMatchComplete() is false.
-// (A completed-but-recent match would also need to be within 3 days, so we
+// (A completed-but-recent match would also need to be within 7 days, so we
 // set date to a few hours ago — mirrors the real "match in progress" case.)
 const ACTIVE_MATCH: OgMatchData = {
   ...MOCK_MATCH,


### PR DESCRIPTION
## Summary

- A match could be flipped to "permanent" (TTL=null, written to D1) while late scorecards were still being submitted, locking comparison tables onto a stale snapshot. Even forced refreshes kept reading the pinned D1 entry.
- Tightens three "match is done" heuristics that were too loose, and bumps the cache schema version to evict any D1 entries already written under the old rule.

## What was wrong

- `isMatchComplete()` returned true at `scoringPct >= 95 && daysSince >= 1`. Multi-day matches cross `daysSince === 1` on day 2 while late scorecards are still being entered.
- `lib/match-data.ts` treated `results === "all"` *alone* as enough to permanently cache. SSI organizers can publish results before every RO has submitted scorecards.
- `lib/queries.ts` stopped client polling at `scoring_completed >= 95` or `results_status === "all"`, so even if the server kept refreshing, the client wouldn't pick up late updates.

## Changes

- `isMatchComplete()` now requires `scoringPct >= 100 || daysSince > 7`. The 7-day backstop covers 2-3 day matches with margin and still pins year-old historical matches at 98%.
- `lib/match-data.ts` permanent gate: `cancelled || isMatchComplete(...)`. The UI-facing `isComplete` flag still includes `resultsPublished` (badges/labels unchanged), but it no longer drives D1 persistence.
- `lib/queries.ts` stops polling only on `match_status === "cp"/"cs"` or `scoring_completed >= 100`.
- `CACHE_SCHEMA_VERSION` 11 -> 12 to invalidate D1 entries already pinned under the old rule. They'll be re-fetched once and re-evaluated.
- `app/api/compare/route.ts` needs no change — it gates D1 persistence purely via `isMatchComplete()` and inherits the fix.

## Test plan

- [x] `pnpm -w run typecheck` clean
- [x] `pnpm -w test` passes (895/895)
- [ ] Manual: load an in-progress multi-day match and confirm comparison table keeps updating past `scoring_completed >= 95%`
- [ ] Manual: confirm match cards/badges still render "complete" state when `results_status === "all"`
- [ ] After deploy: verify D1 entries written under v11 are re-fetched on next access

🤖 Generated with [Claude Code](https://claude.com/claude-code)