### PR TITLE
fix(cache): serve stale match data when SSI upstream is down

### DIFF
--- a/lib/db-d1.ts
+++ b/lib/db-d1.ts
@@ -272,6 +272,15 @@ const db: AppDatabase = {
     return row?.data ?? null;
   },
 
+  async getMatchDataCacheStoredAt(cacheKey) {
+    const db = getDb();
+    const row = await db
+      .prepare(`SELECT stored_at FROM match_data_cache WHERE cache_key = ?`)
+      .bind(cacheKey)
+      .first<{ stored_at: string }>();
+    return row?.stored_at ?? null;
+  },
+
   async setMatchDataCache(cacheKey, data, meta) {
     const db = getDb();
     await db

--- a/lib/db-sqlite.ts
+++ b/lib/db-sqlite.ts
@@ -278,6 +278,13 @@ export function createSqliteDatabase(
       return row?.data ?? null;
     },
 
+    async getMatchDataCacheStoredAt(cacheKey) {
+      const row = getDb()
+        .prepare(`SELECT stored_at FROM match_data_cache WHERE cache_key = ?`)
+        .get(cacheKey) as { stored_at: string } | undefined;
+      return row?.stored_at ?? null;
+    },
+
     async setMatchDataCache(cacheKey, data, meta) {
       getDb()
         .prepare(

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -80,6 +80,10 @@ export interface AppDatabase {
   /** Retrieve a cached match data entry by its cache key. Returns the raw JSON string or null. */
   getMatchDataCache(cacheKey: string): Promise<string | null>;
 
+  /** Retrieve only the `stored_at` timestamp of a match data cache row.
+   *  Used by throttled writers to skip redundant updates. */
+  getMatchDataCacheStoredAt(cacheKey: string): Promise<string | null>;
+
   /** Store a match data entry. Upserts on cache_key. */
   setMatchDataCache(
     cacheKey: string,

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -6,7 +6,7 @@ import cache from "@/lib/cache-impl";
 import db from "@/lib/db-impl";
 import { afterResponse } from "@/lib/background-impl";
 import { CACHE_SCHEMA_VERSION } from "@/lib/constants";
-import { parseMatchCacheKey } from "@/lib/match-data-store";
+import { parseMatchCacheKey, persistActiveMatchToD1 } from "@/lib/match-data-store";
 
 /**
  * Check if the current request is an admin-authenticated request
@@ -340,9 +340,24 @@ export async function refreshCachedQuery<T>(
       cachedAt: new Date().toISOString(),
       v: CACHE_SCHEMA_VERSION,
     };
-    await cache.set(cacheKey, JSON.stringify(entry), ttlSeconds);
+    const payload = JSON.stringify(entry);
+    await cache.set(cacheKey, payload, ttlSeconds);
+    // Mirror the fresh payload into D1 for match keys so the durable store
+    // stays current with the hot Redis cache. Throttled inside the helper.
+    if (parseMatchCacheKey(cacheKey)) {
+      afterResponse(persistActiveMatchToD1(cacheKey, payload));
+    }
   } catch (err) {
     console.error("[cache] background refresh failed for key:", cacheKey, err);
+    // Stale-on-error: extend the existing entry's TTL so users keep seeing
+    // last-known-good data through transient upstream outages. Without this,
+    // the entry would tick toward eviction while every refresh attempt fails,
+    // and a Redis miss during the outage would surface a hard 502 to clients.
+    if (ttlSeconds !== null) {
+      try {
+        await cache.expire(cacheKey, ttlSeconds);
+      } catch { /* entry may already be gone — D1 fallback covers it */ }
+    }
   } finally {
     try {
       await cache.del(lockKey);
@@ -407,12 +422,19 @@ export async function cachedExecuteQuery<T>(
   const data = await executeQuery<T>(query, variables);
   const cachedAt = new Date().toISOString();
 
+  const entry: CacheEntry<T> = { data, cachedAt, v: CACHE_SCHEMA_VERSION };
+  const payload = JSON.stringify(entry);
   try {
-    const entry: CacheEntry<T> = { data, cachedAt, v: CACHE_SCHEMA_VERSION };
-    const payload = JSON.stringify(entry);
     await cache.set(cacheKey, payload, ttlSeconds);
   } catch (err) {
     console.error("[cache] write error for key:", cacheKey, err);
+  }
+
+  // Mirror match keys to D1 as a "last known good" durable fallback so a
+  // Redis eviction during an upstream outage doesn't surface a 502. Throttled
+  // inside the helper to bound write volume on hot paths.
+  if (parseMatchCacheKey(cacheKey)) {
+    afterResponse(persistActiveMatchToD1(cacheKey, payload));
   }
 
   // Record access for popularity tracking (fire-and-forget, non-fatal).

--- a/lib/match-data-store.ts
+++ b/lib/match-data-store.ts
@@ -2,7 +2,12 @@
 // Shared helpers for the tiered match data store: Redis → D1/SQLite → GraphQL.
 //
 // getMatchDataWithFallback() — read from Redis, fall back to D1.
+// persistActiveMatchToD1()   — write to D1 only (no Redis touch), throttled.
+//                              Used on every successful upstream fetch so D1
+//                              has a recent "last known good" snapshot if Redis
+//                              evicts during an upstream outage.
 // persistToMatchStore()      — write to D1, set Redis TTL to 24h (drain).
+//                              Used only when a match is definitively done.
 
 import cache from "@/lib/cache-impl";
 import db from "@/lib/db-impl";
@@ -10,6 +15,9 @@ import { CACHE_SCHEMA_VERSION } from "@/lib/constants";
 
 /** 24 hours — Redis drain TTL for completed matches written to D1. */
 const REDIS_DRAIN_TTL = 86_400;
+
+/** Default minimum age (seconds) before re-writing an active-match D1 row. */
+const ACTIVE_MATCH_D1_THROTTLE_SECONDS = 120;
 
 interface CacheEntryMeta {
   v?: number;
@@ -83,6 +91,52 @@ export function parseMatchCacheKey(
   }
 
   return null;
+}
+
+/**
+ * Persist active-match data to D1/SQLite as a "last known good" fallback.
+ * Does NOT touch Redis (TTL stays whatever the caller set), so SWR freshness
+ * windows are preserved.
+ *
+ * Throttled: skips the write if the existing D1 row is younger than
+ * `minAgeSeconds` (default 120s) to bound D1 write volume on hot paths.
+ *
+ * Fire-and-forget — errors are logged but not thrown.
+ */
+export async function persistActiveMatchToD1(
+  cacheKey: string,
+  rawJson: string,
+  minAgeSeconds: number = ACTIVE_MATCH_D1_THROTTLE_SECONDS,
+): Promise<void> {
+  const parsed = parseMatchCacheKey(cacheKey);
+  if (!parsed) return;
+
+  const { keyType, ct, matchId } = parsed;
+
+  try {
+    const storedAt = await db.getMatchDataCacheStoredAt(cacheKey);
+    if (storedAt) {
+      const ageMs = Date.now() - new Date(storedAt).getTime();
+      if (ageMs < minAgeSeconds * 1000) return; // throttled — recent enough
+    }
+  } catch { /* if the read fails, fall through and try the write */ }
+
+  let schemaVersion = CACHE_SCHEMA_VERSION;
+  try {
+    const meta = JSON.parse(rawJson) as CacheEntryMeta;
+    if (meta.v != null) schemaVersion = meta.v;
+  } catch { /* use default */ }
+
+  try {
+    await db.setMatchDataCache(cacheKey, rawJson, {
+      keyType,
+      ct,
+      matchId,
+      schemaVersion,
+    });
+  } catch (err) {
+    console.error("[match-data-store] active D1 write error:", cacheKey, err);
+  }
 }
 
 /**

--- a/tests/unit/match-data-store.test.ts
+++ b/tests/unit/match-data-store.test.ts
@@ -1,5 +1,28 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { parseMatchCacheKey } from "@/lib/match-data-store";
+
+// Mocks for the active-D1-write tests below. Hoisted vars so vi.mock can
+// reference them — vi.mock() runs before module imports.
+const dbMock = vi.hoisted(() => ({
+  getMatchDataCacheStoredAt: vi.fn<(k: string) => Promise<string | null>>(),
+  setMatchDataCache: vi.fn<
+    (
+      k: string,
+      data: string,
+      meta: { keyType: string; ct: number; matchId: string; schemaVersion: number },
+    ) => Promise<void>
+  >(),
+}));
+const cacheMock = vi.hoisted(() => ({
+  expire: vi.fn<(k: string, ttl: number) => Promise<void>>(),
+}));
+
+vi.mock("@/lib/db-impl", () => ({
+  default: dbMock,
+}));
+vi.mock("@/lib/cache-impl", () => ({
+  default: cacheMock,
+}));
 
 describe("parseMatchCacheKey", () => {
   it("parses gql:GetMatch keys", () => {
@@ -36,5 +59,95 @@ describe("parseMatchCacheKey", () => {
   it("handles numeric match IDs in matchglobal keys", () => {
     const result = parseMatchCacheKey("computed:matchglobal:22:99999");
     expect(result).toEqual({ keyType: "matchglobal", ct: 22, matchId: "99999" });
+  });
+});
+
+describe("persistActiveMatchToD1", () => {
+  const KEY = 'gql:GetMatch:{"ct":22,"id":"26547"}';
+  const PAYLOAD = JSON.stringify({ data: { event: { name: "x" } }, cachedAt: "now", v: 12 });
+
+  beforeEach(() => {
+    dbMock.getMatchDataCacheStoredAt.mockReset();
+    dbMock.setMatchDataCache.mockReset();
+  });
+
+  it("writes to D1 when no existing row exists", async () => {
+    const { persistActiveMatchToD1 } = await import("@/lib/match-data-store");
+    dbMock.getMatchDataCacheStoredAt.mockResolvedValue(null);
+    dbMock.setMatchDataCache.mockResolvedValue(undefined);
+
+    await persistActiveMatchToD1(KEY, PAYLOAD);
+
+    expect(dbMock.setMatchDataCache).toHaveBeenCalledTimes(1);
+    expect(dbMock.setMatchDataCache).toHaveBeenCalledWith(
+      KEY,
+      PAYLOAD,
+      expect.objectContaining({ keyType: "match", ct: 22, matchId: "26547", schemaVersion: 12 }),
+    );
+  });
+
+  it("skips the write if the existing D1 row is younger than the throttle window", async () => {
+    const { persistActiveMatchToD1 } = await import("@/lib/match-data-store");
+    // 30s ago — well under default 120s throttle
+    dbMock.getMatchDataCacheStoredAt.mockResolvedValue(
+      new Date(Date.now() - 30_000).toISOString(),
+    );
+
+    await persistActiveMatchToD1(KEY, PAYLOAD);
+
+    expect(dbMock.setMatchDataCache).not.toHaveBeenCalled();
+  });
+
+  it("writes when the existing row is older than the throttle window", async () => {
+    const { persistActiveMatchToD1 } = await import("@/lib/match-data-store");
+    // 5 min ago — way past default 120s throttle
+    dbMock.getMatchDataCacheStoredAt.mockResolvedValue(
+      new Date(Date.now() - 300_000).toISOString(),
+    );
+    dbMock.setMatchDataCache.mockResolvedValue(undefined);
+
+    await persistActiveMatchToD1(KEY, PAYLOAD);
+
+    expect(dbMock.setMatchDataCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects an explicit minAgeSeconds override", async () => {
+    const { persistActiveMatchToD1 } = await import("@/lib/match-data-store");
+    // 90s ago — under 120s default but over a 30s override
+    dbMock.getMatchDataCacheStoredAt.mockResolvedValue(
+      new Date(Date.now() - 90_000).toISOString(),
+    );
+    dbMock.setMatchDataCache.mockResolvedValue(undefined);
+
+    await persistActiveMatchToD1(KEY, PAYLOAD, 30);
+
+    expect(dbMock.setMatchDataCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores non-match cache keys", async () => {
+    const { persistActiveMatchToD1 } = await import("@/lib/match-data-store");
+
+    await persistActiveMatchToD1("computed:shooter:123:dashboard", PAYLOAD);
+
+    expect(dbMock.getMatchDataCacheStoredAt).not.toHaveBeenCalled();
+    expect(dbMock.setMatchDataCache).not.toHaveBeenCalled();
+  });
+
+  it("does not throw if the storedAt read fails — falls through to the write", async () => {
+    const { persistActiveMatchToD1 } = await import("@/lib/match-data-store");
+    dbMock.getMatchDataCacheStoredAt.mockRejectedValue(new Error("d1 down"));
+    dbMock.setMatchDataCache.mockResolvedValue(undefined);
+
+    await persistActiveMatchToD1(KEY, PAYLOAD);
+
+    expect(dbMock.setMatchDataCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows D1 write errors", async () => {
+    const { persistActiveMatchToD1 } = await import("@/lib/match-data-store");
+    dbMock.getMatchDataCacheStoredAt.mockResolvedValue(null);
+    dbMock.setMatchDataCache.mockRejectedValue(new Error("d1 down"));
+
+    await expect(persistActiveMatchToD1(KEY, PAYLOAD)).resolves.toBeUndefined();
   });
 });

--- a/tests/unit/refresh-cached-query.test.ts
+++ b/tests/unit/refresh-cached-query.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────
+
+const cacheMock = vi.hoisted(() => ({
+  setIfAbsent: vi.fn<(key: string, val: string, ttl: number) => Promise<boolean>>(),
+  set: vi.fn<(key: string, val: string, ttl: number | null) => Promise<void>>(),
+  expire: vi.fn<(key: string, ttl: number) => Promise<void>>(),
+  del: vi.fn<(key: string) => Promise<void>>(),
+  get: vi.fn<(key: string) => Promise<string | null>>(),
+  persist: vi.fn<(key: string) => Promise<void>>(),
+}));
+
+const dbMock = vi.hoisted(() => ({
+  recordMatchAccess: vi.fn(() => Promise.resolve()),
+  getMatchDataCache: vi.fn(() => Promise.resolve(null)),
+  getMatchDataCacheStoredAt: vi.fn(() => Promise.resolve(null)),
+  setMatchDataCache: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/lib/cache-impl", () => ({ default: cacheMock }));
+vi.mock("@/lib/db-impl", () => ({ default: dbMock }));
+vi.mock("@/lib/background-impl", () => ({
+  // Run background work synchronously in tests so we can assert on its effects.
+  afterResponse: (p: Promise<unknown>) => {
+    void p.catch(() => {});
+  },
+}));
+vi.mock("next/headers", () => ({
+  headers: () => Promise.resolve(new Map()),
+}));
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe("refreshCachedQuery — stale-on-error", () => {
+  const KEY = 'gql:GetMatch:{"ct":22,"id":"26547"}';
+  const QUERY = "query GetMatch { x }";
+  const VARS = { ct: 22, id: "26547" };
+
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    cacheMock.setIfAbsent.mockReset();
+    cacheMock.set.mockReset();
+    cacheMock.expire.mockReset();
+    cacheMock.del.mockReset();
+    cacheMock.setIfAbsent.mockResolvedValue(true); // acquire lock
+    cacheMock.set.mockResolvedValue(undefined);
+    cacheMock.expire.mockResolvedValue(undefined);
+    cacheMock.del.mockResolvedValue(undefined);
+
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    process.env.SSI_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("extends the cached entry's TTL when the upstream fetch fails", async () => {
+    const { refreshCachedQuery } = await import("@/lib/graphql");
+    fetchSpy.mockResolvedValue(
+      new Response("upstream down", { status: 502 }),
+    );
+
+    await refreshCachedQuery(KEY, QUERY, VARS, 90);
+
+    // The fresh write should NOT have happened — fetch failed.
+    expect(cacheMock.set).not.toHaveBeenCalledWith(KEY, expect.any(String), 90);
+    // But the existing entry's TTL should have been extended back to 90s.
+    expect(cacheMock.expire).toHaveBeenCalledWith(KEY, 90);
+  });
+
+  it("does not extend TTL when the original ttl is null (permanent)", async () => {
+    const { refreshCachedQuery } = await import("@/lib/graphql");
+    fetchSpy.mockResolvedValue(
+      new Response("upstream down", { status: 502 }),
+    );
+
+    await refreshCachedQuery(KEY, QUERY, VARS, null);
+
+    expect(cacheMock.expire).not.toHaveBeenCalled();
+  });
+
+  it("writes fresh data on success and does NOT call expire", async () => {
+    const { refreshCachedQuery } = await import("@/lib/graphql");
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ data: { event: { name: "ok" } } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await refreshCachedQuery(KEY, QUERY, VARS, 90);
+
+    expect(cacheMock.set).toHaveBeenCalledWith(KEY, expect.any(String), 90);
+    expect(cacheMock.expire).not.toHaveBeenCalled();
+  });
+
+  it("releases the inflight lock even when the fetch fails", async () => {
+    const { refreshCachedQuery } = await import("@/lib/graphql");
+    fetchSpy.mockRejectedValue(new Error("network down"));
+
+    await refreshCachedQuery(KEY, QUERY, VARS, 90);
+
+    expect(cacheMock.del).toHaveBeenCalledWith(`inflight:${KEY}`);
+    expect(cacheMock.expire).toHaveBeenCalledWith(KEY, 90);
+  });
+
+  it("skips the work entirely if the lock was already taken", async () => {
+    const { refreshCachedQuery } = await import("@/lib/graphql");
+    cacheMock.setIfAbsent.mockResolvedValue(false);
+
+    await refreshCachedQuery(KEY, QUERY, VARS, 90);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(cacheMock.expire).not.toHaveBeenCalled();
+    expect(cacheMock.set).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
> Replaces #324 (auto-closed when its stacked base branch was deleted on merge of #323). Now rebased cleanly onto `main`.

## Summary

- During a real SSI outage the app surfaced a hard error instead of serving last-known-good data. Closes the gaps in the SWR layer added in #319.
- Active matches now always have a "last known good" snapshot in the durable D1/SQLite store, and a failed background refresh extends the existing Redis entry's TTL instead of letting it tick toward eviction.

## What was wrong

1. `persistToMatchStore()` was only called when `dataTtl === null` (completed/cancelled matches). Active matches had no D1 row, so once Redis evicted there was literally nothing to serve.
2. `refreshCachedQuery` swallowed upstream errors but did nothing to keep the cached entry alive. With `SWR_TTL_FLOOR = 90s` and a 30s freshness window, a ~90s outage was enough to evict the entry mid-match.
3. Combined: long outage + no D1 fallback for active matches = `executeQuery` throws -> route returns 502 -> client shows "unable to fetch data".

## Changes

### `lib/match-data-store.ts`
- New `persistActiveMatchToD1(cacheKey, rawJson, minAgeSeconds = 120)`. Writes to D1 only (no Redis touch, so SWR freshness windows are preserved). Throttled via `stored_at` to bound D1 write volume.
- `persistToMatchStore()` (D1 + 24h Redis drain) is unchanged -- still used for permanently-cached completed matches.

### `lib/db.ts` + adapters (`db-sqlite.ts`, `db-d1.ts`)
- New lightweight `getMatchDataCacheStoredAt(cacheKey)` to support the throttle check without a full data read.

### `lib/graphql.ts`
- `cachedExecuteQuery` (cache-miss fresh fetch): mirrors match keys to D1 via `persistActiveMatchToD1` (`afterResponse`).
- `refreshCachedQuery` (successful refresh): same.
- `refreshCachedQuery` (catch block): calls `cache.expire(key, ttlSeconds)` to extend the existing entry's life. No-op when `ttl` is `null` (permanent) or when the entry is already gone (D1 covers it).

## Tests

- **`tests/unit/match-data-store.test.ts`**: `persistActiveMatchToD1` -- fresh write, throttle skip (~30s), write past throttle (5min), explicit `minAgeSeconds` override, non-match keys ignored, error swallowing.
- **`tests/unit/refresh-cached-query.test.ts`** (new): TTL extended on upstream 502, no extend on permanent `ttl=null`, success path doesn't call expire, lock released even on failure, skip-when-locked.

## Test plan

- [x] `pnpm -w run typecheck` clean
- [x] `pnpm -w test` (907/907 passing)
- [ ] Manual: simulate a 60s upstream outage (block `shootnscoreit.com` in DNS or set `SSI_API_KEY=invalid`) and confirm the match page keeps showing last-known scorecards instead of the error state
- [ ] Manual: confirm active matches now appear in the D1 `match_data_cache` table during normal operation (one row per match, refreshed every ~120s)
- [ ] Verify D1 write volume on Cloudflare staging stays bounded (the 120s throttle should keep this well under any quota concerns)

## Out of scope

- **End-user UX during outages** -- tracked in #325 so wording and design get proper attention.
- Schema/migration changes -- `match_data_cache` already has all needed columns.
- The `computed:matchglobal:*` key -- derived from scorecards, recomputes naturally once they're available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)