### PR TITLE
fix(events): shrink sub-windows to 7 days so SSI cap doesn't truncate filtered browse

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -41,9 +41,21 @@ const ALLOWED_LEVELS: Record<string, Set<string> | null> = {
 
 // The SSI API applies an undocumented result cap per query when browsing
 // without a search term, silently dropping events further out in the date
-// window. Splitting into 1-month sub-windows keeps each request small enough
-// to fall within the cap, so all events in the full range are returned.
-// Each sub-window gets its own Next.js fetch-cache entry (revalidate: 3600).
+// window. We work around it by splitting the requested range into small
+// sub-windows so each request stays well under the cap.
+//
+// 7 days is chosen to stay safe even when no firearms filter is set: country
+// and minLevel are *post-fetch* filters in this route (the SSI GraphQL has no
+// params for them), so the cap bites on the unfiltered upstream count, not on
+// what the user sees. Bug seen in the wild: browsing a month with discipline
+// "All" + country=SWE + minLevel=L2+ used to show only the first ~9 days
+// because the single 1-month query was already truncated before SWE/L2+
+// filtering ran.
+//
+// Each sub-window gets its own Next.js fetch-cache entry (revalidate: 3600),
+// so the extra requests are cached independently.
+const SUB_WINDOW_DAYS = 7;
+
 function buildSubWindows(
   startsAfter: string,
   startsBefore: string,
@@ -54,7 +66,7 @@ function buildSubWindows(
   const end = new Date(startsBefore);
   while (cur < end) {
     const next = new Date(cur);
-    next.setMonth(next.getMonth() + 1);
+    next.setDate(next.getDate() + SUB_WINDOW_DAYS);
     if (next > end) next.setTime(end.getTime());
     windows.push({
       ...baseVars,
@@ -120,7 +132,7 @@ export async function GET(req: Request) {
       rawEvents = data.events;
     } else {
       // No search text: work around the API's per-request result cap by
-      // splitting the date range into 2-month sub-windows, fetching in
+      // splitting the date range into small sub-windows, fetching in
       // parallel, then deduplicating by event ID.
       const windows = buildSubWindows(startsAfter, startsBefore, firearms ? { firearms } : {});
       const results = await Promise.all(

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -154,10 +154,25 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: message }, { status: 502 });
   }
 
+  // Post-fetch guard against SSI returning events whose `starts` is outside
+  // the requested window (observed: browsing May surfaced matches that started
+  // in April, presumably because SSI matches the date filter against
+  // ends/registration dates too). We only want events whose start date falls
+  // within [startsAfter, startsBefore]. Compare on YYYY-MM-DD prefix so the
+  // raw ISO timestamp's timezone doesn't shift events across the boundary.
+  const startsAfterDate = startsAfter; // already YYYY-MM-DD
+  const startsBeforeDate = startsBefore;
+
   const events: EventSummary[] = rawEvents
     // All IPSC disciplines (Handgun, Rifle, Shotgun, PCC, etc.) share ct=22.
     // Exclude series nodes (ct=43) — those are event series, not scoreable matches.
     .filter((e) => e.get_content_type_key === 22)
+    // Drop events whose start date falls outside the requested window.
+    .filter((e) => {
+      const startDay = (e.starts ?? "").slice(0, 10);
+      if (!startDay) return false;
+      return startDay >= startsAfterDate && startDay <= startsBeforeDate;
+    })
     // Filter by country/region if specified
     .filter((e) => !country || e.region.toUpperCase() === country.toUpperCase())
     // Filter by minimum level (e.g. l2plus keeps only Level II+).


### PR DESCRIPTION
## Summary
- Bug: browsing a month on the main page showed fewer days the looser the discipline filter was. Example: April 2026 + country=SWE + level=L2+ showed Apr 3-19 with Handgun+PCC, but only Apr 3-11 with discipline=All.
- Root cause: `/api/events` browse mode splits the date range into sub-windows to dodge SSI's undocumented per-query result cap, but the windows were 1 month wide. Since the client browses one month at a time, no real splitting happened. `country` and `minLevel` are post-fetch filters in this route (SSI has no params for them), so the cap truncated the upstream list before SWE/L2+ filtering ran. Looser discipline → bigger upstream list → cap bites earlier in the month → fewer days survive post-filter.
- Fix: shrink sub-window size to 7 days (`SUB_WINDOW_DAYS = 7`) so each request stays well under the cap regardless of discipline. Each window is independently cached via `revalidate: 3600`.

## Test plan
- [ ] `pnpm -w run typecheck` passes
- [ ] `pnpm -w run lint` passes
- [ ] Browse April 2026 with discipline=All, country=SWE, minLevel=L2+ -> matches through end of April are visible
- [ ] Browse April 2026 with discipline=Handgun+PCC, country=SWE, minLevel=L2+ -> same coverage as before (or better)
- [ ] Switch months a few times and confirm results aren't duplicated (dedup by event id still works)
- [ ] Search mode (with a query string) still returns expected results

🤖 Generated with [Claude Code](https://claude.com/claude-code)