### PR TITLE
feat(skills): /incident — gather telemetry by match or shooter

### DIFF
--- a/.claude/skills/incident/SKILL.md
+++ b/.claude/skills/incident/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: incident
+description: Investigate "data stuck", "match shows wrong scores", "shooter dashboard broken" reports by gathering all telemetry that touched a specific match or shooter into one timeline. Use when the user describes a user-reported bug tied to a specific match ID or shooter — questions like "match 22157 shows stale data", "why isn't the dashboard updating for shooter 12345", "what happened to this match yesterday", "diagnose this incident". Triggers on "incident", "diagnose", "investigate", "data stuck", "stale data", "wrong scores", or when the user shares a match URL alongside a complaint.
+---
+
+# Incident gather
+
+Lays out a chronological timeline of every telemetry event that touched a
+specific match or shooter, plus a summary of shape (event counts, upstream
+outcomes, error sites, pinning rate). **Gather mode only — no analysis,
+no flagging.** The goal is to surface the data so you can spot the
+divergence point yourself.
+
+## How to drive this
+
+1. **Run the gather script** with the match ID or shooter ID:
+
+   ```bash
+   .claude/skills/incident/scripts/gather.py --match 22157 --since 24h
+   .claude/skills/incident/scripts/gather.py --shooter 12345 --since 7d
+   .claude/skills/incident/scripts/gather.py --env staging --match 22157
+   ```
+
+2. **Read the timeline.** Scan the events in chronological order looking for:
+   - **Cache TTL decisions** — when did `trulyDone` flip true? Did it flip
+     too early relative to scoring progress?
+   - **Upstream outcomes** — any `http-error`, `timeout`, `graphql-error`?
+     What was the latency trend?
+   - **Error events** — any `domain=error` entries near the pivot point?
+     Their `site` field tells you which layer failed.
+   - **Gaps** — long stretches with no events can mean SSI was unreachable,
+     or the cache was permanently pinned and stopped refreshing.
+
+3. **Cross-reference with ground truth.** The R2 telemetry tells you what
+   *we* did. To know what *should* be true, query the SSI MCP server:
+
+   ```
+   mcp__claude_ai_SSI_Scoreboard__get_match(ct=22, id="22157")
+   ```
+
+   Compare the live SSI `match_status`, `results_status`, `scoring_completed`
+   against the most recent cache decision in the timeline. If they diverge,
+   the bug is in our refresh path.
+
+4. **For recent incidents (< 3 days)**, supplement with `wrangler tail`
+   for the live picture if needed:
+
+   ```bash
+   wrangler tail ssi-scoreboard --format json | grep -i 22157
+   ```
+
+   R2 has the historical record; tail catches anything that hasn't been
+   flushed to R2 yet (per-isolate batching means very recent events may
+   not be in R2 yet).
+
+## What gather.py does
+
+Calls `r2-telemetry/scripts/fetch.py` with appropriate filters, parses the
+NDJSON output, prints a summary header, then a per-event timeline.
+
+The summary surfaces shape information that's faster to read than scanning
+hundreds of timeline lines:
+- Total event count
+- Domain breakdown (`{cache: 18, upstream: 4, error: 0, usage: 7}`)
+- Upstream outcome breakdown (`{ok: 4}` vs `{ok: 2, timeout: 1, http-error: 1}`)
+- Cache pinning rate (`5/18 decisions pinned (trulyDone=true)`)
+- Error sites if any (`{shooter.dashboard-cache-read: 2}`)
+
+## Common patterns
+
+### "Match shows old scores" / "stale data"
+- Look for `match-ttl-decision` with `trulyDone=true` and `ttl=null`
+  (permanent pin). Compare its `scoringPct` to ground truth — if SSI
+  shows higher progress, the pin happened too early.
+- Look for `match-cache-schema-evict` events; recent schema bumps would
+  re-fetch on next request.
+- Skepplanda Apr 2026 was this exact pattern — match pinned at high
+  scoring before all squads finished.
+
+### "Match page won't load" / 502s
+- Filter to `--domain upstream` first. Look for `outcome=timeout` or
+  `outcome=http-error` clusters.
+- Cross-reference `httpStatus` for 5xx (SSI down) vs 4xx (auth/bad
+  request). Look at the `errorClass` on related `error` events.
+
+### "Shooter dashboard empty / wrong stats"
+- Use `--shooter <id>` (filters on `shooterId` field — only `error`
+  events have it directly).
+- Check for `error` events with sites starting `shooter.` or `backfill.`.
+- The dashboard rebuilds from cached match data; missing matches in the
+  shooter index typically point to `shooter-index.suppression-load`
+  failures or recent matches that never got indexed.
+
+### "Comparison shows null scoring"
+- Filter to `--match <id>` and look at `gql:GetMatchScorecards:` events.
+- Compare last successful upstream `bytes` against the typical size for
+  matches of that scale (5-10MB scorecards is normal for L3+).
+
+## When the data isn't enough
+
+Some incidents are client-side and won't show in R2:
+- Browser localStorage pointing at stale competitor IDs
+- Client-side TanStack Query staleness
+- A specific browser/OS rendering bug
+
+If `gather.py` shows nothing surprising and the user still sees the
+problem, ask them:
+- to hard-reload (Cmd+Shift+R) and report whether anything changed
+- for a screenshot — sometimes "no scoring data" means a chart panel
+  collapsed, not a missing API response
+- to check the DevTools network tab for failed `/api/*` requests
+
+## Auth
+
+Same as `r2-telemetry`: reads OAuth from wrangler config. Run
+`wrangler login` if you see HTTP 401/403.

