### PR TITLE
feat(telemetry): upstream domain + per-domain sampling rates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,10 @@ the SQLite/D1 adapters via `CREATE TABLE IF NOT EXISTS`.
 ## Telemetry
 
 Structured-event logging for cache decisions and other server-side observability.
-Lives in `lib/telemetry.ts` (transport) + per-domain typed wrappers (`lib/cache-telemetry.ts`).
+Lives in `lib/telemetry.ts` (transport) + per-domain typed wrappers:
+
+- `lib/cache-telemetry.ts` — match TTL decisions, cache reads, schema evictions
+- `lib/upstream-telemetry.ts` — every SSI GraphQL fetch (latency, outcome, bytes)
 
 **Sinks (registered automatically per deploy target):**
 - `console.info` — always on. Picked up by Cloudflare Workers Logs and Docker stdout.
@@ -440,7 +443,7 @@ handles new achievements and tiers automatically.
 | `MATCH_COMPLETE_DAYS_SINCE` | `lib/match-ttl.ts` (server-only) | Both | Hard time gate (days) before a match can be permanently pinned to durable cache. Default `3`. Even SSI flag flips (`status=cp`, `results=all`) cannot pin earlier than this — protects against the Skepplanda-style premature pinning bug where a mid-match flag flip caused stale data to stick. Raise for events with very long scoring tails (e.g. World Shoots that run 5+ days). Never `NEXT_PUBLIC_`. |
 | `MATCH_COMPLETE_SCORING_PCT` | `lib/match-ttl.ts` (server-only) | Both | Scoring threshold (percent, 0-100) for the un-flagged completion heuristic. Default `98`. Used only when SSI never flips `status=cp`/`results=all` and the time gate has passed. Lower values pin more matches earlier (saves upstream calls) at the risk of catching matches still accruing scorecards. Never `NEXT_PUBLIC_`. |
 | `CACHE_TELEMETRY` | `lib/telemetry.ts` (server-only) | Both | Set to `off` to suppress all telemetry. Default on — emits one JSON line per event via `console.info` (picked up by Cloudflare Workers Logs / Docker stdout) and additionally writes to R2 on Cloudflare when the `TELEMETRY` binding is bound. Never `NEXT_PUBLIC_`. |
-| `TELEMETRY_SAMPLE` | `lib/telemetry-sinks-cf.ts` (Cloudflare only) | Cloudflare only | `all` (default) keeps every event; `signal` keeps only the high-signal ones — pinning decisions (`trulyDone=true`), schema evictions, and stale reads. Use `signal` if R2 PUT volume gets close to the 1M Class A free-tier cap. Never `NEXT_PUBLIC_`. |
+| `TELEMETRY_SAMPLE_<DOMAIN>` | `lib/telemetry-sinks-cf.ts` (Cloudflare only) | Cloudflare only | Per-domain sample rate, value in `[0, 1]`. `1` keeps every event, `0` drops everything, `0.1` keeps 10%. Defaults: diagnostic domains (`cache`, `upstream`, `error`, `ai`, `d1`, `background`) are kept whole; high-volume product domains (`usage`) default to `0.1`. Set e.g. `TELEMETRY_SAMPLE_USAGE=0.05` if R2 PUT volume approaches the 1M Class A free-tier cap. Never `NEXT_PUBLIC_`. |
 | `NEXT_PUBLIC_BUILD_ID` | `components/update-banner.tsx`, `app/api/version/route.ts` | Both | Git SHA baked into the client bundle at Docker build time; powers new-version detection. Auto-injected by `pnpm docker:build`. Unset in `pnpm dev` — version check is skipped. |
 | `REDIS_URL` | `lib/cache-node.ts` | Docker only | `redis://localhost:6379` locally, `rediss://...` for managed Redis. Not needed for CF builds. |
 | `APP_DB_PATH` | `lib/db-sqlite.ts` | Docker only | Path to SQLite database file. Defaults to `./data/shooter-index.db`. Not needed for CF builds. |

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -8,6 +8,7 @@ import { afterResponse } from "@/lib/background-impl";
 import { CACHE_SCHEMA_VERSION } from "@/lib/constants";
 import { parseMatchCacheKey, persistActiveMatchToD1 } from "@/lib/match-data-store";
 import { markUpstreamDegraded } from "@/lib/upstream-status";
