### PR TITLE
fix(share): cap share drawer width on desktop so footer stays visible

### DIFF
--- a/components/share-drawer.tsx
+++ b/components/share-drawer.tsx
@@ -98,35 +98,36 @@ export function ShareDrawer({
           </Button>
         )}
       </DrawerTrigger>
-      <DrawerContent className="max-h-[85vh]">
-        <DrawerHeader className="pb-2">
-          <DrawerTitle>{title}</DrawerTitle>
-          <DrawerDescription>{description}</DrawerDescription>
-        </DrawerHeader>
+      <DrawerContent className="max-h-[90vh]">
+        <div className="mx-auto flex w-full max-w-lg flex-col min-h-0 flex-1">
+          <DrawerHeader className="pb-2">
+            <DrawerTitle>{title}</DrawerTitle>
+            <DrawerDescription>{description}</DrawerDescription>
+          </DrawerHeader>
 
-        <div className="px-4 space-y-4">
-          {/* OG image preview — lazy-loaded */}
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={ogImageUrl}
-            alt={ogImageAlt}
-            width={1200}
-            height={630}
-            loading="lazy"
-            className="w-full h-auto rounded-lg border"
-          />
+          <div className="px-4 space-y-4 overflow-y-auto min-h-0 flex-1">
+            {/* OG image preview — lazy-loaded */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={ogImageUrl}
+              alt={ogImageAlt}
+              width={1200}
+              height={630}
+              loading="lazy"
+              className="w-full h-auto rounded-lg border"
+            />
 
-          {/* URL preview */}
-          <div
-            className="flex items-center gap-2 rounded-md border bg-muted/50 px-3 py-2.5 text-sm text-muted-foreground font-mono truncate"
-            title={sharePath}
-          >
-            <Link2 className="w-4 h-4 shrink-0" aria-hidden="true" />
-            <span className="truncate">{sharePath}</span>
+            {/* URL preview */}
+            <div
+              className="flex items-center gap-2 rounded-md border bg-muted/50 px-3 py-2.5 text-sm text-muted-foreground font-mono truncate"
+              title={sharePath}
+            >
+              <Link2 className="w-4 h-4 shrink-0" aria-hidden="true" />
+              <span className="truncate">{sharePath}</span>
+            </div>
           </div>
-        </div>
 
-        <DrawerFooter>
+          <DrawerFooter>
           <Button
             className="w-full"
             onClick={handleShare}
@@ -149,7 +150,8 @@ export function ShareDrawer({
               Cancel
             </Button>
           </DrawerClose>
-        </DrawerFooter>
+          </DrawerFooter>
+        </div>
       </DrawerContent>
     </Drawer>
   );


### PR DESCRIPTION
## Summary
- The share drawer's OG image preview stretched to the full drawer width on desktop (~1200px), making it ~630px tall and pushing the URL preview + Copy/Cancel buttons below the viewport.
- Wrap the drawer body in a centered \`max-w-lg\` flex column with a scrollable content region (\`overflow-y-auto min-h-0 flex-1\`), so the footer buttons always stay in view.
- Mobile is unchanged (drawer is already narrower than \`max-w-lg\`).

## Test plan
- [ ] Open a match page on desktop, click Share or share with N competitors -- drawer footer (Copy link, Cancel) is fully visible.
- [ ] Open the same drawer on mobile (390px) -- layout matches before (image full-width, header/footer visible).
- [ ] Drawer body scrolls if viewport is unusually short.

🤖 Generated with [Claude Code](https://claude.com/claude-code)