--- a/.claude/skills/incident/scripts/gather.py
+++ b/.claude/skills/incident/scripts/gather.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Gather everything that touched a match (or shooter) into one annotated
+timeline. Calls the r2-telemetry fetch.py under the hood, then layers
+the events from each domain on top of each other so you can read the
+divergence point chronologically.
+
+Output is gather-mode by design — no analysis, no flagging. The
+operator reads the timeline and decides where the bug lives.
+
+Usage:
+    gather.py --match 22157 [--since 24h] [--env prod|staging]
+    gather.py --shooter 12345 [--since 7d]
+
+Reads OAuth from wrangler config (same as fetch.py).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Path to the sibling skill's fetch script.
+FETCH_PY = (
+    Path(__file__).resolve().parent.parent.parent / "r2-telemetry" / "scripts" / "fetch.py"
+)
+
+
+def run_fetch(args: list[str]) -> list[dict]:
+    """Run fetch.py with --format json and return the parsed events."""
+    cmd = [str(FETCH_PY), "--format", "json", "--limit", "10000", *args]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"# fetch.py failed: {result.stderr.strip()}", file=sys.stderr)
+        return []
+    events: list[dict] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            pass
+    return events
+
+
+def fmt_event(ev: dict) -> str:
+    ts = ev.get("ts", "")[:19]
+    domain = ev.get("domain", "?")
+    op = ev.get("op", "?")
+    if domain == "cache":
+        return (
+            f"{ts}Z  cache     {op:24}  "
+            f"trulyDone={ev.get('trulyDone')!s:5}  ttl={ev.get('ttl')!s:5}  "
+            f"scoringPct={ev.get('scoringPct')}  status={ev.get('status')}  "
+            f"resultsPublished={ev.get('resultsPublished')}"
+        )
+    if domain == "upstream":
+        return (
+            f"{ts}Z  upstream  {ev.get('operation', '?'):24}  "
+            f"outcome={ev.get('outcome')}  ms={ev.get('ms')}  "
+            f"http={ev.get('httpStatus')}  bytes={ev.get('bytes')}"
+        )
+    if domain == "error":
+        msg = (ev.get("errorMsg") or "")[:80]
+        return (
+            f"{ts}Z  error     {ev.get('site', '?'):24}  "
+            f"class={ev.get('errorClass')}  msg={msg!r}"
+        )
+    if domain == "usage":
+        bits = []
+        for k in ("ct", "level", "scoringBucket", "mode", "nCompetitors", "variant", "kind", "queryLength", "resultBucket", "matchCountBucket", "cacheHit"):
+            if k in ev:
+                bits.append(f"{k}={ev[k]}")
+        return f"{ts}Z  usage     {op:24}  {' '.join(bits)}"
+    return f"{ts}Z  {domain:9}  {op}  {json.dumps({k: v for k, v in ev.items() if k not in ('ts', 'domain', 'op')})}"
+
+
+def render_timeline(events: list[dict]) -> None:
+    events.sort(key=lambda e: e.get("ts", ""))
+    for ev in events:
+        print(fmt_event(ev))
+
+
+def render_summary(events: list[dict], scope: str) -> None:
+    """Quick numeric summary at the top so the operator sees shape first."""
+    by_domain: dict[str, int] = {}
+    by_outcome: dict[str, int] = {}
+    error_sites: dict[str, int] = {}
+    cache_pinned = 0
+    cache_total = 0
+    for ev in events:
+        d = ev.get("domain", "?")
+        by_domain[d] = by_domain.get(d, 0) + 1
+        if d == "upstream":
+            by_outcome[ev.get("outcome", "?")] = by_outcome.get(ev.get("outcome", "?"), 0) + 1
+        if d == "error":
+            error_sites[ev.get("site", "?")] = error_sites.get(ev.get("site", "?"), 0) + 1
+        if d == "cache" and ev.get("op") == "match-ttl-decision":
+            cache_total += 1
+            if ev.get("trulyDone"):
+                cache_pinned += 1
+    print(f"# === incident summary for {scope} ===")
+    print(f"# total events: {len(events)}")
+    print(f"# by domain:    {dict(sorted(by_domain.items()))}")
+    if by_outcome:
+        print(f"# upstream:     {dict(sorted(by_outcome.items()))}")
+    if cache_total:
+        print(f"# cache TTL:    {cache_pinned}/{cache_total} decisions pinned (trulyDone=true)")
+    if error_sites:
+        print(f"# error sites:  {dict(sorted(error_sites.items()))}")
+    print("#")
+    print("# === timeline ===")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    grp = p.add_mutually_exclusive_group(required=True)
+    grp.add_argument("--match", help="match ID — substring searched across all event fields")
+    grp.add_argument("--shooter", type=int, help="shooter ID — exact match on shooterId")
+    p.add_argument("--env", choices=("prod", "staging"), default="prod")
+    p.add_argument("--since", default="24h", help="duration (2h/3d) or YYYY-MM-DD; default 24h")
+    p.add_argument("--until", default=None)
+    args = p.parse_args()
+
+    if not FETCH_PY.is_file():
+        sys.exit(f"Could not find r2-telemetry fetch.py at {FETCH_PY}")
+
+    base_args = ["--env", args.env, "--since", args.since]
+    if args.until:
+        base_args.extend(["--until", args.until])
+
+    if args.match:
+        scope = f"match {args.match}"
+        events = run_fetch([*base_args, "--match", args.match])
+    else:
+        scope = f"shooter {args.shooter}"
+        # error events have shooterId; cache/upstream/usage do not. Two passes:
+        #   1) error events filtered by shooterId
+        #   2) match-scoped events for any matchKey that appeared next to those errors
+        # Keeping it simple: just the direct shooter events for now.
+        events = run_fetch([*base_args, "--shooter", str(args.shooter)])
+
+    if not events:
+        print(f"# no events found for {scope} in the past {args.since} ({args.env})")
+        print("# tips:")
+        print("#   - widen --since (R2 retains 30 days)")
+        print("#   - check --env (default is prod; try staging)")
+        print("#   - run: wrangler login   (token rotates ~hourly)")
+        return
+
+    print(f"# generated at {datetime.now(timezone.utc).isoformat()}")
+    render_summary(events, scope)
+    render_timeline(events)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds a repo-local Claude Code skill that composes `/r2-telemetry` to lay out a chronological timeline of every telemetry event touching a specific match or shooter, with a shape summary up top.