+import { upstreamTelemetry, hashVariables, type UpstreamOutcome } from "@/lib/upstream-telemetry";
 
 /**
  * Check if the current request is an admin-authenticated request
@@ -51,6 +52,22 @@ export async function executeQuery<T>(
 
   // Extract the operation name for log context, e.g. "GetMatchScorecards"
   const operationName = query.match(/query\s+(\w+)/)?.[1] ?? "unknown";
+  const varsHash = hashVariables(variables);
+  const startedAt = Date.now();
+
+  const emit = (
+    outcome: UpstreamOutcome,
+    extra: { httpStatus?: number | null; bytes?: number | null; retryAfter?: string | null; errorClass?: string | null } = {},
+  ) => {
+    upstreamTelemetry({
+      op: "graphql-request",
+      operation: operationName,
+      ms: Date.now() - startedAt,
+      outcome,
+      varsHash,
+      ...extra,
+    });
+  };
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), GRAPHQL_TIMEOUT_MS);
@@ -71,9 +88,11 @@ export async function executeQuery<T>(
   } catch (err) {
     clearTimeout(timeout);
     if (err instanceof DOMException && err.name === "AbortError") {
+      emit("timeout", { errorClass: "AbortError" });
       console.error(`[ssi-api] ${operationName} timed out after ${GRAPHQL_TIMEOUT_MS}ms | vars=${JSON.stringify(variables ?? {})}`);
       throw new Error(`Upstream request timed out after ${GRAPHQL_TIMEOUT_MS / 1000}s`);
     }
+    emit("fetch-error", { errorClass: err instanceof Error ? err.name : "unknown" });
     throw err;
   }
   clearTimeout(timeout);
@@ -92,25 +111,37 @@ export async function executeQuery<T>(
     ].filter(Boolean);
     console.error(parts.join(" | "));
 
+    emit("http-error", { httpStatus: response.status, retryAfter });
+
     const clientMsg = retryAfter
       ? `Upstream HTTP ${response.status}: ${response.statusText} (Retry-After: ${retryAfter}s)`
       : `Upstream HTTP ${response.status}: ${response.statusText}`;
     throw new Error(clientMsg);
   }
 
-  const result: GraphQLResponse<T> = await response.json();
+  const bodyText = await response.text();
+  let result: GraphQLResponse<T>;
+  try {
+    result = JSON.parse(bodyText) as GraphQLResponse<T>;
+  } catch (err) {
+    emit("fetch-error", { errorClass: "JSONParseError", bytes: bodyText.length });
+    throw err;
+  }
 
   if (result.errors?.length) {
     const msg = result.errors.map((e) => e.message).join("; ");
     console.error(`[ssi-api] ${operationName} GraphQL error | vars=${JSON.stringify(variables ?? {})} | ${msg}`);
+    emit("graphql-error", { bytes: bodyText.length });
     throw new Error(msg);
   }
 
   if (!result.data) {
     console.error(`[ssi-api] ${operationName} empty response | vars=${JSON.stringify(variables ?? {})}`);
+    emit("empty", { bytes: bodyText.length });
     throw new Error("Empty response from upstream API");
   }
 
+  emit("ok", { httpStatus: response.status, bytes: bodyText.length });
   return result.data;
 }
 

--- a/lib/telemetry-sinks-cf.ts
+++ b/lib/telemetry-sinks-cf.ts
@@ -27,11 +27,13 @@
 // requests in the same isolate share a single PUT.
 //
 // ── Sampling ─────────────────────────────────────────────────────────
-// Controlled by TELEMETRY_SAMPLE env var:
-//   - "all"    (default): keep every event
-//   - "signal":            keep only the events most useful for incident
-//                          response (see shouldSampleSignal below)
-// The sampler is a pure function — easy to extend with new rules.
+// Per-domain sample rate, controlled by env vars TELEMETRY_SAMPLE_<DOMAIN>
+// (a number between 0 and 1, e.g. 0.1 = keep 10%). Defaults below favour
+// "keep all" for low-volume diagnostic domains and tighter sampling for
+// high-volume product domains.
+//
+// Adding a new domain: pick a sensible default in DEFAULT_RATES below.
+// Tightening one in production: set TELEMETRY_SAMPLE_<DOMAIN>=0.1 (or 0).
 
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { afterResponse } from "@/lib/background-impl";
@@ -44,7 +46,32 @@ interface CFEnvWithTelemetry {
   TELEMETRY?: R2Bucket;
 }
 
-const SAMPLE_MODE = (process.env.TELEMETRY_SAMPLE ?? "all").toLowerCase();
+// Default sample rates per domain. 1 = keep all; 0 = drop all; 0.1 = 10%.
+// Override per domain via TELEMETRY_SAMPLE_<DOMAIN>=<number>.
+const DEFAULT_RATES: Record<string, number> = {
+  // Diagnostic domains — kept whole. Low volume, high signal.
+  cache: 1,
+  upstream: 1,
+  error: 1,
+  ai: 1,
+  d1: 1,
+  background: 1,
+  // Product analytics — high volume, sample heavily by default.
+  usage: 0.1,
+};
+
+// Catch-all for domains not listed above.
+const FALLBACK_RATE = 1;
+
+function getDomainRate(domain: string): number {
+  const envKey = `TELEMETRY_SAMPLE_${domain.toUpperCase()}`;
+  const raw = process.env[envKey];
+  if (raw != null) {
+    const n = parseFloat(raw);
+    if (!isNaN(n)) return Math.max(0, Math.min(1, n));
+  }
+  return DEFAULT_RATES[domain] ?? FALLBACK_RATE;
+}
 
 const buffer: EnrichedEvent[] = [];
 let flushScheduled = false;
@@ -94,22 +121,13 @@ function makeObjectKey(now: Date): string {
 }
 
 function keepEvent(ev: EnrichedEvent): boolean {
-  if (SAMPLE_MODE === "all") return true;
-  if (SAMPLE_MODE === "signal") return shouldSampleSignal(ev);
-  return true;
-}
-
-// High-signal events — the ones that pay off when reading historical logs
-// to diagnose a sync incident. Other events get dropped under SAMPLE=signal.
-function shouldSampleSignal(ev: EnrichedEvent): boolean {
-  if (ev.domain !== "cache") return true; // future domains pass through
-  if (ev.op === "match-ttl-decision" && ev.trulyDone === true) return true;
-  if (ev.op === "match-cache-schema-evict") return true;
-  if (ev.op === "match-cache-read" && ev.stale === true) return true;
-  return false;
+  const rate = getDomainRate(ev.domain);
+  if (rate >= 1) return true;
+  if (rate <= 0) return false;
+  return Math.random() < rate;
 }
 
 export const extraSinks: TelemetrySink[] = [r2Sink];
 
 // Test-only — exported for unit tests of the sampler.
-export const _internal = { keepEvent, shouldSampleSignal, makeObjectKey };
+export const _internal = { keepEvent, getDomainRate, makeObjectKey, DEFAULT_RATES };

--- a/lib/upstream-telemetry.ts
+++ b/lib/upstream-telemetry.ts
@@ -1,0 +1,58 @@
+// Server-only — never import from client components.
+//
+// Typed helper for the "upstream" telemetry domain. Records every SSI
+// GraphQL call (executeQuery in lib/graphql.ts). Useful for:
+//   - tracing slow / failing queries to a specific operation + variables
+//   - measuring upstream latency p95 over time
+//   - correlating user-visible errors with upstream HTTP status codes
+//
+// Field guide:
+//   operation   — GraphQL operation name (GetMatch, GetMatchScorecards, ...)
+//   ms          — wall-clock duration of the fetch
+//   outcome     — "ok" | "http-error" | "graphql-error" | "timeout" | "empty" | "fetch-error"
+//   httpStatus  — set when outcome === "http-error"
+//   bytes       — response body size (only on outcome === "ok")
+//   varsHash    — short hash of the variables JSON, lets you correlate
+//                 repeated calls without logging raw IDs
+//   retryAfter  — Retry-After header echoed back by the upstream
+
+import { telemetry } from "@/lib/telemetry";
+
+export type UpstreamOutcome =
+  | "ok"
+  | "http-error"
+  | "graphql-error"
+  | "timeout"
+  | "empty"
+  | "fetch-error";
+
+export interface UpstreamEvent {
+  op: "graphql-request";
+  operation: string;
+  ms: number;
+  outcome: UpstreamOutcome;
+  httpStatus?: number | null;
+  bytes?: number | null;
+  varsHash?: string | null;
+  retryAfter?: string | null;
+  /** Short error class — never the full message (avoids leaking PII). */
+  errorClass?: string | null;
+}
+
+export function upstreamTelemetry(ev: UpstreamEvent): void {
+  telemetry({ domain: "upstream", ...ev });
+}
+
+/**
+ * Stable short hash for variables — DJB2, mod 2^32, hex-encoded. Not crypto;
+ * just enough to group repeated calls in telemetry without leaking raw IDs.
+ */
+export function hashVariables(vars: Record<string, unknown> | undefined): string {
+  if (!vars) return "0";
+  const s = JSON.stringify(vars);
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) + h + s.charCodeAt(i)) >>> 0;
+  }
+  return h.toString(16);
+}

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -70,40 +70,62 @@ describe("telemetry core", () => {
   });
 });
 
