### PR TITLE
feat(match): show 'live updates paused' banner when SSI is down

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -5,6 +5,7 @@ import { cachedExecuteQuery, gqlCacheKey, SCORECARDS_QUERY, MATCH_QUERY, refresh
 import cache from "@/lib/cache-impl";
 import { computeMatchFreshness, computeMatchSwrTtl, isMatchComplete } from "@/lib/match-ttl";
 import { persistToMatchStore } from "@/lib/match-data-store";
+import { isUpstreamDegraded } from "@/lib/upstream-status";
 import { afterResponse } from "@/lib/background-impl";
 
 import { extractDivision } from "@/lib/divisions";
@@ -208,7 +209,12 @@ export async function GET(req: Request) {
   let fingerprintCacheHit: boolean | null = null;
 
   // Report the older of the two cache timestamps (most stale data wins)
-  const cacheInfo = { cachedAt: matchCachedAt ?? scorecardsCachedAt };
+  const cacheInfo: CompareResponse["cacheInfo"] = {
+    cachedAt: matchCachedAt ?? scorecardsCachedAt,
+  };
+  if (cacheInfo.cachedAt && (await isUpstreamDegraded())) {
+    cacheInfo.upstreamDegraded = true;
+  }
 
   const tFetch = performance.now();
 

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -17,6 +17,7 @@ import { useMatchQuery, useCompareQuery, useCoachingAvailability } from "@/lib/q
 import { detectMatchView, isPreMatchEligible } from "@/lib/mode";
 import type { CompareMode } from "@/lib/types";
 import { CacheInfoBadge } from "@/components/cache-info-badge";
+import { UpstreamDegradedBanner } from "@/components/upstream-degraded-banner";
 import { LoadingBar } from "@/components/loading-bar";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -454,6 +455,12 @@ export default function MatchPageClient() {
         : compareCachedAt
       : matchCachedAt ?? compareCachedAt;
 
+  // Either response can flag the upstream as degraded. Show the banner when
+  // any active query reports it — disappears as soon as a fresh response lands.
+  const upstreamDegraded =
+    match.cacheInfo.upstreamDegraded === true ||
+    compareQuery.data?.cacheInfo.upstreamDegraded === true;
+
   return (
     <main id="main-content" tabIndex={-1} className="min-h-screen p-4 sm:p-6 max-w-6xl mx-auto space-y-6 animate-fade-in">
       <LoadingBar
@@ -486,6 +493,11 @@ export default function MatchPageClient() {
           <ShareButton title={match.name} competitorCount={selectedIds.length} />
         </div>
       </div>
+
+      {/* Upstream degraded banner — shown when SSI is failing and we're serving stale data */}
+      {upstreamDegraded && (
+        <UpstreamDegradedBanner cachedAt={stalestCachedAt} />
+      )}
 
       {/* Match header */}
       <MatchHeader match={match} />

--- a/components/upstream-degraded-banner.tsx
+++ b/components/upstream-degraded-banner.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+
+interface UpstreamDegradedBannerProps {
+  /** ISO timestamp of the cached payload being shown (used for "X minutes ago"). */
+  cachedAt: string | null;
+}
+
+// Single source for the wording so future i18n has one place to translate.
+const COPY = {
+  heading: "Live updates paused",
+  // {age} is filled in below; if unknown, we drop the clause entirely.
+  bodyWithAge: "ShootNScoreIt isn't responding. Showing the last scores we received {age}. We'll refresh as soon as it's back.",
+  bodyWithoutAge: "ShootNScoreIt isn't responding. Showing the last scores we received before the outage. We'll refresh as soon as it's back.",
+} as const;
+
+function formatAge(isoString: string): string {
+  const seconds = Math.floor((Date.now() - new Date(isoString).getTime()) / 1000);
+  if (seconds < 60) return `${seconds} seconds ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return minutes === 1 ? "1 minute ago" : `${minutes} minutes ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return hours === 1 ? "1 hour ago" : `${hours} hours ago`;
+  const days = Math.floor(hours / 24);
+  return days === 1 ? "1 day ago" : `${days} days ago`;
+}
+
+export function UpstreamDegradedBanner({ cachedAt }: UpstreamDegradedBannerProps) {
+  const body = cachedAt
+    ? COPY.bodyWithAge.replace("{age}", formatAge(cachedAt))
+    : COPY.bodyWithoutAge;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 sm:px-4 sm:py-3 flex items-start gap-2.5 text-sm"
+    >
+      <AlertTriangle
+        className="w-5 h-5 shrink-0 text-amber-600 dark:text-amber-400 mt-0.5"
+        aria-hidden="true"
+      />
+      <div className="min-w-0 flex-1">
+        <p className="font-semibold text-amber-900 dark:text-amber-200 leading-tight">
+          {COPY.heading}
+        </p>
+        <p className="text-amber-900/90 dark:text-amber-100/90 mt-0.5 leading-snug">
+          {body}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -7,6 +7,7 @@ import db from "@/lib/db-impl";
 import { afterResponse } from "@/lib/background-impl";
 import { CACHE_SCHEMA_VERSION } from "@/lib/constants";
 import { parseMatchCacheKey, persistActiveMatchToD1 } from "@/lib/match-data-store";
+import { markUpstreamDegraded } from "@/lib/upstream-status";
 
 /**
  * Check if the current request is an admin-authenticated request
@@ -349,6 +350,9 @@ export async function refreshCachedQuery<T>(
     }
   } catch (err) {
     console.error("[cache] background refresh failed for key:", cacheKey, err);
+    // Mark the upstream as degraded so handlers can surface a banner to users.
+    // Best-effort — failure to write the flag is silently swallowed.
+    await markUpstreamDegraded();
     // Stale-on-error: extend the existing entry's TTL so users keep seeing
     // last-known-good data through transient upstream outages. Without this,
     // the entry would tick toward eviction while every refresh attempt fails,

--- a/lib/match-data.ts
+++ b/lib/match-data.ts
@@ -10,6 +10,7 @@ import { extractDivision } from "@/lib/divisions";
 import { decodeShooterId, indexMatchShooters } from "@/lib/shooter-index";
 import { afterResponse } from "@/lib/background-impl";
 import { persistToMatchStore } from "@/lib/match-data-store";
+import { isUpstreamDegraded } from "@/lib/upstream-status";
 import type { MatchResponse, StageInfo, CompetitorInfo, SquadInfo } from "@/lib/types";
 
 // ── Raw GraphQL response shapes ─────────────────────────────────────────────
@@ -315,6 +316,13 @@ export async function fetchMatchData(
     squads,
     cacheInfo: { cachedAt },
   };
+
+  // Decorate with upstream-degraded flag so the client can surface a banner.
+  // Only meaningful for cache hits — a fresh fetch by definition means upstream
+  // just succeeded for this caller.
+  if (cachedAt && (await isUpstreamDegraded())) {
+    response.cacheInfo.upstreamDegraded = true;
+  }
 
   return { data: response, cachedAt, isComplete, msFetch };
 }

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -11,11 +11,30 @@ import type { Release } from "@/lib/types";
  * differs from the value stored in localStorage("whats-new-seen-id").
  */
 /** The `id` of the newest release. Used by e2e tests to suppress the What's New dialog. */
-export const LATEST_RELEASE_ID = "2026-04-26";
+export const LATEST_RELEASE_ID = "2026-04-27";
 
 export const RELEASES: Release[] = [
   {
     id: LATEST_RELEASE_ID,
+    date: "April 27, 2026",
+    title: "Heads-up When SSI Is Down",
+    sections: [
+      {
+        heading: "New",
+        items: [
+          "When ShootNScoreIt isn't responding, the match page now shows a clear 'Live updates paused' banner with how old the displayed scores are, so you know whether you're looking at current data or a snapshot from a few minutes ago.",
+        ],
+      },
+      {
+        heading: "Improved",
+        items: [
+          "During upstream outages, the app keeps serving the last good scores from durable storage instead of failing — combined with the new banner, courtside refreshing no longer feels broken.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "2026-04-26",
     date: "April 26, 2026",
     title: "Pick Your View",
     screenshotScenes: ["comparison-table"],

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -63,6 +63,9 @@ export interface SquadInfo {
 
 export interface CacheInfo {
   cachedAt: string | null; // ISO string of when data was cached; null if just fetched fresh
+  /** True when an upstream refresh failed within the last ~60s.
+   *  Drives the "live updates paused" banner. Absent on fresh successful fetches. */
+  upstreamDegraded?: boolean;
 }
 
 export interface MatchResponse {

--- a/lib/upstream-status.ts
+++ b/lib/upstream-status.ts
@@ -1,0 +1,34 @@
+// Server-only — short-lived signal that the upstream SSI GraphQL API is
+// failing. Set from the catch block in `refreshCachedQuery`; read by handlers
+// that decorate `cacheInfo.upstreamDegraded` on responses.
+//
+// Storage: a single Redis key with a 60s TTL. The key is process-wide
+// (not per match) — any failed refresh marks the system as "degraded" for
+// the next minute, which matches the user's mental model: "scores aren't
+// updating right now".
+
+import cache from "@/lib/cache-impl";
+
+export const UPSTREAM_DEGRADED_KEY = "upstream:lastFailureAt";
+export const UPSTREAM_DEGRADED_TTL_SECONDS = 60;
+
+/** Mark the upstream as degraded for the next ~60s. Fire-and-forget. */
+export async function markUpstreamDegraded(): Promise<void> {
+  try {
+    await cache.set(
+      UPSTREAM_DEGRADED_KEY,
+      new Date().toISOString(),
+      UPSTREAM_DEGRADED_TTL_SECONDS,
+    );
+  } catch { /* cache may be down — degraded state is best-effort */ }
+}
+
+/** Returns true if the upstream has failed within the last ~60s. */
+export async function isUpstreamDegraded(): Promise<boolean> {
+  try {
+    const v = await cache.get(UPSTREAM_DEGRADED_KEY);
+    return v != null;
+  } catch {
+    return false;
+  }
+}

--- a/tests/components/upstream-degraded-banner.test.tsx
+++ b/tests/components/upstream-degraded-banner.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { UpstreamDegradedBanner } from "@/components/upstream-degraded-banner";
+
+describe("UpstreamDegradedBanner", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-26T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the heading and an aria-live=polite status region", () => {
+    render(<UpstreamDegradedBanner cachedAt={null} />);
+    const status = screen.getByRole("status");
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(screen.getByText("Live updates paused")).toBeInTheDocument();
+  });
+
+  it("includes a relative-time clause when cachedAt is provided", () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60_000).toISOString();
+    render(<UpstreamDegradedBanner cachedAt={fiveMinAgo} />);
+    expect(screen.getByText(/5 minutes ago/)).toBeInTheDocument();
+  });
+
+  it("uses singular 'minute' for exactly one minute", () => {
+    const oneMinAgo = new Date(Date.now() - 60_000).toISOString();
+    render(<UpstreamDegradedBanner cachedAt={oneMinAgo} />);
+    expect(screen.getByText(/1 minute ago/)).toBeInTheDocument();
+    expect(screen.queryByText(/1 minutes ago/)).not.toBeInTheDocument();
+  });
+
+  it("falls back to a generic clause when cachedAt is null", () => {
+    render(<UpstreamDegradedBanner cachedAt={null} />);
+    expect(
+      screen.getByText(/Showing the last scores we received before the outage/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the warning icon as decorative (aria-hidden)", () => {
+    const { container } = render(<UpstreamDegradedBanner cachedAt={null} />);
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/tests/unit/refresh-cached-query.test.ts
+++ b/tests/unit/refresh-cached-query.test.ts
@@ -18,8 +18,13 @@ const dbMock = vi.hoisted(() => ({
   setMatchDataCache: vi.fn(() => Promise.resolve()),
 }));
 
+const upstreamMock = vi.hoisted(() => ({
+  markUpstreamDegraded: vi.fn(() => Promise.resolve()),
+}));
+
 vi.mock("@/lib/cache-impl", () => ({ default: cacheMock }));
 vi.mock("@/lib/db-impl", () => ({ default: dbMock }));
+vi.mock("@/lib/upstream-status", () => upstreamMock);
 vi.mock("@/lib/background-impl", () => ({
   // Run background work synchronously in tests so we can assert on its effects.
   afterResponse: (p: Promise<unknown>) => {
@@ -48,6 +53,7 @@ describe("refreshCachedQuery — stale-on-error", () => {
     cacheMock.set.mockResolvedValue(undefined);
     cacheMock.expire.mockResolvedValue(undefined);
     cacheMock.del.mockResolvedValue(undefined);
+    upstreamMock.markUpstreamDegraded.mockClear();
 
     fetchSpy = vi.fn();
     vi.stubGlobal("fetch", fetchSpy);
@@ -106,6 +112,29 @@ describe("refreshCachedQuery — stale-on-error", () => {
 
     expect(cacheMock.del).toHaveBeenCalledWith(`inflight:${KEY}`);
     expect(cacheMock.expire).toHaveBeenCalledWith(KEY, 90);
+  });
+
+  it("marks the upstream as degraded when the fetch fails", async () => {
+    const { refreshCachedQuery } = await import("@/lib/graphql");
+    fetchSpy.mockRejectedValue(new Error("network down"));
+
+    await refreshCachedQuery(KEY, QUERY, VARS, 90);
+
+    expect(upstreamMock.markUpstreamDegraded).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT mark the upstream as degraded on success", async () => {
+    const { refreshCachedQuery } = await import("@/lib/graphql");
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ data: { event: { name: "ok" } } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await refreshCachedQuery(KEY, QUERY, VARS, 90);
+
+    expect(upstreamMock.markUpstreamDegraded).not.toHaveBeenCalled();
   });
 
   it("skips the work entirely if the lock was already taken", async () => {

--- a/tests/unit/upstream-status.test.ts
+++ b/tests/unit/upstream-status.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const cacheMock = vi.hoisted(() => ({
+  get: vi.fn<(key: string) => Promise<string | null>>(),
+  set: vi.fn<(key: string, val: string, ttl: number | null) => Promise<void>>(),
+}));
+
+vi.mock("@/lib/cache-impl", () => ({ default: cacheMock }));
+
+describe("upstream-status", () => {
+  beforeEach(() => {
+    cacheMock.get.mockReset();
+    cacheMock.set.mockReset();
+  });
+
+  it("markUpstreamDegraded writes a 60s key with an ISO timestamp", async () => {
+    cacheMock.set.mockResolvedValue(undefined);
+    const { markUpstreamDegraded, UPSTREAM_DEGRADED_KEY } = await import(
+      "@/lib/upstream-status"
+    );
+
+    await markUpstreamDegraded();
+
+    expect(cacheMock.set).toHaveBeenCalledTimes(1);
+    const [key, value, ttl] = cacheMock.set.mock.calls[0];
+    expect(key).toBe(UPSTREAM_DEGRADED_KEY);
+    expect(ttl).toBe(60);
+    expect(() => new Date(value).toISOString()).not.toThrow();
+  });
+
+  it("markUpstreamDegraded swallows cache errors", async () => {
+    cacheMock.set.mockRejectedValue(new Error("cache down"));
+    const { markUpstreamDegraded } = await import("@/lib/upstream-status");
+
+    await expect(markUpstreamDegraded()).resolves.toBeUndefined();
+  });
+
+  it("isUpstreamDegraded returns true when the key exists", async () => {
+    cacheMock.get.mockResolvedValue(new Date().toISOString());
+    const { isUpstreamDegraded } = await import("@/lib/upstream-status");
+
+    await expect(isUpstreamDegraded()).resolves.toBe(true);
+  });
+
+  it("isUpstreamDegraded returns false when the key is missing", async () => {
+    cacheMock.get.mockResolvedValue(null);
+    const { isUpstreamDegraded } = await import("@/lib/upstream-status");
+
+    await expect(isUpstreamDegraded()).resolves.toBe(false);
+  });
+
+  it("isUpstreamDegraded returns false when the cache read throws", async () => {
+    cacheMock.get.mockRejectedValue(new Error("cache down"));
+    const { isUpstreamDegraded } = await import("@/lib/upstream-status");
+
+    await expect(isUpstreamDegraded()).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #325. Surfaces the upstream-degraded state to non-technical users via a persistent banner on the match page.
- Server side: `refreshCachedQuery`'s catch block writes a 60s `upstream:lastFailureAt` Redis key. `MatchResponse.cacheInfo` and `CompareResponse.cacheInfo` get a new `upstreamDegraded?: boolean` flag on cache hits.
- UI: new `UpstreamDegradedBanner` (role=status, aria-live=polite, `AlertTriangle` icon for shape+color per WCAG 1.4.1). Plain-language copy lives in a single `COPY` object so future i18n has one place to translate. Banner renders above `MatchHeader` and disappears automatically when the upstream recovers.

## What the user sees

When SSI is unreachable and we're serving cached data, the banner appears above the match header:

> ⚠ **Live updates paused**
> ShootNScoreIt isn't responding. Showing the last scores we received `5 minutes ago`. We'll refresh as soon as it's back.

If `cachedAt` is null/unknown, the timestamp clause is dropped: *"Showing the last scores we received before the outage."*

## Stacking

- #323 fixed the heuristics that caused active matches to be pinned to permanent storage.
- #326 made the server serve last-known-good data through outages.
- This PR is the user-visible counterpart to #326 -- without it, courtside users still saw \"loading...\" or stale data with no explanation.

## Files touched

- `lib/upstream-status.ts` (new) -- `markUpstreamDegraded` / `isUpstreamDegraded` helpers.
- `lib/graphql.ts` -- catch block calls `markUpstreamDegraded` before extending TTL.
- `lib/match-data.ts`, `app/api/compare/route.ts` -- decorate `cacheInfo` on cache hits.
- `lib/types.ts` -- extend `CacheInfo`.
- `components/upstream-degraded-banner.tsx` (new) -- the banner.
- `app/match/[ct]/[id]/match-page-client.tsx` -- render banner above `MatchHeader`.
- `lib/releases.ts` -- What's new entry.
- `tests/unit/upstream-status.test.ts` (new) -- 5 tests for the helpers.
- `tests/components/upstream-degraded-banner.test.tsx` (new) -- 5 tests covering rendering, a11y, singular/plural minutes, fallback copy, decorative icon.
- `tests/unit/refresh-cached-query.test.ts` -- 2 added tests verifying `markUpstreamDegraded` fires on failure but not success.

## Test plan
- [x] `pnpm -w run typecheck` clean
- [x] `pnpm -w test` -- 919 tests pass (12 new)
- [x] `pnpm -w run lint` -- no new warnings (3 pre-existing in `discord/`)
- [ ] Manual smoke courtside: simulate a 60s outage, confirm banner appears within 30s and disappears within 30s of recovery
- [ ] Verify WCAG 2.1 AA contrast in light and dark mode at 390px width

🤖 Generated with [Claude Code](https://claude.com/claude-code)