### PR TITLE
fix(pre-match): no 502 when match is too far ahead for forecast

### DIFF
--- a/app/api/pre-match/weather/route.ts
+++ b/app/api/pre-match/weather/route.ts
@@ -9,7 +9,7 @@ import {
   type OpenMeteoResponse,
 } from "@/lib/weather";
 import { geocodeVenueName } from "@/lib/geocoding";
-import type { MatchWeatherData } from "@/lib/types";
+import type { PreMatchWeatherResponse } from "@/lib/types";
 
 export const runtime = "nodejs";
 
@@ -29,7 +29,22 @@ const HOURLY_FIELDS = [
   "visibility",
 ].join(",");
 
-export async function GET(request: Request): Promise<NextResponse<MatchWeatherData | { error: string }>> {
+// Open-Meteo's free forecast endpoint serves roughly the past 90 days
+// (reanalysis-backed) through 16 days into the future. The exact window slides
+// with the current UTC day. Anything outside is a structured "not available"
+// response — never a 5xx.
+const FORECAST_PAST_DAYS = 90;
+const FORECAST_FUTURE_DAYS = 16;
+
+const MS_PER_DAY = 86_400_000;
+
+function startOfUtcDay(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+export async function GET(
+  request: Request,
+): Promise<NextResponse<PreMatchWeatherResponse | { error: string }>> {
   const { searchParams } = new URL(request.url);
   const latStr = searchParams.get("lat");
   const lngStr = searchParams.get("lng");
@@ -39,6 +54,26 @@ export async function GET(request: Request): Promise<NextResponse<MatchWeatherDa
 
   if (!date) {
     return NextResponse.json({ error: "Missing date" }, { status: 400 });
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json({ error: "date must be YYYY-MM-DD" }, { status: 400 });
+  }
+
+  // Window check first: skip geocoding and the upstream call when we already
+  // know the forecast can't cover this date. Saves a round-trip per page load.
+  const today = startOfUtcDay(new Date());
+  const matchDay = startOfUtcDay(new Date(`${date}T00:00:00Z`));
+  const offsetDays = Math.round((matchDay.getTime() - today.getTime()) / MS_PER_DAY);
+
+  if (offsetDays > FORECAST_FUTURE_DAYS) {
+    return NextResponse.json({
+      available: false,
+      reason: "out_of_range_future",
+      daysUntilWindow: offsetDays - FORECAST_FUTURE_DAYS,
+    });
+  }
+  if (offsetDays < -FORECAST_PAST_DAYS) {
+    return NextResponse.json({ available: false, reason: "out_of_range_past" });
   }
 
   let lat = latStr ? parseFloat(latStr) : null;
@@ -61,11 +96,7 @@ export async function GET(request: Request): Promise<NextResponse<MatchWeatherDa
   }
 
   if (lat == null || lng == null) {
-    return NextResponse.json({ error: "No coordinates available for this venue" }, { status: 422 });
-  }
-
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-    return NextResponse.json({ error: "date must be YYYY-MM-DD" }, { status: 400 });
+    return NextResponse.json({ available: false, reason: "no_coordinates" });
   }
 
   const params = new URLSearchParams({
@@ -96,5 +127,5 @@ export async function GET(request: Request): Promise<NextResponse<MatchWeatherDa
   }
 
   const weather = processWeatherResponse(raw, null, null);
-  return NextResponse.json(weather);
+  return NextResponse.json({ available: true, weather });
 }

--- a/components/pre-match-view.tsx
+++ b/components/pre-match-view.tsx
@@ -16,7 +16,7 @@ import {
   Droplets,
 } from "lucide-react";
 import { regionToFlagEmoji } from "@/lib/ipsc-categories";
-import type { MatchResponse, CompetitorInfo, MatchWeatherData } from "@/lib/types";
+import type { MatchResponse, CompetitorInfo, PreMatchWeatherResponse } from "@/lib/types";
 import {
   Popover,
   PopoverContent,
@@ -106,7 +106,14 @@ function weatherIcon(code: number | null) {
   return <Cloud className="w-5 h-5" aria-hidden="true" />;
 }
 
-function WeatherCard({ weather, tooFarAhead }: { weather?: MatchWeatherData; tooFarAhead?: boolean }) {
+function WeatherCard({
+  response,
+  isLoading,
+}: {
+  response: PreMatchWeatherResponse | undefined;
+  isLoading: boolean;
+}) {
+  const weather = response?.available ? response.weather : undefined;
   const tempStr =
     weather?.tempRange != null
       ? `${Math.round(weather.tempRange[0])}–${Math.round(weather.tempRange[1])}°C`
@@ -161,10 +168,18 @@ function WeatherCard({ weather, tooFarAhead }: { weather?: MatchWeatherData; too
       </CardHeader>
 
       <CardContent className="p-0">
-        {tooFarAhead ? (
+        {isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-4 w-48" />
+          </div>
+        ) : response && !response.available ? (
           <p className="text-sm text-muted-foreground">
-            Forecast not yet available — Open-Meteo covers up to 16 days ahead.
-            Check back closer to the match.
+            {response.reason === "out_of_range_future"
+              ? `Forecast not yet available — Open-Meteo covers up to 16 days ahead. Check back in ${response.daysUntilWindow} day${response.daysUntilWindow === 1 ? "" : "s"}.`
+              : response.reason === "out_of_range_past"
+                ? "Match was too long ago for forecast data."
+                : "No coordinates for this venue, so we can't fetch a forecast."}
           </p>
         ) : weather ? (
           <div className="flex items-start gap-3">
@@ -718,14 +733,10 @@ export function PreMatchView({
 
   const useSelectControl = match.squads.length > 8;
 
-  // Weather forecast — fetched when coords or venue name available.
+  // Weather forecast — server returns a structured response (incl. "not yet
+  // available" for far-future dates) so the client just renders whatever it
+  // gets without duplicating window logic.
   const matchDate = match.date ? match.date.slice(0, 10) : null;
-  const [now] = useState(Date.now);
-  const daysUntilMatch = matchDate
-    ? Math.floor((new Date(matchDate).getTime() - now) / 86_400_000)
-    : null;
-  // Open-Meteo forecast covers up to 16 days ahead.
-  const weatherForecastAvailable = daysUntilMatch !== null && daysUntilMatch <= 16;
   const hasVenueInfo = match.lat != null || match.lng != null || match.venue != null;
   const weatherQuery = usePreMatchWeatherQuery(
     match.lat, match.lng, matchDate,
@@ -785,8 +796,8 @@ export function PreMatchView({
       {/* Weather forecast -------------------------------------------------- */}
       {hasVenueInfo && matchDate && (
         <WeatherCard
-          weather={weatherForecastAvailable ? weatherQuery.data : undefined}
-          tooFarAhead={!weatherForecastAvailable}
+          response={weatherQuery.data}
+          isLoading={weatherQuery.isLoading}
         />
       )}
 

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { fetchMatch, fetchCompare, fetchEvents, fetchPopularMatches, fetchCoachingAvailability, fetchCoachingTip, fetchShooterDashboard, fetchShooterSearch } from "@/lib/api";
-import type { CompareMode, MatchResponse, CompareResponse, EventSummary, PopularMatch, CoachingTipResponse, CoachingAvailability, ShooterDashboardResponse, ShooterSearchResult, MatchWeatherData } from "@/lib/types";
+import type { CompareMode, MatchResponse, CompareResponse, EventSummary, PopularMatch, CoachingTipResponse, CoachingAvailability, ShooterDashboardResponse, ShooterSearchResult, PreMatchWeatherResponse } from "@/lib/types";
 import { matchQueryKey, compareQueryKey, coachingAvailabilityKey, coachingTipQueryKey } from "@/lib/query-keys";
 
 // Re-export so existing imports from lib/queries keep working.
@@ -136,7 +136,7 @@ export function usePreMatchWeatherQuery(
   venue: string | null,
   region: string | null,
 ) {
-  return useQuery<MatchWeatherData, Error>({
+  return useQuery<PreMatchWeatherResponse, Error>({
     queryKey: ["pre-match-weather", lat?.toFixed(4), lng?.toFixed(4), date, venue, region],
     queryFn: async () => {
       const params = new URLSearchParams({ date: date!.slice(0, 10) });
@@ -146,7 +146,7 @@ export function usePreMatchWeatherQuery(
       if (region) params.set("region", region);
       const res = await fetch(`/api/pre-match/weather?${params}`);
       if (!res.ok) throw new Error("Weather unavailable");
-      return res.json() as Promise<MatchWeatherData>;
+      return res.json() as Promise<PreMatchWeatherResponse>;
     },
     // Fetch when we have either GPS coords or a venue name to geocode.
     enabled: date != null && (lat != null && lng != null || venue != null),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -476,6 +476,25 @@ export interface MatchWeatherData {
   precipitationDayTotal: number | null;
 }
 
+/**
+ * Pre-match forecast response. Never a 5xx for date or geocoding issues —
+ * unavailability is encoded as a structured 200 so the client renders a clear
+ * empty-state instead of a generic error / retry loop.
+ *
+ * Open-Meteo's free forecast endpoint covers roughly today-90d through
+ * today+16d; anything outside that returns `out_of_range_*`.
+ */
+export type PreMatchWeatherResponse =
+  | { available: true; weather: MatchWeatherData }
+  | {
+      available: false;
+      reason: "out_of_range_future";
+      /** Days the user must wait before the forecast window opens for this date. */
+      daysUntilWindow: number;
+    }
+  | { available: false; reason: "out_of_range_past" }
+  | { available: false; reason: "no_coordinates" };
+
 /** Per-cell conditions overlay for the comparison table (coaching mode only). */
 export interface StageConditions {
   /** UTC hour (0–23) when this competitor shot this stage. */


### PR DESCRIPTION
## Summary
- Server route returns a structured 200 for known unavailability cases (`out_of_range_future`, `out_of_range_past`, `no_coordinates`) instead of upstream-mapped 502 / 422. Genuine Open-Meteo outages still 502.
- New discriminated-union type `PreMatchWeatherResponse` replaces the bare `MatchWeatherData` API contract.
- `WeatherCard` renders each reason explicitly — including a "check back in N days" countdown for far-future matches — and shows a skeleton while loading.
- Drops the duplicated client-side window check; the server is the single source of truth.

## Why
Reported on staging: pre-match view felt stuck while loading on a match dated 2026-07-30 (~3 months out). Open-Meteo's free forecast covers only ~today-90d through today+16d, so it returned HTTP 400 ("start_date out of allowed range"), which the route then mapped to a generic 502. TanStack Query reported the failure (no retries — still noisy in the console) and the user perceived the page as broken even though the gate was rendering the right empty state. The 502 was misleading for both users and observability.

## Test plan
- [x] `pnpm -w run typecheck` clean
- [x] `pnpm -w run lint` clean
- [x] `pnpm -w test` — 919 tests pass
- [x] curl exercises all four branches locally:
  - far future (`2026-07-30`): 200 `{ available: false, reason: "out_of_range_future", daysUntilWindow: 78 }`
  - in range: 200 `{ available: true, weather: {...} }`
  - no coords: 200 `{ available: false, reason: "no_coordinates" }`
  - far past: 200 `{ available: false, reason: "out_of_range_past" }`
- [ ] After deploy: visit a far-future match on staging — pre-match view shows the explicit "Check back in N days" copy, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)