### PR TITLE
feat(skills): /r2-telemetry — fetch + filter R2 NDJSON

### DIFF
--- a/.claude/skills/r2-telemetry/SKILL.md
+++ b/.claude/skills/r2-telemetry/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: r2-telemetry
+description: Fetch and filter SSI Scoreboard telemetry events from R2. Use whenever the user asks to look at cache decisions, upstream latency, errors, or product usage events — questions like "what's the p95 upstream latency this week", "show me match-ttl decisions for match X", "did anyone hit a graphql-error today", "how many people viewed the comparison page yesterday". Triggers on "r2 telemetry", "telemetry", "cache decisions", "upstream errors", "usage events", or when the user wants to inspect operational data flowing into the R2 bucket.
+---
+
+# R2 telemetry
+
+Fetches structured telemetry events from the R2 NDJSON store
+(`ssi-scoreboard-telemetry` / `ssi-scoreboard-telemetry-staging`)
+and returns them as a filtered timeline or grouped count.
+
+The script is the workhorse:
+
+```
+.claude/skills/r2-telemetry/scripts/fetch.py [flags]
+```
+
+It reads the OAuth token from the wrangler config, lists R2 objects
+across the relevant UTC day prefixes, fetches them in parallel, parses
+NDJSON, and applies in-memory filters.
+
+## When to invoke
+
+Use this skill when the user wants to inspect production or staging
+telemetry. Examples:
+
+- "what's the p95 latency for `GetMatchScorecards` over the past day"
+- "show me everything that touched match 22157 in the last 6 hours"
+- "are there any swallowed errors in the shooter dashboard path"
+- "how many people opened a comparison this week"
+- "did the cache evict any entries due to schema bumps today"
+
+Don't use it for live tailing — that's `wrangler tail`. R2 captures the
+last 30 days; live tailing only gives you 3.
+
+## Core flags
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--env` | `prod` | `prod` or `staging` |
+| `--since` | `2h` | `2h`, `30m`, `3d`, or `YYYY-MM-DD` |
+| `--until` | now | `YYYY-MM-DD` |
+| `--domain` | none | `cache` / `upstream` / `error` / `usage` |
+| `--op` | none | filter to one op within the domain |
+| `--match` | none | substring match across all fields (a match ID, error class, etc.) |
+| `--shooter` | none | filter to a specific `shooterId` (error events) |
+| `--where` | none | `key=value` clauses, repeatable, comma-separable |
+| `--group-by` | none | comma-separated keys → counts |
+| `--limit` | 200 | max events emitted (timeline/json modes) |
+| `--format` | `timeline` | `timeline` or `json` |
+
+## How to think about the workflow
+
+1. **Pick the smallest scope first.** If the user asked about a specific
+   match, lead with `--match=<id>` before `--domain`. If they asked about
+   errors, lead with `--domain=error`. Narrow scope = faster, cheaper,
+   easier to read.
+
+2. **Default `--format=timeline`** for human-readable output. Switch to
+   `--format=json` only when the user wants raw events or when piping
+   into another tool.
+
+3. **Reach for `--group-by` when the question is "how many" or "which
+   X is most common".** Examples:
+   - `--group-by op,outcome` — distribution of upstream outcomes
+   - `--group-by site,errorClass` — which error sites fire what
+   - `--group-by op,scoringBucket` — usage events split by match state
+
+4. **Time ranges:** `--since` accepts both `2h`-style durations and
+   absolute dates. The script resolves to UTC day prefixes, so a
+   `--since=2h` near midnight UTC will scan two day prefixes.
+
+## Examples
+
+```bash
+# what is the upstream right now
+.claude/skills/r2-telemetry/scripts/fetch.py --domain upstream --since 1h
+
+# any swallowed errors in the last day
+.claude/skills/r2-telemetry/scripts/fetch.py --domain error --since 24h
+
+# matches that pinned today
+.claude/skills/r2-telemetry/scripts/fetch.py --domain cache --op match-ttl-decision \
+  --where trulyDone=true --since 24h
+
+# usage breakdown by op for the past week
+.claude/skills/r2-telemetry/scripts/fetch.py --domain usage --since 7d --group-by op
+
+# everything touching one match in staging
+.claude/skills/r2-telemetry/scripts/fetch.py --env staging --match 22157 --since 6h
+
+# p95-style latency dump for one operation
+.claude/skills/r2-telemetry/scripts/fetch.py --domain upstream --op graphql-request \
+  --where operation=GetMatchScorecards --since 24h --format json \
+  | jq '.ms' | sort -n | awk 'BEGIN{c=0} {a[c++]=$1} END{print a[int(c*0.95)]}'
+```
+
+## Auth
+
+The script reads the wrangler-cached OAuth token from
+`~/Library/Preferences/.wrangler/config/default.toml` (macOS) or
+`~/.config/.wrangler/config/default.toml` (Linux). If you see "Could
+not find oauth_token" or HTTP 401/403:
+
+```bash
+wrangler login
+```
+
+The token rotates roughly hourly. The account ID is hardcoded at the
+top of the script — update it if the repo's CF account ever changes.
+
+## What you'll see
+
+Each NDJSON event has a `domain`, `op`, and `ts`, plus domain-specific
+fields:
+
+| Domain | Key fields |
+|---|---|
+| `cache` | `matchKey`, `trulyDone`, `ttl`, `scoringPct`, `daysSince`, `status`, `resultsPublished` |
+| `upstream` | `operation`, `outcome` (ok/http-error/timeout/graphql-error/empty/fetch-error), `ms`, `httpStatus`, `bytes`, `varsHash` |
+| `error` | `site`, `errorClass`, `errorMsg` (≤200 chars), optional `matchKey`/`shooterId`/`ct`/`matchId` |
+| `usage` | `op` (match-view/comparison/search/shooter-dashboard-view/og-render) plus per-op buckets |
+
+Privacy guarantees enforced upstream: no IP, no User-Agent, no shooter
+IDs in `usage`, no raw search query text. See `lib/usage-telemetry.ts`
+for the full contract.
+
+## When the script fails
+
+- **HTTP 401/403** → run `wrangler login`
+- **"Could not find oauth_token"** → same
+- **Empty result** but you expect events → check `--env` (default is
+  prod); also remember R2 lifecycle deletes objects after 30 days
+- **Account ID mismatch** → update `ACCOUNT_ID` constant in `scripts/fetch.py`

--- a/.claude/skills/r2-telemetry/scripts/fetch.py
+++ b/.claude/skills/r2-telemetry/scripts/fetch.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""
+Fetch + filter telemetry events from the R2 NDJSON store.
+
+Auth: reads the wrangler-cached OAuth token and account ID. Run
+`wrangler login` first if the token has expired.
+
+Usage examples (see argparse below for the full set):
+
+    # last 2 hours, all domains
+    fetch.py --since 2h
+
+    # last 24 hours, only upstream errors
+    fetch.py --since 24h --domain upstream --where outcome=http-error
+
+    # everything that mentions match 22157 in the last 3 days
+    fetch.py --since 3d --match 22157
+
+    # group usage events by op + level
+    fetch.py --since 7d --domain usage --group-by op,level
+
+    # timeline view (one compact line per event, ts-sorted)
+    fetch.py --since 2h --match 22157 --format timeline
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+# ── Auth ─────────────────────────────────────────────────────────────
+
+WRANGLER_CONFIG_CANDIDATES = [
+    Path.home() / "Library/Preferences/.wrangler/config/default.toml",  # macOS
+    Path.home() / ".config/.wrangler/config/default.toml",              # Linux
+    Path.home() / ".wrangler/config/default.toml",                      # legacy
+]
+
+# This account ID is specific to this repo's CF account. Run
+# `wrangler whoami` to verify if you're hitting auth errors after
+# switching accounts.
+ACCOUNT_ID = "e1854db8e2a989281305b1b229319c31"
+
+BUCKETS = {
+    "prod": "ssi-scoreboard-telemetry",
+    "staging": "ssi-scoreboard-telemetry-staging",
+}
+
+
+def read_oauth_token() -> str:
+    for path in WRANGLER_CONFIG_CANDIDATES:
+        if path.is_file():
+            for line in path.read_text().splitlines():
+                m = re.match(r'^oauth_token\s*=\s*"([^"]+)"', line)
+                if m:
+                    return m.group(1)
+    sys.exit(
+        "Could not find oauth_token in wrangler config. "
+        "Run `wrangler login` first."
+    )
+
+
+# ── Time-range expansion ────────────────────────────────────────────
+
+DURATION_RE = re.compile(r"^(\d+)(m|h|d)$")
+
+
+def parse_since(raw: str, now: datetime) -> datetime:
+    """Accept '2h', '30m', '3d', or an ISO date 'YYYY-MM-DD'."""
+    m = DURATION_RE.match(raw)
+    if m:
+        n, unit = int(m.group(1)), m.group(2)
+        delta = {"m": "minutes", "h": "hours", "d": "days"}[unit]
+        return now - timedelta(**{delta: n})
+    try:
+        return datetime.strptime(raw, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    except ValueError:
+        sys.exit(f"--since must be like '2h', '3d', or 'YYYY-MM-DD' (got {raw!r})")
+
+
+def day_prefixes(since: datetime, until: datetime) -> list[str]:
+    """UTC day strings from `since` (inclusive) to `until` (inclusive)."""
+    days: list[str] = []
+    d = since.replace(hour=0, minute=0, second=0, microsecond=0)
+    while d.date() <= until.date():
+        days.append(d.strftime("%Y-%m-%d"))
+        d += timedelta(days=1)
+    return days
+
+
+# ── R2 REST API ─────────────────────────────────────────────────────
+
+
+def cf_get(path: str, token: str, accept_404: bool = False) -> bytes | None:
+    url = f"https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}{path}"
+    req = Request(url, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urlopen(req, timeout=30) as r:
+            return r.read()
+    except HTTPError as e:
+        if accept_404 and e.code == 404:
+            return None
+        msg = e.read().decode("utf-8", errors="replace")[:300]
+        sys.exit(f"HTTP {e.code} on {path}: {msg}")
+    except URLError as e:
+        sys.exit(f"Network error on {path}: {e}")
+
+
+def list_objects(bucket: str, prefix: str, token: str) -> list[str]:
+    """Return all object keys under `prefix` for the bucket. Paginates."""
+    keys: list[str] = []
+    cursor = ""
+    while True:
+        path = f"/r2/buckets/{bucket}/objects?prefix={quote(prefix)}&per_page=1000"
+        if cursor:
+            path += f"&cursor={quote(cursor)}"
+        body = cf_get(path, token)
+        if body is None:
+            break
+        data = json.loads(body)
+        result = data.get("result") or []
+        for obj in result:
+            keys.append(obj["key"])
+        cursor = data.get("result_info", {}).get("cursor", "")
+        if not cursor or len(result) < 1000:
+            break
+    return keys
+
+
+def fetch_object(bucket: str, key: str, token: str) -> str:
+    """Return the NDJSON body of one object."""
+    body = cf_get(
+        f"/r2/buckets/{bucket}/objects/{quote(key, safe='/')}", token
+    )
+    return body.decode("utf-8") if body else ""
+
+
+# ── Filtering ───────────────────────────────────────────────────────
+
+WHERE_RE = re.compile(r"^([^=!]+)(==|=|!=)(.*)$")
+
+
+def parse_where(raw: list[str]) -> list[tuple[str, str, str]]:
+    """Parse `--where key=value,key=value` into (key, op, value) tuples."""
+    out: list[tuple[str, str, str]] = []
+    for chunk in raw:
+        for clause in chunk.split(","):
+            clause = clause.strip()
+            if not clause:
+                continue
+            m = WHERE_RE.match(clause)
+            if not m:
+                sys.exit(f"--where clause must be key=value, got {clause!r}")
+            out.append((m.group(1).strip(), m.group(2), m.group(3).strip()))
+    return out
+
+
+def matches_clause(ev: dict[str, Any], key: str, op: str, value: str) -> bool:
+    raw = ev.get(key)
+    raw_str = str(raw).lower() if raw is not None else ""
+    target = value.lower()
+    if op == "!=":
+        return raw_str != target
+    # treat = and == identically — common typo proofing
+    return raw_str == target
+
+
+def passes_filters(
+    ev: dict[str, Any],
+    domain: str | None,
+    op: str | None,
+    where: list[tuple[str, str, str]],
+    match_substr: str | None,
+    shooter_id: int | None,
+    since_ts: datetime,
+    until_ts: datetime,
+) -> bool:
+    if domain and ev.get("domain") != domain:
+        return False
+    if op and ev.get("op") != op:
+        return False
+    if match_substr is not None:
+        # match anywhere across any string-valued field
+        joined = " ".join(str(v) for v in ev.values() if isinstance(v, (str, int, float)))
+        if match_substr not in joined:
+            return False
+    if shooter_id is not None and ev.get("shooterId") != shooter_id:
+        return False
+    if where:
+        for k, o, v in where:
+            if not matches_clause(ev, k, o, v):
+                return False
+    ts = ev.get("ts")
+    if isinstance(ts, str):
+        try:
+            ev_ts = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            if ev_ts < since_ts or ev_ts > until_ts:
+                return False
+        except ValueError:
+            pass
+    return True
+
+
+# ── Output ──────────────────────────────────────────────────────────
+
+
+def render_timeline(events: list[dict[str, Any]]) -> None:
+    events.sort(key=lambda e: e.get("ts", ""))
+    for ev in events:
+        ts = ev.get("ts", "")[:19]  # YYYY-MM-DDTHH:MM:SS
+        dom = ev.get("domain", "?")
+        op = ev.get("op", "?")
+        # Compact summary of the most useful 2-3 fields per domain
+        summary_keys = SUMMARY_KEYS.get(dom, [])
+        bits = [f"{k}={ev.get(k)!s}" for k in summary_keys if k in ev]
+        print(f"{ts}Z  {dom:9}  {op:30}  {' '.join(bits)}")
+
+
+SUMMARY_KEYS = {
+    "cache": ["matchKey", "trulyDone", "ttl", "scoringPct"],
+    "upstream": ["operation", "outcome", "ms", "httpStatus"],
+    "error": ["site", "errorClass", "errorMsg"],
+    "usage": ["op", "ct", "level", "scoringBucket", "nCompetitors"],
+}
+
+
+def render_group(events: list[dict[str, Any]], keys: list[str]) -> None:
+    counts: dict[tuple[str, ...], int] = {}
+    for ev in events:
+        k = tuple(str(ev.get(key, "<none>")) for key in keys)
+        counts[k] = counts.get(k, 0) + 1
+    rows = sorted(counts.items(), key=lambda kv: -kv[1])
+    widths = [max(len(keys[i]), max((len(k[i]) for k, _ in rows), default=0)) for i in range(len(keys))]
+    header = "  ".join(k.ljust(w) for k, w in zip(keys, widths)) + "  count"
+    print(header)
+    print("-" * len(header))
+    for k, c in rows:
+        line = "  ".join(v.ljust(w) for v, w in zip(k, widths)) + f"  {c}"
+        print(line)
+    print(f"\n{sum(c for _, c in rows)} events across {len(rows)} groups")
+
+
+# ── Main ────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--env", choices=("prod", "staging"), default="prod")
+    p.add_argument("--since", default="2h", help="duration like 2h/3d or YYYY-MM-DD (default 2h)")
+    p.add_argument("--until", default=None, help="YYYY-MM-DD (default now)")
+    p.add_argument("--domain", default=None, help="cache | upstream | error | usage")
+    p.add_argument("--op", default=None, help="filter to a specific op within the domain")
+    p.add_argument("--match", default=None, help="substring match across all fields (e.g. a match ID)")
+    p.add_argument("--shooter", type=int, default=None, help="filter to a specific shooterId")
+    p.add_argument("--where", action="append", default=[], help="key=value (repeatable, comma-separable)")
+    p.add_argument("--group-by", default=None, help="comma-separated keys to group + count")
+    p.add_argument("--limit", type=int, default=200, help="max events to emit (default 200)")
+    p.add_argument("--format", choices=("json", "timeline"), default="timeline")
+    args = p.parse_args()
+
+    if args.env not in BUCKETS:
+        sys.exit(f"--env must be one of: {', '.join(BUCKETS)}")
+    bucket = BUCKETS[args.env]
+
+    now = datetime.now(timezone.utc)
+    since_ts = parse_since(args.since, now)
+    until_ts = (
+        datetime.strptime(args.until, "%Y-%m-%d").replace(tzinfo=timezone.utc) + timedelta(days=1)
+        if args.until
+        else now
+    )
+    if since_ts >= until_ts:
+        sys.exit("--since is after --until")
+
+    token = read_oauth_token()
+    where = parse_where(args.where)
+
+    # Discover objects across the relevant day prefixes.
+    days = day_prefixes(since_ts, until_ts)
+    print(f"# scanning {len(days)} day prefix(es) in bucket {bucket}", file=sys.stderr)
+    keys: list[str] = []
+    for d in days:
+        keys.extend(list_objects(bucket, f"cache-telemetry/{d}/", token))
+    print(f"# {len(keys)} R2 object(s)", file=sys.stderr)
+
+    # Fetch in parallel.
+    events: list[dict[str, Any]] = []
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        for body in pool.map(lambda k: fetch_object(bucket, k, token), keys):
+            for line in body.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if passes_filters(ev, args.domain, args.op, where, args.match, args.shooter, since_ts, until_ts):
+                    events.append(ev)
+
+    print(f"# {len(events)} event(s) after filtering", file=sys.stderr)
+
+    if args.group_by:
+        keys = [k.strip() for k in args.group_by.split(",") if k.strip()]
+        render_group(events, keys)
+        return
+
+    # Apply limit (most recent first when applicable)
+    events.sort(key=lambda e: e.get("ts", ""), reverse=True)
+    events = events[: args.limit]
+
+    if args.format == "timeline":
+        render_timeline(events)
+    else:
+        for ev in events:
+            print(json.dumps(ev))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds a repo-local Claude Code skill that wraps the curl + REST API workflow for reading the `cache-telemetry` R2 bucket. The skill is checked in here (not global) because it encodes this repo's specific bucket layout, account ID, and event schemas.

## What it does
- Reads wrangler-cached OAuth token
- Lists R2 objects across the relevant UTC day prefixes (handles range expansion + pagination)
- Fetches in parallel (8 workers)
- Filters in memory: `--domain`, `--op`, `--where key=value`, `--match <substring>`, `--shooter <id>`, `--since`, `--until`
- Outputs `timeline` (compact, ts-sorted) or `json` (raw NDJSON) or grouped counts via `--group-by`

## Why a skill (vs just the curl recipe)
- Date-range expansion + R2 listing pagination is annoying to redo every time
- `--group-by` and `--where` filters are not one-liners in jq
- Auth + path resolution can be encoded once
- Most importantly: I can reach for `/r2-telemetry` for both debugging questions ("did anyone hit a graphql-error today") and product questions ("how many people opened a comparison this week") without switching tools

## Verified end-to-end against staging
```
$ .claude/skills/r2-telemetry/scripts/fetch.py --env staging --since 24h --domain cache --group-by op
op                  count
-------------------------
match-ttl-decision  27
27 events across 1 groups
```

## What's next
This is the foundation for `/incident` (separate PR). That skill will compose `/r2-telemetry` with SSI MCP ground-truth lookups + the admin cache health endpoint to lay out a full timeline for "data stuck"-type investigations. Per earlier discussion: `/incident` will gather and lay out, not pre-analyze.

## Test plan
- [x] Smoke-tested against staging — 44 R2 objects, all filter modes work
- [x] `--group-by` aggregation correct
- [x] `--match <substring>` matches both string and numeric fields
- [x] `--format json` outputs raw NDJSON
- [x] Auth-failure path: clear error message pointing at `wrangler login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)