### PR TITLE
perf(d1): throttle shooter-index writes per match

### DIFF
--- a/app/api/shooter/[shooterId]/add-match/route.ts
+++ b/app/api/shooter/[shooterId]/add-match/route.ts
@@ -16,6 +16,7 @@ import { decodeShooterId, indexMatchShooters } from "@/lib/shooter-index";
 import { parseMatchUrl } from "@/lib/utils";
 import { extractDivision } from "@/lib/divisions";
 import db from "@/lib/db-impl";
+import cache from "@/lib/cache-impl";
 import type { RawMatchData } from "@/lib/match-data";
 
 interface RawScorecardsResponse {
@@ -116,7 +117,10 @@ export async function POST(
     division: extractDivision(c),
   }));
 
-  indexMatchShooters(ct, id, matchData.event.starts ?? null, competitors);
+  indexMatchShooters(ct, id, matchData.event.starts ?? null, competitors, undefined, { force: true });
+  // Drop the precomputed dashboard so the user sees their newly added match
+  // without waiting for the 5min TTL to expire.
+  await cache.del(`computed:shooter:${shooterId}:dashboard`).catch(() => {});
 
   // Verify the target shooter is in the competitor list
   const found = competitors.some((c) => c.shooterId === shooterId);

--- a/lib/match-data.ts
+++ b/lib/match-data.ts
@@ -256,8 +256,14 @@ export async function fetchMatchData(
     })
     .filter((s) => s.competitorIds.length > 0);
 
-  // Build cross-match shooter index. Registered with afterResponse() so the
-  // promise completes even after the HTTP response is sent (required on CF Workers).
+  // Build cross-match shooter index. `indexMatchShooters` self-throttles per
+  // match via a Redis lock so a popular match polled by many viewers only
+  // re-indexes at most once per throttle window. Without throttling, each
+  // match page view (or 30s active-match poll) replays ~2 D1 writes per
+  // competitor + 1 per match — a 200-competitor match is ~400 writes per view.
+  //
+  // Registered with afterResponse() so the promise completes even after the
+  // HTTP response is sent (required on CF Workers).
   afterResponse(indexMatchShooters(ct, id, ev.starts ?? null, competitors, {
     name: ev.name,
     venue: ev.venue ?? null,

--- a/lib/shooter-index.ts
+++ b/lib/shooter-index.ts
@@ -6,6 +6,12 @@ import cache from "@/lib/cache-impl";
 import db from "@/lib/db-impl";
 import type { MatchRecord } from "@/lib/types";
 
+// Re-index a match at most once per this many seconds. Bounds D1 write volume:
+// without throttling, every match page view of a 200-competitor match issues
+// ~400 D1 writes (2 per competitor + 1 per match). At 30s active-match polling
+// from many concurrent viewers this dominates the write rate.
+const INDEX_THROTTLE_SECONDS = 300;
+
 /**
  * Decodes a Relay Global ID to extract the numeric ShooterNode primary key.
  *
@@ -100,7 +106,28 @@ export async function indexMatchShooters(
     license?: string | null;
   }>,
   matchMeta?: MatchMetadata,
+  options?: { force?: boolean },
 ): Promise<void> {
+  // Per-match throttle: skip if another caller indexed this match recently.
+  // The Redis SET NX semantics are atomic, so concurrent callers race the lock
+  // and only the winner proceeds. Failures (Redis down) fall through to index.
+  // `force: true` bypasses the throttle — used by user-triggered flows like
+  // POST /api/shooter/{id}/add-match where the user expects the match to be
+  // indexed regardless of recent activity.
+  if (!options?.force) {
+    let lockAcquired: boolean;
+    try {
+      lockAcquired = await cache.setIfAbsent(
+        `idx:m:${ct}:${matchId}`,
+        "1",
+        INDEX_THROTTLE_SECONDS,
+      );
+    } catch {
+      lockAcquired = true;
+    }
+    if (!lockAcquired) return;
+  }
+
   const matchRef = `${ct}:${matchId}`;
   const startTimestamp = matchStart
     ? Math.floor(new Date(matchStart).getTime() / 1000)
@@ -165,9 +192,6 @@ export async function indexMatchShooters(
     writes.push(
       db.indexShooterMatch(shooterId, matchRef, startTimestamp).catch(() => {}),
       db.setShooterProfile(shooterId, profile).catch(() => {}),
-      // Invalidate the pre-computed dashboard cache so the next visit picks up
-      // this newly indexed match immediately rather than serving stale data.
-      cache.del(`computed:shooter:${shooterId}:dashboard`).catch(() => {}),
     );
   }
   return Promise.allSettled(writes).then(() => {});


### PR DESCRIPTION
## Summary
- `indexMatchShooters` self-throttles per match via a Redis `SET NX` lock (300s TTL). A popular match polled by many viewers re-indexes at most once per window instead of on every poll.
- User-triggered `POST /api/shooter/{id}/add-match` passes `{ force: true }` to bypass the throttle, and explicitly drops the shooter's dashboard cache so the just-added match appears without TTL delay.
- Removed the per-competitor `cache.del(...:dashboard)` from inside the index loop — it was redundant with the dashboard cache's own 5min TTL and added ~hundreds of Upstash REST calls per indexing run.

## Why
Diagnostics on production showed D1 doing **232K writes/day vs 3.8K reads** — a 60:1 write/read ratio. Root cause: every match page view (or 30s poll) re-ran the full index, writing ~2 rows per competitor + 1 per match. A 200-competitor match was ~400 writes per view.

A separate one-off cleanup (`DELETE FROM match_data_cache WHERE schema_version < 12`) was run against prod and staging D1 — shrunk prod from 530 MB to 17.8 MB. That doesn't need a code change because `lib/graphql.ts` already treats stale-version rows as misses; rerun the same DELETE after each `CACHE_SCHEMA_VERSION` bump.

## Test plan
- [x] `pnpm -w run typecheck` clean
- [x] `pnpm -w run lint` clean
- [x] `pnpm -w test` — 919 tests pass
- [ ] After deploy: confirm D1 `write_queries_24h` drops substantially in `wrangler d1 info`
- [ ] Spot-check a popular live match: index lock visible in Upstash (`idx:m:22:<id>`), shooter dashboard still loads with expected matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)