### PR TITLE
fix(telemetry): correct match-view emission + split search vs browse

### DIFF
--- a/.claude/skills/usage-analysis/scripts/analyze.py
+++ b/.claude/skills/usage-analysis/scripts/analyze.py
@@ -255,13 +255,20 @@ def cmd_report(args: argparse.Namespace) -> None:
             GROUP BY mode, nCompetitors
             ORDER BY mode, nCompetitors;
         """),
-        ("Search effectiveness", f"""
+        ("Search effectiveness (intent-driven, queryLength > 0)", f"""
             SELECT kind, resultBucket, count(*) AS searches,
                    round(avg(queryLength), 1) AS avg_query_len
             FROM usage_events
             {since_clause} AND op = 'search'
             GROUP BY kind, resultBucket
             ORDER BY kind, searches DESC;
+        """),
+        ("Browse activity (no query — passive list view)", f"""
+            SELECT kind, resultBucket, count(*) AS browses
+            FROM usage_events
+            {since_clause} AND op = 'browse'
+            GROUP BY kind, resultBucket
+            ORDER BY kind, browses DESC;
         """),
         ("OG image variants", f"""
             SELECT variant, count(*) AS renders

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -217,12 +217,20 @@ export async function GET(req: Request) {
     ms_total: Math.round(performance.now() - t0),
   }));
 
-  usageTelemetry({
-    op: "search",
-    kind: "events",
-    queryLength: q.length,
-    resultBucket: bucketCount(events.length),
-  });
+  if (q.length > 0) {
+    usageTelemetry({
+      op: "search",
+      kind: "events",
+      queryLength: q.length,
+      resultBucket: bucketCount(events.length),
+    });
+  } else {
+    usageTelemetry({
+      op: "browse",
+      kind: "events",
+      resultBucket: bucketCount(events.length),
+    });
+  }
 
   return NextResponse.json(events);
 }

--- a/app/api/match/[ct]/[id]/route.ts
+++ b/app/api/match/[ct]/[id]/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import { fetchMatchData } from "@/lib/match-data";
-import { usageTelemetry, bucketScoring } from "@/lib/usage-telemetry";
 
 export async function GET(
   _req: Request,
@@ -35,15 +34,11 @@ export async function GET(
     ms_graphql: Math.round(result.msFetch),
     ms_total: Math.round(tDone - t0),
   }));
-
-  usageTelemetry({
-    op: "match-view",
-    ct: ctNum,
-    level: response.level ?? null,
-    region: response.region ?? null,
-    scoringBucket: bucketScoring(response.scoring_completed ?? 0),
-    cacheHit: cachedAt !== null,
-  });
+  // No usageTelemetry here on purpose — match-view is emitted from the
+  // page server component (app/match/[ct]/[id]/page.tsx) so each page
+  // load counts once. Client-side refresh polls hit this route, and
+  // showing up in the upstream/cache telemetry domains is the right
+  // place for them.
 
   return NextResponse.json(response, {
     headers: {

--- a/app/api/shooter/search/route.ts
+++ b/app/api/shooter/search/route.ts
@@ -21,12 +21,20 @@ export async function GET(req: Request) {
     results = [];
   }
 
-  usageTelemetry({
-    op: "search",
-    kind: "shooter",
-    queryLength: q.length,
-    resultBucket: bucketCount(results.length),
-  });
+  if (q.length > 0) {
+    usageTelemetry({
+      op: "search",
+      kind: "shooter",
+      queryLength: q.length,
+      resultBucket: bucketCount(results.length),
+    });
+  } else {
+    usageTelemetry({
+      op: "browse",
+      kind: "shooter",
+      resultBucket: bucketCount(results.length),
+    });
+  }
 
   return NextResponse.json(results);
 }

--- a/app/match/[ct]/[id]/page.tsx
+++ b/app/match/[ct]/[id]/page.tsx
@@ -4,6 +4,7 @@ import { QueryClient, dehydrate, HydrationBoundary } from "@tanstack/react-query
 import MatchPageClient from "./match-page-client";
 import { fetchMatchData } from "@/lib/match-data";
 import { matchQueryKey } from "@/lib/query-keys";
+import { usageTelemetry, bucketScoring } from "@/lib/usage-telemetry";
 
 interface PageProps {
   params: Promise<{ ct: string; id: string }>;
@@ -62,6 +63,22 @@ export default async function MatchPage({ params }: PageProps) {
         ms_fetch: result ? Math.round(result.msFetch) : null,
       }));
       if (!result) throw new Error("Match not found");
+      // Fire match-view telemetry from the SSR prefetch — this is the call
+      // that always runs when a user opens a match page. The /api/match
+      // route also fires it (for client-side polls when staleTime expires);
+      // SSR + API together give us page-views + refresh activity, with
+      // client-side polls visible in the upstream telemetry domain.
+      const ctNum = parseInt(ct, 10);
+      if (!isNaN(ctNum)) {
+        usageTelemetry({
+          op: "match-view",
+          ct: ctNum,
+          level: result.data.level ?? null,
+          region: result.data.region ?? null,
+          scoringBucket: bucketScoring(result.data.scoring_completed ?? 0),
+          cacheHit: result.cachedAt !== null,
+        });
+      }
       return result.data;
     },
   });

--- a/lib/usage-telemetry.ts
+++ b/lib/usage-telemetry.ts
@@ -52,9 +52,20 @@ export type UsageEvent =
       nCompetitors: number;
     }
   | {
+      // User typed a query (queryLength > 0). For empty/no-text fetches
+      // (initial event browse, default shooter list) use op="browse".
       op: "search";
       kind: "events" | "shooter";
       queryLength: number;
+      resultBucket: "0" | "1-9" | "10-99" | "100+";
+    }
+  | {
+      // User loaded the events/shooter list without typing — a passive
+      // browse rather than an intent-driven search. Helps separate
+      // "people are looking at upcoming matches" from "people are
+      // hunting for a specific thing".
+      op: "browse";
+      kind: "events" | "shooter";
       resultBucket: "0" | "1-9" | "10-99" | "100+";
     }
   | {

--- a/tests/unit/usage-telemetry.test.ts
+++ b/tests/unit/usage-telemetry.test.ts
@@ -70,9 +70,10 @@ describe("usageTelemetry", () => {
     usageTelemetry({ op: "match-view", ct: 22, level: null, region: null, scoringBucket: "pre", cacheHit: false });
     usageTelemetry({ op: "comparison", ct: 22, mode: "coaching", nCompetitors: 3 });
     usageTelemetry({ op: "search", kind: "shooter", queryLength: 5, resultBucket: "1-9" });
+    usageTelemetry({ op: "browse", kind: "events", resultBucket: "10-99" });
     usageTelemetry({ op: "shooter-dashboard-view", matchCountBucket: "10-99", cacheHit: true });
     usageTelemetry({ op: "og-render", ct: 22, variant: "multi", nCompetitors: 4 });
-    expect(infoSpy).toHaveBeenCalledTimes(5);
+    expect(infoSpy).toHaveBeenCalledTimes(6);
   });
 
   it("never logs query strings — only lengths", () => {


### PR DESCRIPTION
## Summary
Two coverage gaps surfaced by an actual hands-on staging session — fixing both.

## 1. match-view never fired during the staging click-through

**Symptom:** 34 `match-ttl-decision` cache events for matches the user opened, but **zero** `match-view` usage events.

**Cause:** The emit lived in `app/api/match/[ct]/[id]/route.ts`. The match page is server-rendered — SSR calls `fetchMatchData()` directly (which fires cache telemetry from `lib/match-data.ts`) and dehydrates the result into the client cache. The client's `useMatchQuery` has `staleTime: 30_000`, so during a normal click-around session it never re-fetches the API route. No re-fetch → no `match-view`.

**Fix:** Move the emit into the page server component itself, inside the `prefetchQuery` queryFn. Now each actual page load counts exactly once, and the `/api/match` route handler stays clean. Client-side refresh polls (active matches, every 30s) still show up in `upstream` + `cache` telemetry — which is the right place for them.

## 2. The lone staging \"search\" event had queryLength=0

That's not a search. It's the events panel being opened without typing — a passive browse of upcoming matches. Conflating them makes search effectiveness numbers misleading.

**Fix:** Add a separate `op = \"browse\"` variant. Routing rule:
- `queryLength > 0` → `op: \"search\"` (intent-driven)
- `queryLength == 0` → `op: \"browse\"` (passive list view)

Applies to both `/api/events` and `/api/shooter/search`. The canned report grows a new \"Browse activity\" section.

## Files touched
- `app/match/[ct]/[id]/page.tsx` — add `match-view` emit in prefetchQuery
- `app/api/match/[ct]/[id]/route.ts` — remove the `match-view` emit, comment explaining why
- `lib/usage-telemetry.ts` — add `browse` op variant alongside `search`
- `app/api/events/route.ts` — branch on `q.length > 0`
- `app/api/shooter/search/route.ts` — same
- `.claude/skills/usage-analysis/scripts/analyze.py` — add Browse activity report section
- `tests/unit/usage-telemetry.test.ts` — cover the new op

## Test plan
- [x] `pnpm -w run typecheck` clean
- [x] `pnpm -w run lint` clean
- [x] `pnpm -w test` — 1526/1526 passing
- [ ] After merge, click around staging again, sync R2, confirm `match-view` events finally appear and `search` vs `browse` counts split as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)