-describe("R2 sampler (signal mode)", () => {
-  const { shouldSampleSignal } = _internal;
+describe("per-domain sampling", () => {
+  const { getDomainRate, keepEvent, DEFAULT_RATES } = _internal;
+  const ORIG_ENV = { ...process.env };
 
-  function ev(fields: Partial<EnrichedEvent> & { domain: string; op: string }): EnrichedEvent {
-    return { ts: "2026-04-28T00:00:00.000Z", ...fields } as EnrichedEvent;
+  function ev(domain: string): EnrichedEvent {
+    return { ts: "2026-04-28T00:00:00.000Z", domain, op: "test" } as EnrichedEvent;
   }
 
-  it("keeps trulyDone ttl-decisions", () => {
-    expect(
-      shouldSampleSignal(ev({ domain: "cache", op: "match-ttl-decision", trulyDone: true })),
-    ).toBe(true);
+  afterEach(() => {
+    process.env = { ...ORIG_ENV };
   });
 
-  it("drops trulyDone=false ttl-decisions", () => {
-    expect(
-      shouldSampleSignal(ev({ domain: "cache", op: "match-ttl-decision", trulyDone: false })),
-    ).toBe(false);
+  it("uses DEFAULT_RATES when no env override is set", () => {
+    delete process.env.TELEMETRY_SAMPLE_CACHE;
+    expect(getDomainRate("cache")).toBe(DEFAULT_RATES.cache);
+    expect(getDomainRate("usage")).toBe(DEFAULT_RATES.usage);
   });
 
-  it("keeps schema-evict events unconditionally", () => {
-    expect(shouldSampleSignal(ev({ domain: "cache", op: "match-cache-schema-evict" }))).toBe(true);
+  it("env override wins over the default", () => {
+    process.env.TELEMETRY_SAMPLE_USAGE = "0.5";
+    expect(getDomainRate("usage")).toBe(0.5);
   });
 
-  it("keeps stale reads, drops fresh reads", () => {
-    expect(
-      shouldSampleSignal(ev({ domain: "cache", op: "match-cache-read", stale: true })),
-    ).toBe(true);
-    expect(
-      shouldSampleSignal(ev({ domain: "cache", op: "match-cache-read", stale: false })),
-    ).toBe(false);
+  it("clamps env override to [0, 1]", () => {
+    process.env.TELEMETRY_SAMPLE_CACHE = "5";
+    expect(getDomainRate("cache")).toBe(1);
+    process.env.TELEMETRY_SAMPLE_CACHE = "-1";
+    expect(getDomainRate("cache")).toBe(0);
   });
 
-  it("passes future non-cache domains through", () => {
-    expect(shouldSampleSignal(ev({ domain: "ai", op: "rate-limit" }))).toBe(true);
+  it("falls back to 1 for unknown domains with no env override", () => {
+    delete process.env.TELEMETRY_SAMPLE_FOOBAR;
+    expect(getDomainRate("foobar")).toBe(1);
+  });
+
+  it("rate=1 keeps every event", () => {
+    process.env.TELEMETRY_SAMPLE_CACHE = "1";
+    for (let i = 0; i < 50; i++) expect(keepEvent(ev("cache"))).toBe(true);
+  });
+
+  it("rate=0 drops every event", () => {
+    process.env.TELEMETRY_SAMPLE_USAGE = "0";
+    for (let i = 0; i < 50; i++) expect(keepEvent(ev("usage"))).toBe(false);
+  });
+
+  it("rate=0.5 lands between 30% and 70% over 1000 trials", () => {
+    process.env.TELEMETRY_SAMPLE_USAGE = "0.5";
+    let kept = 0;
+    for (let i = 0; i < 1000; i++) if (keepEvent(ev("usage"))) kept++;
+    expect(kept).toBeGreaterThan(300);
+    expect(kept).toBeLessThan(700);
+  });
+
+  it("invalid env value falls back to default", () => {
+    process.env.TELEMETRY_SAMPLE_CACHE = "not-a-number";
+    expect(getDomainRate("cache")).toBe(DEFAULT_RATES.cache);
   });
 });
 

--- a/tests/unit/upstream-telemetry.test.ts
+++ b/tests/unit/upstream-telemetry.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { _resetTelemetryForTests } from "@/lib/telemetry";
+import { upstreamTelemetry, hashVariables } from "@/lib/upstream-telemetry";
+
+describe("upstreamTelemetry", () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    _resetTelemetryForTests();
+    infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+    _resetTelemetryForTests();
+  });
+
+  it("emits with domain=upstream and op=graphql-request", () => {
+    upstreamTelemetry({
+      op: "graphql-request",
+      operation: "GetMatch",
+      ms: 124,
+      outcome: "ok",
+      httpStatus: 200,
+      bytes: 8421,
+      varsHash: "abc123",
+    });
+    const line = JSON.parse(infoSpy.mock.calls[0][0] as string);
+    expect(line.domain).toBe("upstream");
+    expect(line.op).toBe("graphql-request");
+    expect(line.operation).toBe("GetMatch");
+    expect(line.outcome).toBe("ok");
+    expect(line.ms).toBe(124);
+    expect(line.bytes).toBe(8421);
+  });
+
+  it("supports each outcome variant", () => {
+    const outcomes = ["ok", "http-error", "graphql-error", "timeout", "empty", "fetch-error"] as const;
+    for (const outcome of outcomes) {
+      upstreamTelemetry({ op: "graphql-request", operation: "X", ms: 1, outcome });
+    }
+    expect(infoSpy).toHaveBeenCalledTimes(outcomes.length);
+  });
+});
+
+describe("hashVariables", () => {
+  it("returns '0' for undefined", () => {
+    expect(hashVariables(undefined)).toBe("0");
+  });
+
+  it("is deterministic for identical input", () => {
+    const a = hashVariables({ ct: 22, id: "12345" });
+    const b = hashVariables({ ct: 22, id: "12345" });
+    expect(a).toBe(b);
+  });
+
+  it("differs across distinct inputs (probabilistic)", () => {
+    const a = hashVariables({ ct: 22, id: "12345" });
+    const b = hashVariables({ ct: 22, id: "67890" });
+    expect(a).not.toBe(b);
+  });
+
+  it("returns a hex string", () => {
+    expect(hashVariables({ a: 1 })).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it("is sensitive to key order — JSON.stringify preserves insertion order", () => {
+    // Documented limitation: callers passing the same logical vars in
+    // different orders will get different hashes. That's fine for our use
+    // case because callers always build the variables object the same way.
+    const a = hashVariables({ ct: 22, id: "1" });
+    const b = hashVariables({ id: "1", ct: 22 });
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `lib/upstream-telemetry.ts` and wires every `executeQuery()` SSI GraphQL call to record `operation`, `ms`, `outcome` (`ok`/`http-error`/`graphql-error`/`timeout`/`empty`/`fetch-error`), `httpStatus`, `bytes`, and a short `varsHash`.
- Replaces the (just-merged) `TELEMETRY_SAMPLE=signal` global mode with per-domain sample rates configurable via `TELEMETRY_SAMPLE_<DOMAIN>` env vars (any number in `[0, 1]`, clamped). Defaults: diagnostic domains kept whole, `usage` at 10%.

## Why
- **Upstream telemetry**: when a user reports a slow page or a 502, today there's no historical record of which SSI query was slow or failing. The Skepplanda incident took longer than it should have because we couldn't see upstream latency over the affected window. Now we can.
- **Per-domain sampling**: the previous global `TELEMETRY_SAMPLE` mode was a blunt instrument — the upcoming `usage` domain (page views, feature use) will dwarf everything else, and tightening it shouldn't cost diagnostic visibility on `cache` / `upstream` / `error`.

## Behavioural notes
- `varsHash` is a non-crypto DJB2 over `JSON.stringify(variables)`. It lets you correlate repeated calls in R2 without logging raw match IDs. Documented limitation: sensitive to key order — fine because callers always build `variables` the same way.
- One additional `await response.text()` (instead of `response.json()`) so we can record body size. Net cost is one extra `JSON.parse` per upstream call, which is negligible compared to the network round-trip.

## Test plan
- [x] `pnpm -w run typecheck` clean
- [x] `pnpm -w run lint` clean
- [x] `pnpm -w test` — 1510/1510 passing (10 new tests covering sampler env-var handling, rate clamping, statistical sampling, hash properties, outcome variants)
- [ ] After merge: tail staging logs to confirm new `domain:"upstream"` events appear, then list R2 to verify they get persisted alongside `cache` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)