**Gather mode by design** — no analysis, no heuristic flagging. The operator reads the timeline and decides where the bug lives. Per the call from earlier: \"pre-analysis hides the data behind a heuristic that might miss the real cause.\"

## Output shape
```
# === incident summary for match 22157 ===
# total events: 18
# by domain:    {'cache': 18}
# cache TTL:    18/18 decisions pinned (trulyDone=true)
#
# === timeline ===
2026-04-28T05:26:04Z  cache  match-ttl-decision  trulyDone=True  ttl=None  scoringPct=100  status=cp  resultsPublished=True
...
```

The summary surfaces shape (domain breakdown, upstream outcomes, cache pinning rate, error sites) faster than scanning hundreds of timeline lines.

## SKILL.md guidance
The SKILL.md teaches Claude to:
1. Run `gather.py --match` or `--shooter`
2. Read the timeline looking for divergence points (early pinning, error clusters, gaps)
3. Cross-reference against SSI MCP (`get_match`) for ground truth
4. For recent incidents (< 3 days), supplement with `wrangler tail`

Plus pattern hints for the four most common report shapes:
- \"stale data\" / \"shows old scores\" → look for early-pinned `trulyDone`
- \"502s on match page\" → filter `--domain upstream`, scan outcomes
- \"shooter dashboard empty\" → `--shooter`, check error sites
- \"comparison shows null scoring\" → check `GetMatchScorecards` byte trend

And explicitly notes when telemetry isn't enough — client-side bugs (browser localStorage, TanStack Query staleness, rendering issues) won't show in R2.

## Verified
```
$ .claude/skills/incident/scripts/gather.py --env staging --match 22157 --since 24h
```
Pulled 18 cache events for match 22157, summary + chronological timeline rendered correctly.

## Test plan
- [x] Smoke-tested against staging match 22157 → 18 events, timeline correctly sorted
- [x] Smoke-tested empty match (filter that returns no results) → friendly message + tips
- [x] Both `--match <id>` (substring) and `--shooter <id>` (exact) modes work
- [x] Skill registered in available-skills list

🤖 Generated with [Claude Code](https://claude.com/claude-code)