### PR TITLE
feat(telemetry): generic transport + R2 NDJSON sink (closes #347)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,54 @@ or any other type that is serialised into the **match cache** (Redis/D1) via `ca
 This does **not** apply to AppDatabase schema changes — those are managed independently by
 the SQLite/D1 adapters via `CREATE TABLE IF NOT EXISTS`.
 
+## Telemetry
+
+Structured-event logging for cache decisions and other server-side observability.
+Lives in `lib/telemetry.ts` (transport) + per-domain typed wrappers (`lib/cache-telemetry.ts`).
+
+**Sinks (registered automatically per deploy target):**
+- `console.info` — always on. Picked up by Cloudflare Workers Logs and Docker stdout.
+- R2 NDJSON — Cloudflare only, when the `TELEMETRY` binding is present (see `lib/telemetry-sinks-cf.ts`).
+  Per-isolate batching, flushed via `ctx.waitUntil()` to one object per request burst at
+  `cache-telemetry/YYYY-MM-DD/HHmmss-NNNN.ndjson`. Lifecycle rule on the bucket auto-deletes
+  after 30 days. Sampling controlled by `TELEMETRY_SAMPLE`.
+
+**Adding a new domain:**
+1. Create `lib/<domain>-telemetry.ts` with a typed discriminated union over `op`.
+2. Export a thin wrapper: `export function fooTelemetry(ev: FooEvent) { telemetry({ domain: "foo", ...ev }); }`.
+   No transport changes needed — the existing sinks handle it automatically.
+
+**Adding a new sink:**
+1. Implement `TelemetrySink` (a function over `EnrichedEvent`).
+2. For deploy-target-agnostic sinks: call `registerSink()` at module load.
+3. For CF-only sinks: append to `extraSinks` in `lib/telemetry-sinks-cf.ts`.
+4. For Docker-only sinks: append to `lib/telemetry-sinks-impl.ts`.
+
+**One-time R2 setup (Cloudflare):**
+```bash
+# Production
+wrangler r2 bucket create ssi-scoreboard-telemetry
+wrangler r2 bucket lifecycle set ssi-scoreboard-telemetry --rule \
+  '{"id":"expire-30d","enabled":true,"conditions":{"prefix":""},"action":{"type":"Expire","conditions":{"age":2592000}}}'
+
+# Staging
+wrangler r2 bucket create ssi-scoreboard-telemetry-staging
+wrangler r2 bucket lifecycle set ssi-scoreboard-telemetry-staging --rule \
+  '{"id":"expire-30d","enabled":true,"conditions":{"prefix":""},"action":{"type":"Expire","conditions":{"age":2592000}}}'
+```
+
+**Reading telemetry:**
+```bash
+# List a day's events
+wrangler r2 object list ssi-scoreboard-telemetry --prefix=cache-telemetry/2026-04-28/
+
+# Pipe one object to jq (NDJSON — one event per line)
+wrangler r2 object get ssi-scoreboard-telemetry/cache-telemetry/2026-04-28/132405-a1b2c3.ndjson | \
+  jq 'select(.op == "match-ttl-decision" and .trulyDone == true)'
+
+# Bulk: download a whole day's prefix and feed into DuckDB / sqlite for analysis
+```
+
 ## Shooter Index & Match Backfill
 
 The shooter dashboard (`/shooter/{id}`) shows cross-competition stats. It relies on
@@ -370,7 +418,8 @@ handles new achievements and tiers automatically.
 | `MIN_CACHE_TTL_SECONDS` | `lib/match-ttl.ts` (server-only) | Both | Minimum TTL floor for all non-permanent cache entries. Default `30` (s) — keeps active matches near-real-time so courtside polling picks up fresh scorecards within seconds. Raise it to reduce upstream load on shared deployments. Set to `0` to disable. Never `NEXT_PUBLIC_`. |
 | `MATCH_COMPLETE_DAYS_SINCE` | `lib/match-ttl.ts` (server-only) | Both | Hard time gate (days) before a match can be permanently pinned to durable cache. Default `3`. Even SSI flag flips (`status=cp`, `results=all`) cannot pin earlier than this — protects against the Skepplanda-style premature pinning bug where a mid-match flag flip caused stale data to stick. Raise for events with very long scoring tails (e.g. World Shoots that run 5+ days). Never `NEXT_PUBLIC_`. |
 | `MATCH_COMPLETE_SCORING_PCT` | `lib/match-ttl.ts` (server-only) | Both | Scoring threshold (percent, 0-100) for the un-flagged completion heuristic. Default `98`. Used only when SSI never flips `status=cp`/`results=all` and the time gate has passed. Lower values pin more matches earlier (saves upstream calls) at the risk of catching matches still accruing scorecards. Never `NEXT_PUBLIC_`. |
-| `CACHE_TELEMETRY` | `lib/cache-telemetry.ts` (server-only) | Both | Set to `off` to suppress structured cache/freshness telemetry logs. Default on — emits one JSON line per TTL decision and read-path observation, picked up by Cloudflare Workers logs / Docker stdout. Useful for diagnosing future "data stuck" reports. Never `NEXT_PUBLIC_`. |
+| `CACHE_TELEMETRY` | `lib/telemetry.ts` (server-only) | Both | Set to `off` to suppress all telemetry. Default on — emits one JSON line per event via `console.info` (picked up by Cloudflare Workers Logs / Docker stdout) and additionally writes to R2 on Cloudflare when the `TELEMETRY` binding is bound. Never `NEXT_PUBLIC_`. |
+| `TELEMETRY_SAMPLE` | `lib/telemetry-sinks-cf.ts` (Cloudflare only) | Cloudflare only | `all` (default) keeps every event; `signal` keeps only the high-signal ones — pinning decisions (`trulyDone=true`), schema evictions, and stale reads. Use `signal` if R2 PUT volume gets close to the 1M Class A free-tier cap. Never `NEXT_PUBLIC_`. |
 | `NEXT_PUBLIC_BUILD_ID` | `components/update-banner.tsx`, `app/api/version/route.ts` | Both | Git SHA baked into the client bundle at Docker build time; powers new-version detection. Auto-injected by `pnpm docker:build`. Unset in `pnpm dev` — version check is skipped. |
 | `REDIS_URL` | `lib/cache-node.ts` | Docker only | `redis://localhost:6379` locally, `rediss://...` for managed Redis. Not needed for CF builds. |
 | `APP_DB_PATH` | `lib/db-sqlite.ts` | Docker only | Path to SQLite database file. Defaults to `./data/shooter-index.db`. Not needed for CF builds. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,17 +251,17 @@ Lives in `lib/telemetry.ts` (transport) + per-domain typed wrappers (`lib/cache-
 3. For CF-only sinks: append to `extraSinks` in `lib/telemetry-sinks-cf.ts`.
 4. For Docker-only sinks: append to `lib/telemetry-sinks-impl.ts`.
 
-**One-time R2 setup (Cloudflare):**
+**One-time R2 setup (Cloudflare) — already applied; documented for reproducibility:**
 ```bash
 # Production
 wrangler r2 bucket create ssi-scoreboard-telemetry
-wrangler r2 bucket lifecycle set ssi-scoreboard-telemetry --rule \
-  '{"id":"expire-30d","enabled":true,"conditions":{"prefix":""},"action":{"type":"Expire","conditions":{"age":2592000}}}'
+wrangler r2 bucket lifecycle add ssi-scoreboard-telemetry expire-30d "" \
+  --expire-days 30 --force
 
 # Staging
 wrangler r2 bucket create ssi-scoreboard-telemetry-staging
-wrangler r2 bucket lifecycle set ssi-scoreboard-telemetry-staging --rule \
-  '{"id":"expire-30d","enabled":true,"conditions":{"prefix":""},"action":{"type":"Expire","conditions":{"age":2592000}}}'
+wrangler r2 bucket lifecycle add ssi-scoreboard-telemetry-staging expire-30d "" \
+  --expire-days 30 --force
 ```
 
 **Reading telemetry:**

--- a/lib/cache-telemetry.ts
+++ b/lib/cache-telemetry.ts
@@ -1,16 +1,14 @@
 // Server-only — never import from client components.
 //
-// Lightweight structured-logging shim for cache and freshness decisions.
-// The aim is to make incidents like the Skepplanda Apr 2026 sync bug
-// diagnosable from logs after the fact: we want to be able to grep for
-// "ttl=null" decisions on a given match key and see which signal pinned
-// it (SSI flag flip, scoring threshold, or historical fallback).
+// Typed helper for the "cache" telemetry domain. Owns the event shape;
+// the actual transport (console / R2 / future sinks) lives in
+// `lib/telemetry.ts`.
 //
-// Default behavior: log JSON-shaped lines via console.info (picked up by
-// Cloudflare Workers logs, Docker stdout, etc., with zero infra dependency).
-// Disable globally with `CACHE_TELEMETRY=off`.
+// To add a new cache event, extend the union below. To add a new
+// *domain*, create a sibling file (e.g. `lib/ai-telemetry.ts`) with its
+// own discriminated union and a wrapper that calls `telemetry()`.
 
-const ENABLED = (process.env.CACHE_TELEMETRY ?? "on").toLowerCase() !== "off";
+import { telemetry } from "@/lib/telemetry";
 
 type CacheTelemetryEvent =
   // Decision points
@@ -50,13 +48,5 @@ type CacheTelemetryEvent =
     };
 
 export function cacheTelemetry(ev: CacheTelemetryEvent): void {
-  if (!ENABLED) return;
-  // One JSON line per event — easy to grep, easy to ship to a log aggregator.
-  // Avoid console.log so it doesn't get swallowed by stdout-to-stderr fallback
-  // on some hosts; .info is INFO-level and visible by default everywhere.
-  try {
-    console.info(JSON.stringify({ ts: new Date().toISOString(), ...ev }));
-  } catch {
-    /* ignore — telemetry must never throw into the request path */
-  }
+  telemetry({ domain: "cache", ...ev });
 }

--- a/lib/telemetry-sinks-cf.ts
+++ b/lib/telemetry-sinks-cf.ts
@@ -1,0 +1,115 @@
+// Cloudflare-target extra sinks — registers an R2 NDJSON sink when the
+// `TELEMETRY` binding is present.
+//
+// ── Why R2 ───────────────────────────────────────────────────────────
+// Cloudflare Workers Logs retains for 3 days only. Diagnosing a "data
+// stuck" report often requires looking back further. R2 free tier:
+//   - 10 GB storage
+//   - 1M Class A ops/month (PUT/LIST)
+//   - 10M Class B ops/month (GET)
+// Plenty of headroom for decision-level telemetry with a 30-day lifecycle.
+//
+// ── How writes work ──────────────────────────────────────────────────
+// R2 has no native append. Concurrent read-modify-write would race, so
+// instead each flush writes a *unique-keyed* NDJSON object:
+//
+//   cache-telemetry/YYYY-MM-DD/HHmmss-NNNN.ndjson
+//
+// The day prefix groups objects for easy listing; the nonce avoids
+// collisions across concurrent isolates. Lifecycle rules on the bucket
+// (set once via `wrangler r2 bucket lifecycle set`) auto-delete after
+// 30 days so this never grows unbounded.
+//
+// ── Batching ─────────────────────────────────────────────────────────
+// Per-isolate in-memory buffer. The first event in a burst schedules a
+// flush via afterResponse() (ctx.waitUntil); subsequent events join the
+// buffer. The flush splices the whole buffer atomically, so concurrent
+// requests in the same isolate share a single PUT.
+//
+// ── Sampling ─────────────────────────────────────────────────────────
+// Controlled by TELEMETRY_SAMPLE env var:
+//   - "all"    (default): keep every event
+//   - "signal":            keep only the events most useful for incident
+//                          response (see shouldSampleSignal below)
+// The sampler is a pure function — easy to extend with new rules.
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { afterResponse } from "@/lib/background-impl";
+import type { TelemetrySink, EnrichedEvent } from "@/lib/telemetry";
+
+interface R2Bucket {
+  put(key: string, body: string): Promise<unknown>;
+}
+interface CFEnvWithTelemetry {
+  TELEMETRY?: R2Bucket;
+}
+
+const SAMPLE_MODE = (process.env.TELEMETRY_SAMPLE ?? "all").toLowerCase();
+
+const buffer: EnrichedEvent[] = [];
+let flushScheduled = false;
+
+const r2Sink: TelemetrySink = (ev) => {
+  if (!keepEvent(ev)) return;
+  const bucket = getR2Binding();
+  if (!bucket) return;
+
+  buffer.push(ev);
+  if (flushScheduled) return;
+  flushScheduled = true;
+  afterResponse(flushBuffer(bucket));
+};
+
+function getR2Binding(): R2Bucket | null {
+  try {
+    const { env } = getCloudflareContext() as unknown as { env: CFEnvWithTelemetry };
+    return env?.TELEMETRY ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function flushBuffer(bucket: R2Bucket): Promise<void> {
+  const events = buffer.splice(0);
+  flushScheduled = false;
+  if (events.length === 0) return;
+  const body = events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  const key = makeObjectKey(new Date());
+  try {
+    await bucket.put(key, body);
+  } catch (err) {
+    // One warning per flush — telemetry must never break the request path.
+    console.warn("[telemetry] R2 PUT failed:", err);
+  }
+}
+
+function makeObjectKey(now: Date): string {
+  const iso = now.toISOString(); // 2026-04-28T13:24:05.123Z
+  const day = iso.slice(0, 10); // 2026-04-28
+  const time = iso.slice(11, 19).replace(/:/g, ""); // 132405
+  // 6-hex nonce — collision odds across concurrent isolates within the
+  // same second are ~0 for our request volume.
+  const nonce = Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, "0");
+  return `cache-telemetry/${day}/${time}-${nonce}.ndjson`;
+}
+
+function keepEvent(ev: EnrichedEvent): boolean {
+  if (SAMPLE_MODE === "all") return true;
+  if (SAMPLE_MODE === "signal") return shouldSampleSignal(ev);
+  return true;
+}
+
+// High-signal events — the ones that pay off when reading historical logs
+// to diagnose a sync incident. Other events get dropped under SAMPLE=signal.
+function shouldSampleSignal(ev: EnrichedEvent): boolean {
+  if (ev.domain !== "cache") return true; // future domains pass through
+  if (ev.op === "match-ttl-decision" && ev.trulyDone === true) return true;
+  if (ev.op === "match-cache-schema-evict") return true;
+  if (ev.op === "match-cache-read" && ev.stale === true) return true;
+  return false;
+}
+
+export const extraSinks: TelemetrySink[] = [r2Sink];
+
+// Test-only — exported for unit tests of the sampler.
+export const _internal = { keepEvent, shouldSampleSignal, makeObjectKey };

--- a/lib/telemetry-sinks-impl.ts
+++ b/lib/telemetry-sinks-impl.ts
@@ -1,0 +1,9 @@
+// Default extra sinks — Docker / Node / dev. Console is registered by
+// the core; this list is for transport sinks that need infra (R2, files,
+// external HTTP). On Docker we have none.
+//
+// CF builds replace this module with `lib/telemetry-sinks-cf.ts` via the
+// webpack/turbopack alias in next.config.ts (DEPLOY_TARGET=cloudflare).
+import type { TelemetrySink } from "@/lib/telemetry";
+
+export const extraSinks: TelemetrySink[] = [];

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -1,0 +1,68 @@
+// Server-only — never import from client components.
+//
+// Generic structured-telemetry transport. Domain-specific helpers (e.g.
+// `cacheTelemetry()` in `lib/cache-telemetry.ts`) sit on top of this and
+// give callers a typed event shape; this module owns the wire format,
+// the on/off switch, and the sink registry.
+//
+// ── Adding a new domain ───────────────────────────────────────────────
+// 1. Create `lib/<domain>-telemetry.ts` exporting a typed wrapper:
+//      export function fooTelemetry(ev: FooEvent) { telemetry({ domain: "foo", ...ev }); }
+// 2. Define `FooEvent` as a discriminated union on `op`. That gives every
+//    call site compile-time field checking inside the domain.
+//
+// ── Adding a new sink ────────────────────────────────────────────────
+// 1. Implement `TelemetrySink` (a function over `EnrichedEvent`).
+// 2. Register it via `registerSink()` at module load. For sinks that need
+//    a deploy-target-specific runtime (Cloudflare bindings, file system,
+//    external HTTP), add it to `lib/telemetry-sinks-cf.ts` (CF) or to the
+//    default `lib/telemetry-sinks-impl.ts` (Docker/Node).
+
+import { extraSinks } from "@/lib/telemetry-sinks-impl";
+
+export interface TelemetryEvent {
+  /** Domain bucket — "cache", "ai", "ratelimit", etc. */
+  domain: string;
+  /** Operation within the domain — "match-ttl-decision", etc. */
+  op: string;
+  /** Free-form fields. Keep values primitive so the JSON line stays greppable. */
+  [key: string]: string | number | boolean | null | undefined;
+}
+
+export interface EnrichedEvent extends TelemetryEvent {
+  ts: string;
+}
+
+export type TelemetrySink = (ev: EnrichedEvent) => void;
+
+const ENABLED = (process.env.CACHE_TELEMETRY ?? "on").toLowerCase() !== "off";
+
+const sinks: TelemetrySink[] = [consoleSink, ...extraSinks];
+
+export function registerSink(sink: TelemetrySink): void {
+  sinks.push(sink);
+}
+
+export function telemetry(ev: TelemetryEvent): void {
+  if (!ENABLED) return;
+  const enriched: EnrichedEvent = { ts: new Date().toISOString(), ...ev };
+  for (const s of sinks) {
+    try {
+      s(enriched);
+    } catch {
+      /* never throw into the request path */
+    }
+  }
+}
+
+function consoleSink(ev: EnrichedEvent): void {
+  // .info (not .log) is INFO-level and visible by default on Workers Logs,
+  // Docker stdout, and `next dev`.
+  console.info(JSON.stringify(ev));
+}
+
+// Test-only escape hatch.
+export function _resetTelemetryForTests(): void {
+  sinks.length = 0;
+  sinks.push(consoleSink, ...extraSinks);
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,9 @@ const nextConfig: NextConfig = {
           // Replace the no-op background scheduler with the CF waitUntil
           // implementation so D1 writes complete after the response is sent.
           "@/lib/background-impl": "@/lib/background-cf",
+          // Register the R2 NDJSON telemetry sink on CF; Docker has no
+          // extra sinks beyond the always-on console sink.
+          "@/lib/telemetry-sinks-impl": "@/lib/telemetry-sinks-cf",
         },
       }
     : {},
@@ -60,12 +63,14 @@ const nextConfig: NextConfig = {
       const edgeImpl = path.resolve(process.cwd(), "lib/cache-edge");
       const d1Impl = path.resolve(process.cwd(), "lib/db-d1");
       const bgCf = path.resolve(process.cwd(), "lib/background-cf");
+      const telemetryCf = path.resolve(process.cwd(), "lib/telemetry-sinks-cf");
       config.resolve = {
         ...config.resolve,
         alias: {
           "@/lib/cache-impl": edgeImpl,
           "@/lib/db-impl": d1Impl,
           "@/lib/background-impl": bgCf,
+          "@/lib/telemetry-sinks-impl": telemetryCf,
           ...(config.resolve?.alias as Record<string, string> | undefined ?? {}),
         },
       };

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  telemetry,
+  registerSink,
+  _resetTelemetryForTests,
+  type EnrichedEvent,
+} from "@/lib/telemetry";
+import { _internal } from "@/lib/telemetry-sinks-cf";
+import { cacheTelemetry } from "@/lib/cache-telemetry";
+
+describe("telemetry core", () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    _resetTelemetryForTests();
+    infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+    _resetTelemetryForTests();
+  });
+
+  it("emits one JSON line per event via console.info", () => {
+    telemetry({ domain: "cache", op: "match-cache-permanent", matchKey: "foo", reason: "ttl-null" });
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const line = infoSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(line);
+    expect(parsed.domain).toBe("cache");
+    expect(parsed.op).toBe("match-cache-permanent");
+    expect(parsed.matchKey).toBe("foo");
+    expect(typeof parsed.ts).toBe("string");
+  });
+
+  it("fan-outs to multiple sinks", () => {
+    const seen: EnrichedEvent[] = [];
+    registerSink((ev) => seen.push(ev));
+    telemetry({ domain: "cache", op: "match-cache-permanent", matchKey: "k", reason: "ttl-null" });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].matchKey).toBe("k");
+    // Console sink also fires.
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows sink exceptions so telemetry never breaks the request path", () => {
+    registerSink(() => { throw new Error("boom"); });
+    expect(() =>
+      telemetry({ domain: "cache", op: "match-cache-permanent", matchKey: "k", reason: "ttl-null" }),
+    ).not.toThrow();
+    // Other sinks (console) still fire.
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("cacheTelemetry() wraps with domain=cache", () => {
+    cacheTelemetry({
+      op: "match-ttl-decision",
+      matchKey: "gql:GetMatch:22:12345",
+      scoringPct: 95,
+      daysSince: 1,
+      status: "on",
+      resultsPublished: false,
+      trulyDone: false,
+      ttl: 60,
+    });
+    const parsed = JSON.parse(infoSpy.mock.calls[0][0] as string);
+    expect(parsed.domain).toBe("cache");
+    expect(parsed.op).toBe("match-ttl-decision");
+    expect(parsed.trulyDone).toBe(false);
+  });
+});
+
+describe("R2 sampler (signal mode)", () => {
+  const { shouldSampleSignal } = _internal;
+
+  function ev(fields: Partial<EnrichedEvent> & { domain: string; op: string }): EnrichedEvent {
+    return { ts: "2026-04-28T00:00:00.000Z", ...fields } as EnrichedEvent;
+  }
+
+  it("keeps trulyDone ttl-decisions", () => {
+    expect(
+      shouldSampleSignal(ev({ domain: "cache", op: "match-ttl-decision", trulyDone: true })),
+    ).toBe(true);
+  });
+
+  it("drops trulyDone=false ttl-decisions", () => {
+    expect(
+      shouldSampleSignal(ev({ domain: "cache", op: "match-ttl-decision", trulyDone: false })),
+    ).toBe(false);
+  });
+
+  it("keeps schema-evict events unconditionally", () => {
+    expect(shouldSampleSignal(ev({ domain: "cache", op: "match-cache-schema-evict" }))).toBe(true);
+  });
+
+  it("keeps stale reads, drops fresh reads", () => {
+    expect(
+      shouldSampleSignal(ev({ domain: "cache", op: "match-cache-read", stale: true })),
+    ).toBe(true);
+    expect(
+      shouldSampleSignal(ev({ domain: "cache", op: "match-cache-read", stale: false })),
+    ).toBe(false);
+  });
+
+  it("passes future non-cache domains through", () => {
+    expect(shouldSampleSignal(ev({ domain: "ai", op: "rate-limit" }))).toBe(true);
+  });
+});
+
+describe("R2 object key shape", () => {
+  it("produces day-prefixed keys with a nonce", () => {
+    const key = _internal.makeObjectKey(new Date("2026-04-28T13:24:05.123Z"));
+    expect(key).toMatch(/^cache-telemetry\/2026-04-28\/132405-[0-9a-f]{6}\.ndjson$/);
+  });
+
+  it("two consecutive keys differ (nonce)", () => {
+    const now = new Date("2026-04-28T13:24:05.123Z");
+    const a = _internal.makeObjectKey(now);
+    const b = _internal.makeObjectKey(now);
+    // Statistical: collisions are 1/16M.
+    expect(a).not.toBe(b);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -70,8 +70,8 @@ migrations_dir = "migrations"
 # R2 bucket for long-retention telemetry (cache decisions, etc.) — see
 # lib/telemetry-sinks-cf.ts. Free-tier friendly. One-time setup:
 #   wrangler r2 bucket create ssi-scoreboard-telemetry
-#   wrangler r2 bucket lifecycle set ssi-scoreboard-telemetry \
-#     --rule '{"id":"expire-30d","enabled":true,"conditions":{"prefix":""},"action":{"type":"Expire","conditions":{"age":2592000}}}'
+#   wrangler r2 bucket lifecycle add ssi-scoreboard-telemetry expire-30d "" \
+#     --expire-days 30 --force
 [[r2_buckets]]
 binding = "TELEMETRY"
 bucket_name = "ssi-scoreboard-telemetry"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -67,6 +67,15 @@ database_name = "ssi-scoreboard-app-db-eu"
 database_id = "4a3d6cf5-31ce-4775-84f5-f9abee4206e2"  # patched by scripts/setup-d1.ts
 migrations_dir = "migrations"
 
+# R2 bucket for long-retention telemetry (cache decisions, etc.) — see
+# lib/telemetry-sinks-cf.ts. Free-tier friendly. One-time setup:
+#   wrangler r2 bucket create ssi-scoreboard-telemetry
+#   wrangler r2 bucket lifecycle set ssi-scoreboard-telemetry \
+#     --rule '{"id":"expire-30d","enabled":true,"conditions":{"prefix":""},"action":{"type":"Expire","conditions":{"age":2592000}}}'
+[[r2_buckets]]
+binding = "TELEMETRY"
+bucket_name = "ssi-scoreboard-telemetry"
+
 [assets]
 directory = ".open-next/assets"
 
@@ -90,3 +99,9 @@ binding = "APP_DB"
 database_name = "ssi-scoreboard-app-db-staging-eu"
 database_id = "1b1c7faf-c206-41f6-9557-adbdf1c0ba18"  # patched by scripts/setup-d1.ts
 migrations_dir = "migrations"
+
+# Staging R2 bucket — same setup commands as prod, with --env staging:
+#   wrangler r2 bucket create ssi-scoreboard-telemetry-staging
+[[env.staging.r2_buckets]]
+binding = "TELEMETRY"
+bucket_name = "ssi-scoreboard-telemetry-staging"


### PR DESCRIPTION
## Summary
- Refactors `lib/cache-telemetry.ts` into a generic `lib/telemetry.ts` transport so new domains and sinks are cheap to add — adding a new domain is one file with a typed `op` union; adding a new sink follows the same `*-impl` alias pattern as cache/db/background.
- Adds an R2 NDJSON sink for Cloudflare (`lib/telemetry-sinks-cf.ts`). Per-isolate batching, flushed via `ctx.waitUntil()` to unique-keyed objects (`cache-telemetry/YYYY-MM-DD/HHmmss-NONCE.ndjson`) to avoid read-modify-write races. Lifecycle rule on the bucket handles 30-day retention.
- Adds `[[r2_buckets]]` bindings (prod + staging) to `wrangler.toml`. The buckets themselves still need to be created out-of-band — see commands in `CLAUDE.md`.
- New `TELEMETRY_SAMPLE` env var: `all` (default) keeps everything; `signal` keeps only high-signal events (pinning decisions with `trulyDone=true`, schema evictions, stale reads). Switch later if R2 PUT volume approaches the 1M Class A free-tier cap.

## Why
Cloudflare Workers Logs only retain for 3 days, which is too short for diagnosing slow-burn staleness reports like the Skepplanda Apr 2026 bug. R2 free tier covers this at zero cost: 10 GB storage, 1M Class A ops/month — plenty of headroom for decision-level events.

## Extending
- New domain (e.g. AI rate-limit telemetry): create `lib/<domain>-telemetry.ts` with a typed wrapper around `telemetry({ domain: \"...\", ...ev })`. No transport changes.
- New sink: implement `TelemetrySink`, register via `registerSink()` or by appending to `extraSinks` in the appropriate impl file.

## One-time setup before deploying
```bash
wrangler r2 bucket create ssi-scoreboard-telemetry
wrangler r2 bucket lifecycle set ssi-scoreboard-telemetry --rule \
  '{\"id\":\"expire-30d\",\"enabled\":true,\"conditions\":{\"prefix\":\"\"},\"action\":{\"type\":\"Expire\",\"conditions\":{\"age\":2592000}}}'
# repeat with -staging suffix for staging
```

## Test plan
- [x] `pnpm -w run typecheck` — clean
- [x] `pnpm -w run lint` — clean
- [x] `pnpm -w test` — 1500/1500 passing (11 new tests for telemetry core, sampler, key shape)
- [ ] After merge: create the R2 buckets + lifecycle rules, deploy, verify objects appear under `cache-telemetry/<today>/`
- [ ] Confirm `TELEMETRY_SAMPLE=signal` filters events correctly in production by setting it temporarily and reading R2 listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)