### PR TITLE
feat(cache): incremental scorecard delta merge

### DIFF
--- a/.github/workflows/check-ssi-schema.yml
+++ b/.github/workflows/check-ssi-schema.yml
@@ -17,6 +17,10 @@ on:
     # match cycle ramps up Wednesday onwards.
     - cron: '0 6 * * 1'
 
+# Minimal permissions: only need to clone the repo; no write access required.
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-ssi-schema.yml
+++ b/.github/workflows/check-ssi-schema.yml
@@ -1,0 +1,36 @@
+name: Check SSI Schema Drift
+
+# Detects drift between the live SSI GraphQL schema and our snapshot
+# (`scripts/ssi-schema-snapshot.json`). The delta merge in #362 mirrors SSI's
+# scorecard structure, so silent upstream changes can corrupt cached data.
+#
+# Runs weekly + on demand. Failure opens a notification via the workflow's
+# job status (visible in the Actions tab); pair with branch protection or a
+# manual review cadence.
+#
+# Setup: requires `SSI_API_KEY` as a repo secret.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays 06:00 UTC — early enough that drift surfaces before the weekend
+    # match cycle ramps up Wednesday onwards.
+    - cron: '0 6 * * 1'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Compare snapshot vs live SSI schema
+        env:
+          SSI_API_KEY: ${{ secrets.SSI_API_KEY }}
+        run: pnpm check:ssi-schema

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,69 @@ or any other type that is serialised into the **match cache** (Redis/D1) via `ca
 This does **not** apply to AppDatabase schema changes — those are managed independently by
 the SQLite/D1 adapters via `CREATE TABLE IF NOT EXISTS`.
 
+## Delta-merge contract (CRITICAL)
+
+`refreshCachedMatchQuery` no longer just caches SSI responses opaquely — when the match-level
+probe (#361) reports `changed`, the helper attempts an incremental scorecard delta merge (#362)
+via `scorecards(updated_after:)`. We are now **mirroring SSI's data structure** and applying
+upstream changes incrementally, so any SSI schema drift can silently corrupt cached snapshots.
+
+**When changing scorecard fields, ALL of these must be updated together — in the SAME PR:**
+
+1. **`SCORECARD_NODE_FIELDS`** in `lib/graphql.ts` — the shared GraphQL fragment used by both
+   `SCORECARDS_QUERY` (full fetch) and `SCORECARDS_DELTA_QUERY` (delta fetch). Adding the field
+   here automatically threads it through both. Do NOT add a field to one query and not the other.
+2. **`RawScCard`** in `lib/scorecard-data.ts` — the TypeScript shape of a cached scorecard.
+3. **`ScorecardDeltaEntry`** in `lib/graphql.ts` — the delta-payload shape (subset of `RawScCard`
+   plus `stage.id`).
+4. **`deltaToCacheCard()`** in `lib/scorecard-merge.ts` — the field-by-field copy from delta entry
+   to cached scorecard. New fields must be copied here or they will be silently dropped on every
+   delta merge.
+5. **`parseRawScorecards()`** in `lib/scorecard-data.ts` — if the field is consumed downstream
+   (e.g. used in `computeGroupRankings`).
+6. **`CACHE_SCHEMA_VERSION`** in `lib/constants.ts` — bump by 1 with a one-line history comment.
+   Otherwise old delta-merged entries written before the change will linger.
+7. **`scripts/ssi-schema-snapshot.json`** — run `pnpm check:ssi-schema --update` to refresh the
+   snapshot. Commit the diff. Reviewers can see exactly which SSI fields changed.
+
+**For other tracked types** (`IpscMatchNode`, `IpscStageNode`, `IpscCompetitorNode`,
+`IpscSquadNode`): the same discipline applies, but the surface area is smaller — match metadata
+goes through the standard probe + full refetch path, no merge logic. Update the relevant
+GraphQL query, the corresponding TypeScript type, and bump `CACHE_SCHEMA_VERSION`.
+
+**Detecting SSI drift before users do:**
+
+```bash
+pnpm check:ssi-schema           # report drift, exit 1 if any
+pnpm check:ssi-schema --update  # accept current schema as the new snapshot
+pnpm check:ssi-schema --json    # machine-readable output for CI
+```
+
+The script introspects `IpscMatchNode`, `IpscStageNode`, `IpscScoreCardNode`,
+`IpscCompetitorNode`, and `IpscSquadNode` from the live SSI GraphQL endpoint and compares against
+`scripts/ssi-schema-snapshot.json`. Run it weekly (manually or via cron) to catch silent
+upstream changes. If it reports drift:
+
+- **Added fields** — usually safe to ignore unless we want to consume them. Update the snapshot
+  with `--update` once you've decided.
+- **Removed fields** — high-risk. The delta merge will write `null` for removed fields, so
+  cached entries gradually lose data. Plan a migration: stop reading the field, bump
+  `CACHE_SCHEMA_VERSION`, then update the snapshot.
+- **Type / argument changes** — read the diff carefully; may be a breaking change.
+
+**Recovery from a corrupted snapshot:**
+
+If a delta merge produces wrong data on a live match, the user-facing recovery lever is:
+
+```bash
+curl -X POST -H "Authorization: Bearer $CACHE_PURGE_SECRET" \
+  "https://scoreboard.urdr.dev/api/admin/cache/force-refresh?ct=22&id=<match-id>"
+```
+
+This sets a `force-refresh:{ct}:{id}` Redis sentinel that bypasses probe / delta paths and
+forces a clean full refetch on the next SWR cycle. The sentinel auto-clears after a successful
+refresh and auto-expires after 5 minutes.
+
 ## Telemetry
 
 Structured-event logging for cache decisions and other server-side observability.
@@ -454,6 +517,9 @@ handles new achievements and tiers automatically.
 | `MATCH_COMPLETE_SCORING_PCT` | `lib/match-ttl.ts` (server-only) | Both | Scoring threshold (percent, 0-100) for the un-flagged completion heuristic. Default `98`. Used only when SSI never flips `status=cp`/`results=all` and the time gate has passed. Lower values pin more matches earlier (saves upstream calls) at the risk of catching matches still accruing scorecards. Never `NEXT_PUBLIC_`. |
 | `MATCH_PROBE_ENABLED` | `lib/graphql.ts` (server-only) | Both | Kill switch for the match-level "if-modified-since" probe (`refreshCachedMatchQuery`). Default on. Set to `off` to disable the probe and fall back to always-refetch SWR behaviour. Use this if telemetry shows `IpscMatchNode.updated` doesn't track scorecard activity (e.g. only bumps on match-level admin edits, not per-scorecard saves). Never `NEXT_PUBLIC_`. |
 | `MATCH_PROBE_MAX_SKIP_AGE_SECONDS` | `lib/graphql.ts` (server-only) | Both | Belt-and-braces ceiling: even when the probe says "no change", never skip a refetch if the cached entry's *original* `cachedAt` is older than this many seconds. Default `300` (5 min). Caps worst-case staleness if `match.updated` lies — at most we'd serve N-seconds-stale data instead of indefinitely-stale. Lower for more conservative safety, raise once empirical telemetry validates the probe. Never `NEXT_PUBLIC_`. |
+| `SCORECARDS_DELTA_ENABLED` | `lib/graphql.ts` (server-only) | Both | Kill switch for the incremental scorecard delta path (`scorecards(updated_after:)`). Default on. Set to `off` to disable delta merges and fall back to full refetches on every `changed` probe outcome. Use this if delta merges produce subtly wrong scorecard data. Never `NEXT_PUBLIC_`. |
+| `SCORECARDS_DELTA_MAX_AGE_SECONDS` | `lib/graphql.ts` (server-only) | Both | Reconcile interval (seconds): even when delta merges succeed, force a periodic full refetch to self-heal from drift the delta cannot detect (upstream deletions, new stages, subtle merge bugs). Default `600` (10 min). Lower for more aggressive self-healing during high-stakes events. Never `NEXT_PUBLIC_`. |
+| (admin) `POST /api/admin/cache/force-refresh?ct=&id=` | `app/api/admin/cache/force-refresh/route.ts` | Both | Recovery lever: sets a `force-refresh:{ct}:{id}` Redis sentinel that bypasses probe / delta on the next SWR cycle. Requires `Authorization: Bearer <CACHE_PURGE_SECRET>`. Sentinel auto-clears after a successful full refresh; auto-expires after 5 min. |
 | `CACHE_TELEMETRY` | `lib/telemetry.ts` (server-only) | Both | Set to `off` to suppress all telemetry. Default on — emits one JSON line per event via `console.info` (picked up by Cloudflare Workers Logs / Docker stdout) and additionally writes to R2 on Cloudflare when the `TELEMETRY` binding is bound. Never `NEXT_PUBLIC_`. |
 | `TELEMETRY_SAMPLE_<DOMAIN>` | `lib/telemetry-sinks-cf.ts` (Cloudflare only) | Cloudflare only | Per-domain sample rate, value in `[0, 1]`. `1` keeps every event, `0` drops everything, `0.1` keeps 10%. All domains (`cache`, `upstream`, `error`, `ai`, `d1`, `background`, `usage`) default to `1` — at current ~3-6k requests/day even the highest-volume `usage` domain stays under 2% of the R2 free-tier cap. Set e.g. `TELEMETRY_SAMPLE_USAGE=0.1` if traffic grows ~10x. Never `NEXT_PUBLIC_`. |
 | `NEXT_PUBLIC_BUILD_ID` | `components/update-banner.tsx`, `app/api/version/route.ts` | Both | Git SHA baked into the client bundle at Docker build time; powers new-version detection. Auto-injected by `pnpm docker:build`. Unset in `pnpm dev` — version check is skipped. |

--- a/app/api/admin/cache/force-refresh/route.ts
+++ b/app/api/admin/cache/force-refresh/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import cache from "@/lib/cache-impl";
+import { forceRefreshKey } from "@/lib/graphql";
+
+// POST /api/admin/cache/force-refresh?ct=22&id=<match-id>
+// Requires Authorization: Bearer <CACHE_PURGE_SECRET>
+//
+// Sets a `force-refresh:{ct}:{id}` Redis sentinel. The next probe-aware
+// refresh (#361) for this match bypasses probe/delta logic entirely and does
+// a clean full refetch of both GetMatch and GetMatchScorecards via the
+// original `refreshCachedQuery` path. The sentinel is cleared automatically
+// after a successful refresh.
+//
+// Use when you suspect the cached snapshot has been corrupted by a delta
+// merge (#362) or when match.updated under-reported scorecard activity (#361).
+// Faster than DELETE /purge because it doesn't require a full cold-cache
+// refetch on the next user request — the next SWR cycle handles the refresh.
+export async function POST(req: Request) {
+  const secret = process.env.CACHE_PURGE_SECRET;
+  const auth = req.headers.get("Authorization");
+  if (!secret || auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const ct = searchParams.get("ct");
+  const id = searchParams.get("id");
+  if (!ct || !id) {
+    return NextResponse.json({ error: "ct and id are required" }, { status: 400 });
+  }
+
+  const ctNum = parseInt(ct, 10);
+  if (isNaN(ctNum)) {
+    return NextResponse.json({ error: "Invalid content_type" }, { status: 400 });
+  }
+
+  // Sentinel auto-expires after 5 minutes — caps how long an unconsumed
+  // sentinel can linger if no SWR cycle ever runs for this match.
+  await cache.set(forceRefreshKey(ctNum, id), "1", 300);
+
+  return NextResponse.json({
+    forceRefreshSet: forceRefreshKey(ctNum, id),
+    note: "Next SWR refresh for this match will bypass probe/delta and do a full refetch.",
+  });
+}

--- a/lib/cache-telemetry.ts
+++ b/lib/cache-telemetry.ts
@@ -77,6 +77,33 @@ type CacheTelemetryEvent =
        *  `forced-refresh`. Lets us measure inter-bump intervals and detect
        *  long-flat windows that should have triggered changes. */
       prevUpstreamUpdatedIso?: string | null;
+    }
+  // Incremental scorecard delta path — emitted from refreshCachedMatchQuery
+  // when a `changed` probe outcome attempts a delta fetch instead of a full
+  // refetch. Only fires for `keyType=scorecards`.
+  //   delta-merge    — delta fetched and merged successfully; full refetch skipped
+  //   full-fallback  — merge failed (missing stage, malformed payload, cache miss);
+  //                    caller did a full refetch instead
+  //   reconcile      — cached entry's original `cachedAt` exceeded the reconcile
+  //                    ceiling; full refetch forced to self-heal from drift
+  //   error          — delta fetch itself failed (timeout / HTTP / GraphQL error)
+  //   disabled       — SCORECARDS_DELTA_ENABLED=off; delta path bypassed
+  | {
+      op: "scorecards-delta";
+      matchKey: string;
+      outcome: "delta-merge" | "full-fallback" | "reconcile" | "error" | "disabled";
+      /** Number of scorecards in the delta payload (0 on disabled / cache miss). */
+      deltaCount: number;
+      /** Number of cached scorecards replaced by the merge. */
+      updatedCount: number;
+      /** Number of scorecards added by the merge that did not exist before. */
+      addedCount: number;
+      /** Pure merge time (ms) — excludes upstream fetch + cache I/O. */
+      mergeMs: number;
+      /** Delta payload size (bytes) — used for "bytes saved" computation. */
+      deltaBytes: number | null;
+      /** Short reason string for full-fallback / error outcomes. */
+      reason: string | null;
     };
 
 export function cacheTelemetry(ev: CacheTelemetryEvent): void {

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -10,6 +10,8 @@ import { parseMatchCacheKey, persistActiveMatchToD1 } from "@/lib/match-data-sto
 import { markUpstreamDegraded } from "@/lib/upstream-status";
 import { upstreamTelemetry, hashVariables, type UpstreamOutcome } from "@/lib/upstream-telemetry";
 import { cacheTelemetry } from "@/lib/cache-telemetry";
+import { mergeScorecardDelta } from "@/lib/scorecard-merge";
+import type { RawScorecardsData } from "@/lib/scorecard-data";
 
 /**
  * Check if the current request is an admin-authenticated request
@@ -329,6 +331,189 @@ async function readCachedAt(cacheKey: string): Promise<string | null> {
   }
 }
 
+/** Kill switch for the incremental scorecard delta path. When off, the
+ *  `changed` probe outcome falls through to a full refetch — same as #361
+ *  alone. Use this if the delta path proves buggy in production. */
+function isScorecardsDeltaEnabled(): boolean {
+  return process.env.SCORECARDS_DELTA_ENABLED !== "off";
+}
+
+/** Reconcile interval (seconds): even when delta merges succeed, force a
+ *  periodic full refetch to self-heal from drift the delta cannot detect:
+ *    - scorecards deleted upstream (DQ reversals, admin deletes)
+ *    - new stages added to the match
+ *    - subtle merge bugs that don't trigger structural failures
+ *  Default 10 minutes — at the 30s active-match polling cadence that's one
+ *  reconcile per ~20 polls. The cached entry's *original* `cachedAt` is the
+ *  timer reference; delta merges intentionally do NOT bump it so the reconcile
+ *  timer keeps ticking on a steady delta stream. */
+function scorecardsDeltaMaxAgeSeconds(): number {
+  const raw = process.env.SCORECARDS_DELTA_MAX_AGE_SECONDS;
+  if (raw == null) return 600;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 600;
+}
+
+/** Sentinel Redis key that any code path can set to force the next probe-aware
+ *  refresh to do a clean full refetch — bypassing probe, sidecar, and delta
+ *  paths entirely. Cleared after a successful full refresh.
+ *
+ *  Use cases:
+ *   - Admin endpoint exposing a "force-refresh" lever for instant recovery.
+ *   - Future detection code that observes suspicious cache shape and invalidates
+ *     it for the next user.
+ *   - Manual debugging via `redis-cli SET force-refresh:22:12345 1 EX 60`. */
+export function forceRefreshKey(ct: number, id: string): string {
+  return `force-refresh:${ct}:${id}`;
+}
+
+/** Read the force-refresh sentinel; failures default to false (best-effort). */
+async function isForceRefreshRequested(ct: number, id: string): Promise<boolean> {
+  try {
+    const raw = await cache.get(forceRefreshKey(ct, id));
+    return raw != null;
+  } catch {
+    return false;
+  }
+}
+
+/** Clear the force-refresh sentinel after a successful full refetch. */
+async function clearForceRefresh(ct: number, id: string): Promise<void> {
+  try {
+    await cache.del(forceRefreshKey(ct, id));
+  } catch { /* best-effort */ }
+}
+
+interface DeltaMergeAttempt {
+  outcome: "delta-merge" | "full-fallback" | "reconcile" | "error" | "disabled";
+  /** Number of scorecards in the delta payload. */
+  deltaCount: number;
+  /** Number of cached scorecards replaced by the merge. */
+  updatedCount: number;
+  /** Number of scorecards added by the merge. */
+  addedCount: number;
+  /** Pure-merge time (ms). Excludes upstream fetch + cache I/O. */
+  mergeMs: number;
+  /** Bytes returned by the delta query (vs. full refetch payload). */
+  deltaBytes: number | null;
+  /** Short reason string when outcome is `full-fallback` or `error`. */
+  reason: string | null;
+}
+
+/**
+ * Attempt a delta merge for a `GetMatchScorecards` cache entry. Returns the
+ * outcome details for telemetry; on `delta-merge` / `reconcile` the cache has
+ * been updated. On `full-fallback` / `error` / `disabled` the caller should
+ * run a full refresh.
+ */
+async function tryScorecardsDeltaMerge(
+  cacheKey: string,
+  variables: { ct: number; id: string },
+  since: string,
+  ttlSeconds: number | null,
+): Promise<DeltaMergeAttempt> {
+  if (!isScorecardsDeltaEnabled()) {
+    return { outcome: "disabled", deltaCount: 0, updatedCount: 0, addedCount: 0, mergeMs: 0, deltaBytes: null, reason: null };
+  }
+
+  let cachedEntry: CacheEntry<RawScorecardsData>;
+  let cachedAtIso: string;
+  try {
+    const raw = await cache.get(cacheKey);
+    if (!raw) {
+      return { outcome: "full-fallback", deltaCount: 0, updatedCount: 0, addedCount: 0, mergeMs: 0, deltaBytes: null, reason: "no-cached-entry" };
+    }
+    cachedEntry = JSON.parse(raw) as CacheEntry<RawScorecardsData>;
+    cachedAtIso = cachedEntry.cachedAt;
+    if (cachedEntry.v !== CACHE_SCHEMA_VERSION) {
+      return { outcome: "full-fallback", deltaCount: 0, updatedCount: 0, addedCount: 0, mergeMs: 0, deltaBytes: null, reason: "schema-version-mismatch" };
+    }
+  } catch {
+    return { outcome: "full-fallback", deltaCount: 0, updatedCount: 0, addedCount: 0, mergeMs: 0, deltaBytes: null, reason: "cache-read-error" };
+  }
+
+  // Reconcile gate: if the cached entry's *original* fetch is older than the
+  // ceiling, force a full refetch even though a delta would merge cleanly.
+  // Self-heals from upstream deletions and stage additions.
+  const cacheAgeSeconds = (Date.now() - new Date(cachedAtIso).getTime()) / 1000;
+  if (cacheAgeSeconds > scorecardsDeltaMaxAgeSeconds()) {
+    return { outcome: "reconcile", deltaCount: 0, updatedCount: 0, addedCount: 0, mergeMs: 0, deltaBytes: null, reason: null };
+  }
+
+  let deltaData: ScorecardDeltaData;
+  let deltaBytes: number | null = null;
+  try {
+    // We can't get bytes here (executeQuery does, but doesn't expose it);
+    // approximate with serialized JSON length post-fetch.
+    deltaData = await executeQuery<ScorecardDeltaData>(SCORECARDS_DELTA_QUERY, { ...variables, since });
+    try { deltaBytes = JSON.stringify(deltaData).length; } catch { /* ignore */ }
+  } catch (err) {
+    return {
+      outcome: "error",
+      deltaCount: 0,
+      updatedCount: 0,
+      addedCount: 0,
+      mergeMs: 0,
+      deltaBytes: null,
+      reason: err instanceof Error ? err.name : "fetch-error",
+    };
+  }
+
+  const delta = deltaData.event?.scorecards ?? [];
+  const t0 = Date.now();
+  const merge = mergeScorecardDelta(cachedEntry.data, delta);
+  const mergeMs = Date.now() - t0;
+
+  if (!merge.ok) {
+    return {
+      outcome: "full-fallback",
+      deltaCount: delta.length,
+      updatedCount: 0,
+      addedCount: 0,
+      mergeMs,
+      deltaBytes,
+      reason: merge.reason,
+    };
+  }
+
+  // Write the merged snapshot back. CRITICAL: keep the original `cachedAt`
+  // so the reconcile timer keeps ticking on a steady delta stream.
+  const newEntry: CacheEntry<RawScorecardsData> = {
+    data: merge.data,
+    cachedAt: cachedAtIso,
+    v: CACHE_SCHEMA_VERSION,
+  };
+  const payload = JSON.stringify(newEntry);
+  try {
+    await cache.set(cacheKey, payload, ttlSeconds);
+  } catch {
+    // Cache write failed — surface as full-fallback so caller does a full
+    // refetch and writes a coherent snapshot via the standard path.
+    return {
+      outcome: "full-fallback",
+      deltaCount: delta.length,
+      updatedCount: merge.updatedCount,
+      addedCount: merge.addedCount,
+      mergeMs,
+      deltaBytes,
+      reason: "cache-write-error",
+    };
+  }
+  if (parseMatchCacheKey(cacheKey)) {
+    afterResponse(persistActiveMatchToD1(cacheKey, payload));
+  }
+
+  return {
+    outcome: "delta-merge",
+    deltaCount: delta.length,
+    updatedCount: merge.updatedCount,
+    addedCount: merge.addedCount,
+    mergeMs,
+    deltaBytes,
+    reason: null,
+  };
+}
+
 /**
  * Probe-aware single-flight refresh of a cached match-level GraphQL query
  * (GetMatch or GetMatchScorecards). Sends a tiny `MatchUpdatedProbe` first;
@@ -351,6 +536,30 @@ export async function refreshCachedMatchQuery<T>(
   // (e.g. only bumps on match-level admin edits, not per-scorecard saves).
   if (!isMatchProbeEnabled()) {
     return refreshCachedQuery<T>(cacheKey, query, variables, ttlSeconds, lockTtlSeconds);
+  }
+
+  // Force-refresh sentinel: any code path (admin endpoint, recovery script)
+  // can request a clean full refetch by setting `force-refresh:{ct}:{id}` in
+  // Redis. We bypass probe, sidecar, and delta entirely. After a successful
+  // refresh the sentinel is cleared. Both probe (#361) and delta (#362)
+  // paths respect this for symmetry.
+  if (await isForceRefreshRequested(match.ct, match.id)) {
+    await refreshCachedQuery<T>(cacheKey, query, variables, ttlSeconds, lockTtlSeconds);
+    await clearForceRefresh(match.ct, match.id);
+    cacheTelemetry({
+      op: "match-probe",
+      matchKey: cacheKey,
+      keyType:
+        parseMatchCacheKey(cacheKey)?.keyType === "match" ? "match"
+          : parseMatchCacheKey(cacheKey)?.keyType === "scorecards" ? "scorecards"
+          : "other",
+      outcome: "forced-refresh",
+      probeMs: 0,
+      cachedAgeSeconds: null,
+      upstreamUpdatedIso: null,
+      prevUpstreamUpdatedIso: null,
+    });
+    return;
   }
 
   const lockKey = `inflight:${cacheKey}`;
@@ -447,11 +656,49 @@ export async function refreshCachedMatchQuery<T>(
 
     // First-seen or state changed — do the full refresh, then update sidecar.
     probeOutcome = prevState ? "changed" : "first-seen";
-    await fullRefresh<T>(cacheKey, query, variables, ttlSeconds);
+
+    // Delta path: on `changed` for a scorecards key, try fetching only the
+    // delta scorecards (`scorecards(updated_after: prev_match_updated)`) and
+    // merging into the cached snapshot. Falls through to the full refresh on
+    // any failure or when the periodic reconcile is due.
+    let deltaAttempt: DeltaMergeAttempt | null = null;
+    const canTryDelta =
+      keyType === "scorecards" &&
+      probeOutcome === "changed" &&
+      prevState?.updated != null;
+    if (canTryDelta && prevState?.updated) {
+      deltaAttempt = await tryScorecardsDeltaMerge(
+        cacheKey,
+        match,
+        prevState.updated,
+        ttlSeconds,
+      );
+    }
+
+    const skipFullRefresh =
+      deltaAttempt?.outcome === "delta-merge";
+
+    if (!skipFullRefresh) {
+      await fullRefresh<T>(cacheKey, query, variables, ttlSeconds);
+    }
     try {
       await cache.set(sidecarKey, JSON.stringify(currentState), ttlSeconds ?? null);
     } catch {
       // Sidecar write failure just costs us one extra full refetch next cycle.
+    }
+
+    if (deltaAttempt) {
+      cacheTelemetry({
+        op: "scorecards-delta",
+        matchKey: cacheKey,
+        outcome: deltaAttempt.outcome,
+        deltaCount: deltaAttempt.deltaCount,
+        updatedCount: deltaAttempt.updatedCount,
+        addedCount: deltaAttempt.addedCount,
+        mergeMs: deltaAttempt.mergeMs,
+        deltaBytes: deltaAttempt.deltaBytes,
+        reason: deltaAttempt.reason,
+      });
     }
   } finally {
     cacheTelemetry({
@@ -732,6 +979,59 @@ export async function cachedExecuteQuery<T>(
   return { data, cachedAt: null };
 }
 
+// ─── Shared scorecard field set ──────────────────────────────────────────────
+// CRITICAL: SCORECARDS_QUERY and SCORECARDS_DELTA_QUERY MUST request the same
+// scorecard fields. The delta merge (#362, lib/scorecard-merge.ts) writes
+// delta entries into the cached full snapshot — if the delta is missing fields
+// the full query has, the merge silently corrupts the cached entry.
+//
+// This shared constant is interpolated into both queries so they CANNOT drift.
+//
+// When adding a scorecard field, see CLAUDE.md → "Delta-merge contract" for
+// the full list of files that must be updated together. In short:
+//   1. Add to SCORECARD_NODE_FIELDS (here)
+//   2. Add to RawScCard (lib/scorecard-data.ts)
+//   3. Add to ScorecardDeltaEntry (this file)
+//   4. Copy in deltaToCacheCard() (lib/scorecard-merge.ts)
+//   5. Bump CACHE_SCHEMA_VERSION (lib/constants.ts)
+//   6. Run `pnpm check:ssi-schema --update` and commit the snapshot diff
+const SCORECARD_NODE_FIELDS = `
+  ... on IpscScoreCardNode {
+    created
+    points
+    hitfactor
+    time
+    disqualified
+    zeroed
+    stage_not_fired
+    incomplete
+    ascore
+    bscore
+    cscore
+    dscore
+    miss
+    penalty
+    procedural
+    competitor {
+      id
+      ... on IpscCompetitorNode {
+        first_name
+        last_name
+        number
+        club
+        get_division_display
+        handgun_div
+        get_handgun_div_display
+        region
+        get_region_display
+        category
+        ics_alias
+        license
+      }
+    }
+  }
+`;
+
 // ─── Query: all stage scorecards for a match ─────────────────────────────────
 // Returns raw scorecard data for every competitor on every stage.
 // `get_results` (official placement) is blocked during active matches — this
@@ -749,43 +1049,77 @@ export const SCORECARDS_QUERY = `
             max_points
           }
           scorecards {
-            ... on IpscScoreCardNode {
-              created
-              points
-              hitfactor
-              time
-              disqualified
-              zeroed
-              stage_not_fired
-              incomplete
-              ascore
-              bscore
-              cscore
-              dscore
-              miss
-              penalty
-              procedural
-              competitor {
-                id
-                ... on IpscCompetitorNode {
-                  first_name
-                  last_name
-                  number
-                  club
-                  get_division_display
-                  handgun_div
-                  get_handgun_div_display
-                  region
-                  get_region_display
-                  category
-                  ics_alias
-                  license
-                }
-              }
-            }
+            ${SCORECARD_NODE_FIELDS}
           }
         }
       }
     }
   }
 `;
+
+// ─── Query: incremental scorecard delta ──────────────────────────────────────
+// Fetches only scorecards whose `updated` timestamp is strictly after `since`.
+// Single match-level round-trip (not per-stage) — each scorecard returns its
+// `stage.id` so the merge step can re-bucket into the cached per-stage shape.
+//
+// Validated empirically: SSI accepts ISO 8601 with timezone (the format
+// `IpscMatchNode.updated` itself returns), so we just pass that value back
+// as the `since` parameter.
+//
+// The scorecard field set MUST stay in sync with SCORECARDS_QUERY — the merge
+// produces the same on-disk shape as a full fetch, so the cache schema version
+// covers both. Any field added to SCORECARDS_QUERY must be added here too.
+export const SCORECARDS_DELTA_QUERY = `
+  query GetMatchScorecardsDelta($ct: Int!, $id: String!, $since: String!) {
+    event(content_type: $ct, id: $id) {
+      ... on IpscMatchNode {
+        scorecards(updated_after: $since) {
+          ... on IpscScoreCardNode {
+            stage { id }
+          }
+          ${SCORECARD_NODE_FIELDS}
+        }
+      }
+    }
+  }
+`;
+
+export interface ScorecardDeltaEntry {
+  stage: { id: string };
+  created?: string | null;
+  points?: number | string | null;
+  hitfactor?: number | string | null;
+  time?: number | string | null;
+  disqualified?: boolean | null;
+  zeroed?: boolean | null;
+  stage_not_fired?: boolean | null;
+  incomplete?: boolean | null;
+  ascore?: number | string | null;
+  bscore?: number | string | null;
+  cscore?: number | string | null;
+  dscore?: number | string | null;
+  miss?: number | string | null;
+  penalty?: number | string | null;
+  procedural?: number | string | null;
+  competitor?: {
+    id: string;
+    first_name?: string;
+    last_name?: string;
+    number?: string;
+    club?: string | null;
+    get_division_display?: string | null;
+    handgun_div?: string | null;
+    get_handgun_div_display?: string | null;
+    region?: string | null;
+    get_region_display?: string | null;
+    category?: string | null;
+    ics_alias?: string | null;
+    license?: string | null;
+  } | null;
+}
+
+export interface ScorecardDeltaData {
+  event: {
+    scorecards?: ScorecardDeltaEntry[];
+  } | null;
+}

--- a/lib/scorecard-merge.ts
+++ b/lib/scorecard-merge.ts
@@ -1,0 +1,139 @@
+// Pure merge logic for the incremental scorecard delta path. No I/O —
+// dependency-injected from `refreshCachedMatchQuery` so it is fully unit-tested
+// without the cache or GraphQL layers.
+//
+// The merge maps a flat delta payload (each entry carrying its `stage.id` and
+// `competitor.id`) onto the cached per-stage `RawScorecardsData` shape. Match
+// key is the composite `(stageId, competitorId)` — a competitor has at most
+// one scorecard per stage in IPSC scoring (reshoots replace, not append).
+//
+// On any structural problem (missing stage in cached snapshot, malformed
+// delta entry) the merge fails with `ok: false` so callers can fall back to a
+// full refetch instead of producing an inconsistent snapshot.
+
+import type { RawScorecardsData, RawScCard, RawStage } from "@/lib/scorecard-data";
+import type { ScorecardDeltaEntry } from "@/lib/graphql";
+
+export interface MergeResult {
+  ok: true;
+  data: RawScorecardsData;
+  /** Number of scorecards that replaced an existing entry. */
+  updatedCount: number;
+  /** Number of scorecards added that did not previously exist. */
+  addedCount: number;
+}
+
+export interface MergeFailure {
+  ok: false;
+  /** Stable short reason — used in telemetry to spot recurring patterns. */
+  reason:
+    | "stage-missing"
+    | "competitor-missing"
+    | "stages-missing"
+    | "no-event";
+}
+
+// CRITICAL: every field on RawScCard / ScorecardDeltaEntry must be copied here.
+// A missing field would silently null-out that field in the cached snapshot on
+// every delta merge, corrupting downstream rendering. See CLAUDE.md
+// → "Delta-merge contract" for the full update checklist.
+function deltaToCacheCard(d: ScorecardDeltaEntry): RawScCard {
+  return {
+    created: d.created ?? null,
+    points: d.points ?? null,
+    hitfactor: d.hitfactor ?? null,
+    time: d.time ?? null,
+    disqualified: d.disqualified ?? null,
+    zeroed: d.zeroed ?? null,
+    stage_not_fired: d.stage_not_fired ?? null,
+    incomplete: d.incomplete ?? null,
+    ascore: d.ascore ?? null,
+    bscore: d.bscore ?? null,
+    cscore: d.cscore ?? null,
+    dscore: d.dscore ?? null,
+    miss: d.miss ?? null,
+    penalty: d.penalty ?? null,
+    procedural: d.procedural ?? null,
+    competitor: d.competitor
+      ? {
+          id: d.competitor.id,
+          first_name: d.competitor.first_name,
+          last_name: d.competitor.last_name,
+          number: d.competitor.number,
+          club: d.competitor.club ?? null,
+          get_division_display: d.competitor.get_division_display ?? null,
+          handgun_div: d.competitor.handgun_div ?? null,
+          get_handgun_div_display: d.competitor.get_handgun_div_display ?? null,
+        }
+      : null,
+  };
+}
+
+/**
+ * Merge a flat delta payload into the cached per-stage scorecard snapshot.
+ *
+ * Returns a new `RawScorecardsData` (the cached input is not mutated) plus
+ * counts. Caller should write the new snapshot back to the cache and
+ * (separately) re-emit telemetry.
+ *
+ * Failure modes — caller falls back to a full refetch:
+ *   - cached entry has no event / no stages list (cache shape drift)
+ *   - delta entry references a stage that doesn't exist in the cached entry
+ *     (a new stage was added upstream — full refetch will pick it up)
+ *   - delta entry has no competitor (malformed payload)
+ */
+export function mergeScorecardDelta(
+  cached: RawScorecardsData,
+  delta: ScorecardDeltaEntry[],
+): MergeResult | MergeFailure {
+  if (!cached.event) return { ok: false, reason: "no-event" };
+  if (!cached.event.stages) return { ok: false, reason: "stages-missing" };
+
+  // Build a stage-id → cloned-stage map for O(1) lookups during merge.
+  // Clone scorecards arrays so we can mutate without touching the input.
+  const stagesById = new Map<string, RawStage>();
+  for (const s of cached.event.stages) {
+    stagesById.set(s.id, {
+      ...s,
+      scorecards: s.scorecards ? [...s.scorecards] : [],
+    });
+  }
+
+  let updatedCount = 0;
+  let addedCount = 0;
+
+  for (const d of delta) {
+    const stageId = d.stage?.id;
+    if (!stageId) return { ok: false, reason: "stage-missing" };
+
+    const stage = stagesById.get(stageId);
+    if (!stage) return { ok: false, reason: "stage-missing" };
+
+    if (!d.competitor?.id) return { ok: false, reason: "competitor-missing" };
+    const competitorId = d.competitor.id;
+
+    const cards = stage.scorecards as RawScCard[];
+    const idx = cards.findIndex((c) => c.competitor?.id === competitorId);
+    const merged = deltaToCacheCard(d);
+
+    if (idx >= 0) {
+      cards[idx] = merged;
+      updatedCount++;
+    } else {
+      cards.push(merged);
+      addedCount++;
+    }
+  }
+
+  return {
+    ok: true,
+    data: {
+      event: {
+        ...cached.event,
+        stages: Array.from(stagesById.values()),
+      },
+    },
+    updatedCount,
+    addedCount,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "icons": "bash scripts/generate-icons.sh",
     "warm-cache": "tsx scripts/warm-cache.ts",
     "release:post": "tsx scripts/generate-release-post.ts",
-    "release:screenshots": "tsx scripts/screenshot-match.ts"
+    "release:screenshots": "tsx scripts/screenshot-match.ts",
+    "check:ssi-schema": "tsx scripts/check-ssi-schema.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",

--- a/scripts/check-ssi-schema.ts
+++ b/scripts/check-ssi-schema.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env tsx
+/**
+ * Drift-detection between the live SSI GraphQL schema and our local snapshot.
+ *
+ * WHY: With the incremental scorecard delta path (#362) we no longer just cache
+ * SSI responses opaquely — we mirror the IpscScoreCardNode / IpscCompetitorNode
+ * shape and apply upstream changes incrementally. If SSI silently adds, removes,
+ * or renames a field on one of these types, the cached snapshot can drift in
+ * subtle, hard-to-debug ways. This script catches drift early, before users do.
+ *
+ * USAGE:
+ *   pnpm tsx scripts/check-ssi-schema.ts                  # report drift, exit 1 if any
+ *   pnpm tsx scripts/check-ssi-schema.ts --update         # accept current schema as the new snapshot
+ *   pnpm tsx scripts/check-ssi-schema.ts --json           # machine-readable output for CI
+ *
+ * The snapshot file (scripts/ssi-schema-snapshot.json) is checked into the repo
+ * so a `git diff` after running with --update shows exactly what changed.
+ *
+ * If this script reports drift, see CLAUDE.md → "Delta-merge contract".
+ */
+
+import { writeFileSync, readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SNAPSHOT_PATH = resolve(__dirname, "ssi-schema-snapshot.json");
+
+// Types we depend on. If you start consuming new types from SSI, add them here.
+const TRACKED_TYPES = [
+  "IpscMatchNode",
+  "IpscStageNode",
+  "IpscScoreCardNode",
+  "IpscCompetitorNode",
+  "IpscSquadNode",
+] as const;
+
+interface FieldArg {
+  name: string;
+  type: string;
+}
+
+interface FieldEntry {
+  name: string;
+  type: string;
+  args: FieldArg[];
+}
+
+type Snapshot = Record<string, FieldEntry[]>;
+
+function typeRef(t: { name: string | null; kind: string; ofType?: { name: string | null; kind: string } | null }): string {
+  if (t.kind === "NON_NULL" && t.ofType) return `${typeRef(t.ofType)}!`;
+  if (t.kind === "LIST" && t.ofType) return `[${typeRef(t.ofType)}]`;
+  return t.name ?? t.kind;
+}
+
+async function introspectType(typeName: string, endpoint: string, token: string): Promise<FieldEntry[]> {
+  const query = `{ __type(name: "${typeName}") { fields { name type { name kind ofType { name kind ofType { name kind } } } args { name type { name kind ofType { name kind } } } } } }`;
+  const r = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Token ${token}` },
+    body: JSON.stringify({ query }),
+  });
+  if (!r.ok) throw new Error(`SSI HTTP ${r.status}`);
+  const json = (await r.json()) as { data?: { __type?: { fields?: { name: string; type: { name: string | null; kind: string; ofType?: { name: string | null; kind: string; ofType?: { name: string | null; kind: string } | null } | null }; args: { name: string; type: { name: string | null; kind: string; ofType?: { name: string | null; kind: string } | null } }[] }[] | null } | null } };
+  const fields = json.data?.__type?.fields ?? [];
+  return fields
+    .map((f): FieldEntry => ({
+      name: f.name,
+      type: typeRef(f.type),
+      args: (f.args ?? []).map((a): FieldArg => ({ name: a.name, type: typeRef(a.type) })),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+interface FieldDiff {
+  added: FieldEntry[];
+  removed: FieldEntry[];
+  changed: { name: string; before: FieldEntry; after: FieldEntry }[];
+}
+
+function diffFields(before: FieldEntry[], after: FieldEntry[]): FieldDiff {
+  const beforeByName = new Map(before.map((f) => [f.name, f]));
+  const afterByName = new Map(after.map((f) => [f.name, f]));
+  const added: FieldEntry[] = [];
+  const removed: FieldEntry[] = [];
+  const changed: { name: string; before: FieldEntry; after: FieldEntry }[] = [];
+  for (const [name, fAfter] of afterByName) {
+    const fBefore = beforeByName.get(name);
+    if (!fBefore) { added.push(fAfter); continue; }
+    if (JSON.stringify(fBefore) !== JSON.stringify(fAfter)) {
+      changed.push({ name, before: fBefore, after: fAfter });
+    }
+  }
+  for (const [name, fBefore] of beforeByName) {
+    if (!afterByName.has(name)) removed.push(fBefore);
+  }
+  return { added, removed, changed };
+}
+
+function loadSnapshot(): Snapshot | null {
+  if (!existsSync(SNAPSHOT_PATH)) return null;
+  return JSON.parse(readFileSync(SNAPSHOT_PATH, "utf8")) as Snapshot;
+}
+
+function saveSnapshot(s: Snapshot): void {
+  writeFileSync(SNAPSHOT_PATH, JSON.stringify(s, null, 2) + "\n", "utf8");
+}
+
+async function main() {
+  const apiKey = process.env.SSI_API_KEY;
+  if (!apiKey) {
+    console.error("[check-ssi-schema] SSI_API_KEY not set");
+    process.exit(2);
+  }
+  const endpoint = "https://shootnscoreit.com/graphql/";
+  const update = process.argv.includes("--update");
+  const jsonMode = process.argv.includes("--json");
+
+  const live: Snapshot = {};
+  for (const t of TRACKED_TYPES) {
+    live[t] = await introspectType(t, endpoint, apiKey);
+  }
+
+  const previous = loadSnapshot();
+  if (update || !previous) {
+    saveSnapshot(live);
+    if (!previous) {
+      console.log(`[check-ssi-schema] wrote initial snapshot to ${SNAPSHOT_PATH}`);
+    } else {
+      console.log(`[check-ssi-schema] snapshot updated`);
+    }
+    return;
+  }
+
+  let drifted = false;
+  const report: Record<string, FieldDiff> = {};
+  for (const t of TRACKED_TYPES) {
+    const d = diffFields(previous[t] ?? [], live[t] ?? []);
+    if (d.added.length || d.removed.length || d.changed.length) {
+      drifted = true;
+      report[t] = d;
+    }
+  }
+
+  if (jsonMode) {
+    console.log(JSON.stringify(report, null, 2));
+    process.exit(drifted ? 1 : 0);
+  }
+
+  if (!drifted) {
+    console.log("[check-ssi-schema] no drift — schema matches snapshot");
+    return;
+  }
+
+  for (const [t, d] of Object.entries(report)) {
+    console.log(`\n=== ${t} ===`);
+    for (const f of d.added) console.log(`  + ${f.name}: ${f.type}`);
+    for (const f of d.removed) console.log(`  - ${f.name}: ${f.type}`);
+    for (const c of d.changed) console.log(`  ~ ${c.name}: ${c.before.type} -> ${c.after.type}`);
+  }
+  console.log("\n[check-ssi-schema] drift detected. See CLAUDE.md -> 'Delta-merge contract' for what to update.");
+  console.log("[check-ssi-schema] After updating queries / types / schema version, run `pnpm tsx scripts/check-ssi-schema.ts --update` to accept.");
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("[check-ssi-schema] failed:", err);
+  process.exit(2);
+});

--- a/scripts/ssi-schema-snapshot.json
+++ b/scripts/ssi-schema-snapshot.json
@@ -1,0 +1,3120 @@
+{
+  "IpscMatchNode": [
+    {
+      "name": "accreditation_status",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "accreditor",
+      "type": "DjangoModelType",
+      "args": []
+    },
+    {
+      "name": "air_divs",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "allow_team_self_management",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "allow_teams",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "allows_spotter_shooter_teams",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "available_standard_stages",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "banner",
+      "type": "SafeImageType",
+      "args": []
+    },
+    {
+      "name": "banner_url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "can_be_deleted",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "cat_result_limit",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "categories",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "chrono_progress",
+      "type": "ChronoProgressNode!",
+      "args": []
+    },
+    {
+      "name": "chrono_progress_unsquadded",
+      "type": "ChronoProgressNode!",
+      "args": []
+    },
+    {
+      "name": "chronocards",
+      "type": "[NON_NULL]!",
+      "args": [
+        {
+          "name": "updated_after",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "chronocards_failed",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "comment",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "competitor_payment",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "competitors",
+      "type": "[NON_NULL]!",
+      "args": [
+        {
+          "name": "updated_after",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "competitors_approved_w_wo_results_not_dnf",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "competitors_approved_w_wo_results_wo_squad_not_dnf",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "competitors_count",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "competitors_did_not_finish",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "competitors_dq",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "competitors_indexed",
+      "type": "[NON_NULL]!",
+      "args": [
+        {
+          "name": "sqs",
+          "type": "String!"
+        },
+        {
+          "name": "shift_on",
+          "type": "Int!"
+        },
+        {
+          "name": "incl_dnf",
+          "type": "Boolean!"
+        },
+        {
+          "name": "incl_dqed",
+          "type": "Boolean!"
+        }
+      ]
+    },
+    {
+      "name": "competitors_unscored_list",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "competitors_w_warning",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "component_matches",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "created",
+      "type": "DateTime!",
+      "args": []
+    },
+    {
+      "name": "created_by",
+      "type": "ShooterNode!",
+      "args": []
+    },
+    {
+      "name": "currency",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "custom_data",
+      "type": "JSON!",
+      "args": []
+    },
+    {
+      "name": "description",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "deviating_competitors",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "deviating_scorecards",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "do_chrono",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "do_equipment_check",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "do_index_competitor_when_scoring",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "does_current_user_get_result",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "ends",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "f1",
+      "type": "DjangoFileType",
+      "args": []
+    },
+    {
+      "name": "f1_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "f2",
+      "type": "DjangoFileType",
+      "args": []
+    },
+    {
+      "name": "f2_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "f3",
+      "type": "DjangoFileType",
+      "args": []
+    },
+    {
+      "name": "f3_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "f4",
+      "type": "DjangoFileType",
+      "args": []
+    },
+    {
+      "name": "f4_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "f5",
+      "type": "DjangoFileType",
+      "args": []
+    },
+    {
+      "name": "f5_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "f6",
+      "type": "DjangoFileType",
+      "args": []
+    },
+    {
+      "name": "f6_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "firearms",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "gcal_uid",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_chronocard",
+      "type": "ChronoCardInterface!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_competitor",
+      "type": "CompetitorInterface!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_squad",
+      "type": "SquadInterface!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_stage",
+      "type": "StageInterface!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_team",
+      "type": "TeamInterface!",
+      "args": []
+    },
+    {
+      "name": "get_air_divs_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_air_divs_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_categories_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_categories_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_content_type_key",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "get_content_type_model",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_currency_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_currency_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_current_rbac_operations",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_disqualified",
+      "type": "[NON_NULL]!",
+      "args": [
+        {
+          "name": "division",
+          "type": "String"
+        },
+        {
+          "name": "category",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "get_divisions_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_firearms_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_firearms_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_full_absolute_url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_full_level_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_full_rule_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_handgun_divs_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_handgun_divs_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_level_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_level_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_mini_rifle_divs_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_mini_rifle_divs_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_organizer_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_pcc_divs_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_pcc_divs_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_prec_rifle_divs_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_prec_rifle_divs_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_prematch_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_prematch_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_region_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_region_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_registration_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_registration_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_results",
+      "type": "[NON_NULL]!",
+      "args": [
+        {
+          "name": "division",
+          "type": "String"
+        },
+        {
+          "name": "category",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "get_results_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_results_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_rifle_divs_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_rifle_divs_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_rounds_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_shotgun_divs_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_shotgun_divs_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_standard_stage_selection",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_state_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_state_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_status_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_status_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_tournament_divisions_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_tournament_divisions_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_unique_select_result_choices",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_verify_using_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_verify_using_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_visibility_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_visibility_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "group",
+      "type": "DjangoModelType!",
+      "args": []
+    },
+    {
+      "name": "handgun_divs",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "has_accepted_event_data_ass_agreement",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "has_geopos",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "has_prematch",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "has_prematch_included",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "id",
+      "type": "ID!",
+      "args": []
+    },
+    {
+      "name": "image",
+      "type": "SafeImageType",
+      "args": []
+    },
+    {
+      "name": "include_pcc_in_combined",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "information",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "is_component_match",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_current_role_admin",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_current_role_assistant",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_current_role_staff",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_imported_event",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_live_scores_accessible",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_locked",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_match",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_nrof_scored_w_abc",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_nrof_scored_w_s123",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_pm_squadding_possible",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_premium_activated",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_premium_fully_valid",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_rated",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_registration_possible",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_series",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_squadding_possible",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_tournament_match",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "lat",
+      "type": "Decimal",
+      "args": []
+    },
+    {
+      "name": "level",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "lng",
+      "type": "Decimal",
+      "args": []
+    },
+    {
+      "name": "lock_changed",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "lock_changed_by",
+      "type": "ShooterNode",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_approved",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_approved_w_wo_results",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_approved_w_wo_results_wo_squad",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_approved_wo_results",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_declined",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_deleted",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_pending",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_registered",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_waiting",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "max_competitors",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "max_prematch_competitors",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "merchandize_orders",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "merchandizes",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "merchandizes_on_registration",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "merge_juniors",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "merge_seniors",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "mini_rifle_divs",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "minimum_rounds",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "multiple_reg_allowed",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "name",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "number_of_mainmatch_competitors_approved",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_mainmatch_competitors_approved_w_wo_results",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_mainmatch_competitors_pending",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_mainmatch_competitors_registered",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_mainmatch_competitors_waiting",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_prematch_competitors_approved",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_prematch_competitors_approved_w_wo_results",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_prematch_competitors_pending",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_prematch_competitors_registered",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_prematch_competitors_waiting",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_rounds_per_string",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_strings",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "number_of_team_members",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "obfuscated_kongsberg_api_key",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "order_payments",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "organization_enabled_event_premium",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "organizer",
+      "type": "OrganizationNode",
+      "args": []
+    },
+    {
+      "name": "payment_methods",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "pcc_divs",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "pm_registration_closes",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "pm_registration_starts",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "pm_squadding_starts",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "prec_rifle_divs",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "prematch",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_approved",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_approved_w_wo_results",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_approved_w_wo_results_wo_squad",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_approved_wo_results",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_declined",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_deleted",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_pending",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_registered",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_waiting",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "premium_currency",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "premium_payments",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "rated",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "region",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "registration",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "registration_closes",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "registration_starts",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "result_from_team_members",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "results",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "rifle_divs",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "role_names",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "rule",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "scorecards",
+      "type": "[NON_NULL]!",
+      "args": [
+        {
+          "name": "updated_after",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "scorecards_count",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "scorecards_dq",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "scorecards_w_warning",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "scoring_completed",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "serie_type",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "short_url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "shotgun_divs",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "squadding_closes",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "squadding_starts",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "squads",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "squads_count",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "stages",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "stages_count",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "starts",
+      "type": "DateTime!",
+      "args": []
+    },
+    {
+      "name": "state",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "status",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "sub_rule",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "supports_bulk_scoring",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "supports_rating",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "supports_score_all_in_squad_at_stage",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "supports_score_string_for_squad",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "supports_shoot_off_strings",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "supports_standard_stages",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "teams",
+      "type": "[TeamInterface!]",
+      "args": []
+    },
+    {
+      "name": "teams_count",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "third_party_scoring_mode",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "third_party_scoring_url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "total_fee",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "total_net",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "total_tax",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "tournament_divisions",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "transfer_mode",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "updated",
+      "type": "DateTime!",
+      "args": []
+    },
+    {
+      "name": "updated_by",
+      "type": "ShooterNode",
+      "args": []
+    },
+    {
+      "name": "url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "url_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "uses_pin_verification",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "uses_shoot_off_stages",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "uses_signature_verification",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "uses_stages",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "uses_strings",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "venue",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "verify_using",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "visibility",
+      "type": "String!",
+      "args": []
+    }
+  ],
+  "IpscStageNode": [
+    {
+      "name": "all_steel",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "banner",
+      "type": "SafeImageType",
+      "args": []
+    },
+    {
+      "name": "banner_url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "bonus",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "can_do_third_party_scoring_kongsberg",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "competitors_indexed",
+      "type": "[NON_NULL]!",
+      "args": [
+        {
+          "name": "sqs",
+          "type": "String!"
+        },
+        {
+          "name": "shift_on",
+          "type": "Int!"
+        },
+        {
+          "name": "incl_dnf",
+          "type": "Boolean!"
+        },
+        {
+          "name": "incl_dqed",
+          "type": "Boolean!"
+        }
+      ]
+    },
+    {
+      "name": "course",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "created",
+      "type": "DateTime!",
+      "args": []
+    },
+    {
+      "name": "created_by",
+      "type": "ShooterNode!",
+      "args": []
+    },
+    {
+      "name": "custom_data",
+      "type": "JSON!",
+      "args": []
+    },
+    {
+      "name": "event",
+      "type": "IpscMatchNode!",
+      "args": []
+    },
+    {
+      "name": "evt",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "firearm_condition",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "firearms",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "frangible",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_scorecard",
+      "type": "ScoreCardInterface!",
+      "args": []
+    },
+    {
+      "name": "get_content_type_key",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "get_content_type_model",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_course_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_course_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_disqualified",
+      "type": "[NON_NULL]!",
+      "args": [
+        {
+          "name": "division",
+          "type": "String"
+        },
+        {
+          "name": "category",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "get_firearm_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_firearms_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_full_absolute_url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_next_stage",
+      "type": "StageInterface!",
+      "args": []
+    },
+    {
+      "name": "get_previous_stage",
+      "type": "StageInterface!",
+      "args": []
+    },
+    {
+      "name": "get_results",
+      "type": "[NON_NULL]!",
+      "args": [
+        {
+          "name": "division",
+          "type": "String"
+        },
+        {
+          "name": "category",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "get_rounds_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_scoring_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_scoring_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_shotgun_ammo_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_shotgun_ammo_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_sra_targets_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_sra_tasks_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "handgun_targets",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "has_helfigur_2020",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "has_paper_or_bonus",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "id",
+      "type": "ID!",
+      "args": []
+    },
+    {
+      "name": "image",
+      "type": "SafeImageType",
+      "args": []
+    },
+    {
+      "name": "included",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_locked",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_nrof_scored_w_abc",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_nrof_scored_w_s123",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_scoring_started",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_third_party_scoring_kongsberg",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "lock_changed",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "lock_changed_by",
+      "type": "ShooterNode",
+      "args": []
+    },
+    {
+      "name": "manual_maximum_rounds",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "manual_minimum_rounds",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "match_percent",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "max_manual_rifle_points",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "max_points",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "max_sivil_time",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "maximum_rounds",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "minimum_rounds",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "name",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "number",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "paper",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "paper_2",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "penalties_notes",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "penalty",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "plate",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "popper",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "procedure",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "reactive",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "rifle_targets",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "safety_angles",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "score_manual_rifle",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "scorecards",
+      "type": "[NON_NULL]!",
+      "args": [
+        {
+          "name": "updated_after",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "scorecards_count",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "scorecards_dq",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "scorecards_w_warning",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "scoring",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "scoring_completed",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "scoring_progress",
+      "type": "ScoringProgressNode!",
+      "args": []
+    },
+    {
+      "name": "setup_notes",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "shotgun_ammo",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "shotgun_targets",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "sort",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "squad_scoring_progress",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "sra_targets",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "sra_tasks",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "sra_total_targets",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "sra_total_tasks",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "standard",
+      "type": "DjangoModelType",
+      "args": []
+    },
+    {
+      "name": "start_on",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "start_pos",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "stop_on",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "third_party_scoring_mode",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "third_party_scoring_url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "total_targets",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "updated",
+      "type": "DateTime!",
+      "args": []
+    },
+    {
+      "name": "updated_by",
+      "type": "ShooterNode",
+      "args": []
+    },
+    {
+      "name": "venue",
+      "type": "String!",
+      "args": []
+    }
+  ],
+  "IpscScoreCardNode": [
+    {
+      "name": "ascore",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "bscore",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "cat_percent",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "cat_place",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "cat_points",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "combined_percent",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "combined_place",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "combined_points",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "comment",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "competitor",
+      "type": "IpscCompetitorNode!",
+      "args": []
+    },
+    {
+      "name": "created",
+      "type": "DateTime!",
+      "args": []
+    },
+    {
+      "name": "created_by",
+      "type": "ShooterNode!",
+      "args": []
+    },
+    {
+      "name": "cscore",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "custom_data",
+      "type": "JSON!",
+      "args": []
+    },
+    {
+      "name": "deductions",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "disqualified",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "div_percent",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "div_place",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "div_points",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "dq_reason",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "dscore",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "evt",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "fte",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "get_content_type_key",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "get_content_type_model",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_dq_reason_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_dq_reason_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_full_absolute_url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_scoring_analytics",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_scoring_history",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_scoring_history_as_list",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "hitfactor",
+      "type": "Decimal",
+      "args": []
+    },
+    {
+      "name": "hscore",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "id",
+      "type": "ID!",
+      "args": []
+    },
+    {
+      "name": "incomplete",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_locked",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_verified",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_verified_w_signature",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "lock_changed",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "lock_changed_by",
+      "type": "ShooterNode",
+      "args": []
+    },
+    {
+      "name": "miss",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "miss_aerial_clay",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "mot_0",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "mot_1",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "mot_2",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "overtime",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "penalty",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "pf_correction",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "points",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "procedural",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "procedural_1",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "procedural_2",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "score",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "signature",
+      "type": "SafeImageType",
+      "args": []
+    },
+    {
+      "name": "single_non_zero",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "spec_penalty",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "sra_targets",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "sra_targets_incremental_score",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "sra_tasks",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "sra_tasks_score",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "stage",
+      "type": "IpscStageNode!",
+      "args": []
+    },
+    {
+      "name": "stage_not_fired",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "supports_scoring_analytics",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "time",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "timeplus",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "tne",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "tnh",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "tnn",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "updated",
+      "type": "DateTime!",
+      "args": []
+    },
+    {
+      "name": "updated_by",
+      "type": "ShooterNode",
+      "args": []
+    },
+    {
+      "name": "verified",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "verified_by",
+      "type": "ShooterNode",
+      "args": []
+    },
+    {
+      "name": "warning",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "xscore",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "zeroed",
+      "type": "Boolean!",
+      "args": []
+    }
+  ],
+  "IpscCompetitorNode": [
+    {
+      "name": "accepted_in_team",
+      "type": "TeamInterface",
+      "args": []
+    },
+    {
+      "name": "air_div",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "can_current_update",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "cat_percent",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "cat_place",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "cat_points",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "category",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "category_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "classification",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "classification_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "club",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "club_member",
+      "type": "DjangoModelType",
+      "args": []
+    },
+    {
+      "name": "code",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "combined_percent",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "combined_place",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "combined_points",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "comment",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "created",
+      "type": "DateTime!",
+      "args": []
+    },
+    {
+      "name": "created_by",
+      "type": "ShooterNode!",
+      "args": []
+    },
+    {
+      "name": "custom_data",
+      "type": "JSON!",
+      "args": []
+    },
+    {
+      "name": "details",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "did_not_finish",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "div_percent",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "div_place",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "div_points",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "email",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "event",
+      "type": "IpscMatchNode!",
+      "args": []
+    },
+    {
+      "name": "first_name",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_chronocard",
+      "type": "ChronoCardInterface!",
+      "args": []
+    },
+    {
+      "name": "get_air_div_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_air_div_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_category_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_cc_calling_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_chronocard",
+      "type": "ChronoCardInterface",
+      "args": []
+    },
+    {
+      "name": "get_classification_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_classification_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_club_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_club_member_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_club_short_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_code_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_code_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_content_type_key",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "get_content_type_model",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_division_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_full_absolute_url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_handgun_div_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_handgun_div_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_handgun_pf_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_handgun_pf_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_mini_rifle_div_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_mini_rifle_div_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_pcc_div_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_pcc_div_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_prec_rifle_div_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_prec_rifle_div_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_prec_rifle_pf_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_prec_rifle_pf_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_region_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_region_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_result_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_rifle_div_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_rifle_div_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_rifle_pf_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_rifle_pf_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_sex_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_sex_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_shotgun_div_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_shotgun_div_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_squad_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_sra_division_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_state_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_state_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_status_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_status_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_tournament_division_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "get_tournament_division_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "handgun_div",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "handgun_pf",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "has_accepted_event_data_policy",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "has_warning",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "ice_phone",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "ics_alias",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "id",
+      "type": "ID!",
+      "args": []
+    },
+    {
+      "name": "ipsc_region",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "is_alread_logged",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_chrono_approved",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_chrono_failed",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_chrono_pending",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_chronoed",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_disqualified",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_equipment_checked",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_locked",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_paid",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_scoring_started",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "last_name",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "license",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "lock_changed",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "lock_changed_by",
+      "type": "ShooterNode",
+      "args": []
+    },
+    {
+      "name": "mainmatch",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "merchandize_orders",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "mini_rifle_div",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "minimum_rounds",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "notify",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "nrof_id",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "number",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "payments",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "pcc_div",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "phone",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "pin",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "prec_rifle_div",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "prec_rifle_pf",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "prematch",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "region",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "rifle_div",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "rifle_pf",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "scorecards",
+      "type": "[NON_NULL]!",
+      "args": [
+        {
+          "name": "updated_after",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "scorecards_count",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "scoring_history",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "scoring_progress",
+      "type": "ScoringProgressNode!",
+      "args": []
+    },
+    {
+      "name": "sex",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "shooter",
+      "type": "ShooterNode!",
+      "args": []
+    },
+    {
+      "name": "shoots_handgun_major",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "shoots_manual_rifle",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "shoots_prec_rifle_major",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "shoots_rifle_major",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "shotgun_div",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "squad",
+      "type": "IpscSquadNode",
+      "args": []
+    },
+    {
+      "name": "sra_num",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "state",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "status",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "three_gun_id",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "tot_a",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "tot_b",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "tot_c",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "tot_d",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "tot_evt10",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "tot_miss",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "tot_penalty",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "tot_procedural",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "tot_raw_time",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "tournament_division",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "updated",
+      "type": "DateTime!",
+      "args": []
+    },
+    {
+      "name": "updated_by",
+      "type": "ShooterNode",
+      "args": []
+    },
+    {
+      "name": "uspsa_num",
+      "type": "String!",
+      "args": []
+    }
+  ],
+  "IpscSquadNode": [
+    {
+      "name": "chrono_progress",
+      "type": "ChronoProgressNode!",
+      "args": []
+    },
+    {
+      "name": "comment",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "competitors",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "competitors_count",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "competitors_indexed",
+      "type": "[NON_NULL]!",
+      "args": [
+        {
+          "name": "shift_on",
+          "type": "Int!"
+        },
+        {
+          "name": "incl_dnf",
+          "type": "Boolean!"
+        },
+        {
+          "name": "incl_dqed",
+          "type": "Boolean!"
+        }
+      ]
+    },
+    {
+      "name": "created",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "created_by",
+      "type": "ShooterNode",
+      "args": []
+    },
+    {
+      "name": "custom_data",
+      "type": "JSON!",
+      "args": []
+    },
+    {
+      "name": "event",
+      "type": "IpscMatchNode!",
+      "args": []
+    },
+    {
+      "name": "get_content_type_key",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "get_content_type_model",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_full_absolute_url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_next_squad",
+      "type": "SquadInterface!",
+      "args": []
+    },
+    {
+      "name": "get_previous_squad",
+      "type": "SquadInterface!",
+      "args": []
+    },
+    {
+      "name": "get_squad_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_squad_registration_choices",
+      "type": "[NON_NULL]!",
+      "args": []
+    },
+    {
+      "name": "id",
+      "type": "ID!",
+      "args": []
+    },
+    {
+      "name": "is_locked",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "lock_changed",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "lock_changed_by",
+      "type": "ShooterNode!",
+      "args": []
+    },
+    {
+      "name": "mainmatch",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "max_competitors",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "prematch",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "registration",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "scoring_progress",
+      "type": "ScoringProgressNode!",
+      "args": []
+    },
+    {
+      "name": "scoring_progress_at_stage",
+      "type": "ScoringProgressNode!",
+      "args": [
+        {
+          "name": "stage_id",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "updated",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "updated_by",
+      "type": "ShooterNode",
+      "args": []
+    }
+  ]
+}

--- a/tests/unit/scorecard-merge.test.ts
+++ b/tests/unit/scorecard-merge.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import { mergeScorecardDelta } from "@/lib/scorecard-merge";
+import type { RawScorecardsData } from "@/lib/scorecard-data";
+import type { ScorecardDeltaEntry } from "@/lib/graphql";
+
+function competitor(id: string) {
+  return { id, first_name: `F${id}`, last_name: `L${id}` };
+}
+
+function cachedFixture(): RawScorecardsData {
+  return {
+    event: {
+      stages: [
+        {
+          id: "100",
+          number: 1,
+          name: "Stage 1",
+          max_points: 80,
+          scorecards: [
+            { points: 60, hitfactor: 4.5, competitor: competitor("c1") },
+            { points: 50, hitfactor: 3.8, competitor: competitor("c2") },
+          ],
+        },
+        {
+          id: "101",
+          number: 2,
+          name: "Stage 2",
+          max_points: 100,
+          scorecards: [
+            { points: 90, hitfactor: 5.5, competitor: competitor("c1") },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+describe("mergeScorecardDelta", () => {
+  it("replaces an existing scorecard by (stage, competitor) and counts as updated", () => {
+    const cached = cachedFixture();
+    const delta: ScorecardDeltaEntry[] = [
+      {
+        stage: { id: "100" },
+        points: 75,
+        hitfactor: 5.2,
+        competitor: { id: "c1", first_name: "F1", last_name: "L1" },
+      },
+    ];
+
+    const result = mergeScorecardDelta(cached, delta);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.updatedCount).toBe(1);
+    expect(result.addedCount).toBe(0);
+    const stage = result.data.event!.stages![0];
+    const c1 = stage.scorecards!.find((s) => s.competitor?.id === "c1");
+    expect(c1?.points).toBe(75);
+    expect(c1?.hitfactor).toBe(5.2);
+    // Other competitor untouched
+    expect(stage.scorecards!.find((s) => s.competitor?.id === "c2")?.points).toBe(50);
+  });
+
+  it("appends a brand-new (stage, competitor) scorecard and counts as added", () => {
+    const cached = cachedFixture();
+    const delta: ScorecardDeltaEntry[] = [
+      {
+        stage: { id: "100" },
+        points: 70,
+        hitfactor: 4.0,
+        competitor: { id: "c3", first_name: "F3", last_name: "L3" },
+      },
+    ];
+
+    const result = mergeScorecardDelta(cached, delta);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.updatedCount).toBe(0);
+    expect(result.addedCount).toBe(1);
+    const stage = result.data.event!.stages![0];
+    expect(stage.scorecards!.length).toBe(3);
+    expect(stage.scorecards!.some((s) => s.competitor?.id === "c3")).toBe(true);
+  });
+
+  it("does not mutate the cached input", () => {
+    const cached = cachedFixture();
+    const before = JSON.stringify(cached);
+    mergeScorecardDelta(cached, [
+      {
+        stage: { id: "100" },
+        points: 1,
+        competitor: { id: "c1" },
+      },
+    ]);
+    expect(JSON.stringify(cached)).toBe(before);
+  });
+
+  it("fails with stage-missing when delta references an unknown stage (e.g. new stage added upstream)", () => {
+    const cached = cachedFixture();
+    const delta: ScorecardDeltaEntry[] = [
+      {
+        stage: { id: "999" }, // not in cached snapshot
+        points: 70,
+        competitor: { id: "c1" },
+      },
+    ];
+
+    const result = mergeScorecardDelta(cached, delta);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("stage-missing");
+  });
+
+  it("fails with competitor-missing on malformed delta", () => {
+    const cached = cachedFixture();
+    const delta: ScorecardDeltaEntry[] = [
+      {
+        stage: { id: "100" },
+        points: 70,
+        competitor: null,
+      },
+    ];
+
+    const result = mergeScorecardDelta(cached, delta);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("competitor-missing");
+  });
+
+  it("fails with no-event when cached entry has no event payload", () => {
+    const result = mergeScorecardDelta({ event: null }, []);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("no-event");
+  });
+
+  it("fails with stages-missing when cached entry has no stages array", () => {
+    const result = mergeScorecardDelta({ event: { stages: undefined } }, []);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("stages-missing");
+  });
+
+  it("merges a mixed batch (replaces some, appends others, across stages)", () => {
+    const cached = cachedFixture();
+    const delta: ScorecardDeltaEntry[] = [
+      // Replace c1 on stage 100
+      { stage: { id: "100" }, points: 78, competitor: { id: "c1" } },
+      // Append c2 on stage 101 (only c1 was there before)
+      { stage: { id: "101" }, points: 85, competitor: { id: "c2" } },
+      // Append brand-new c3 on stage 100
+      { stage: { id: "100" }, points: 60, competitor: { id: "c3" } },
+    ];
+
+    const result = mergeScorecardDelta(cached, delta);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.updatedCount).toBe(1);
+    expect(result.addedCount).toBe(2);
+    const s100 = result.data.event!.stages!.find((s) => s.id === "100")!;
+    const s101 = result.data.event!.stages!.find((s) => s.id === "101")!;
+    expect(s100.scorecards!.length).toBe(3); // c1, c2, c3
+    expect(s101.scorecards!.length).toBe(2); // c1, c2
+    expect(s100.scorecards!.find((s) => s.competitor?.id === "c1")?.points).toBe(78);
+  });
+
+  it("returns empty counts on empty delta", () => {
+    const result = mergeScorecardDelta(cachedFixture(), []);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.updatedCount).toBe(0);
+    expect(result.addedCount).toBe(0);
+  });
+});

--- a/tests/unit/scorecards-delta-integration.test.ts
+++ b/tests/unit/scorecards-delta-integration.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────
+
+const cacheMock = vi.hoisted(() => ({
+  setIfAbsent: vi.fn<(key: string, val: string, ttl: number) => Promise<boolean>>(),
+  set: vi.fn<(key: string, val: string, ttl: number | null) => Promise<void>>(),
+  expire: vi.fn<(key: string, ttl: number) => Promise<void>>(),
+  del: vi.fn<(key: string) => Promise<void>>(),
+  get: vi.fn<(key: string) => Promise<string | null>>(),
+  persist: vi.fn<(key: string) => Promise<void>>(),
+}));
+
+const dbMock = vi.hoisted(() => ({
+  recordMatchAccess: vi.fn(() => Promise.resolve()),
+  getMatchDataCache: vi.fn(() => Promise.resolve(null)),
+  getMatchDataCacheStoredAt: vi.fn(() => Promise.resolve(null)),
+  setMatchDataCache: vi.fn(() => Promise.resolve()),
+}));
+
+const upstreamMock = vi.hoisted(() => ({
+  markUpstreamDegraded: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/lib/cache-impl", () => ({ default: cacheMock }));
+vi.mock("@/lib/db-impl", () => ({ default: dbMock }));
+vi.mock("@/lib/upstream-status", () => upstreamMock);
+vi.mock("@/lib/background-impl", () => ({
+  afterResponse: (p: Promise<unknown>) => {
+    void p.catch(() => {});
+  },
+}));
+vi.mock("next/headers", () => ({
+  headers: () => Promise.resolve(new Map()),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+const KEY = 'gql:GetMatchScorecards:{"ct":22,"id":"26547"}';
+const QUERY = "query GetMatchScorecards { x }";
+const VARS = { ct: 22, id: "26547" };
+const MATCH = { ct: 22, id: "26547" };
+const SIDECAR = "probe:match-state:22:26547";
+const FORCE = "force-refresh:22:26547";
+
+function probeResponse(body: { updated?: string | null; status?: string | null; results?: string | null } | null) {
+  return new Response(JSON.stringify({ data: { event: body } }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function deltaResponse(scorecards: unknown[]) {
+  return new Response(JSON.stringify({ data: { event: { scorecards } } }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function fullResponse() {
+  return new Response(
+    JSON.stringify({
+      data: { event: { stages: [{ id: "100", number: 1, name: "S1", max_points: 80, scorecards: [] }] } },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function cachedScorecardsEntry(cachedAtIso: string) {
+  return JSON.stringify({
+    data: {
+      event: {
+        stages: [
+          {
+            id: "100",
+            number: 1,
+            name: "S1",
+            max_points: 80,
+            scorecards: [
+              { points: 60, hitfactor: 4.5, competitor: { id: "c1", first_name: "F1", last_name: "L1" } },
+            ],
+          },
+          { id: "101", number: 2, name: "S2", max_points: 100, scorecards: [] },
+        ],
+      },
+    },
+    cachedAt: cachedAtIso,
+    v: 12, // CACHE_SCHEMA_VERSION at time of writing — must match
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe("scorecards delta integration", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    cacheMock.setIfAbsent.mockReset();
+    cacheMock.set.mockReset();
+    cacheMock.expire.mockReset();
+    cacheMock.del.mockReset();
+    cacheMock.get.mockReset();
+    cacheMock.setIfAbsent.mockResolvedValue(true);
+    cacheMock.set.mockResolvedValue(undefined);
+    cacheMock.expire.mockResolvedValue(undefined);
+    cacheMock.del.mockResolvedValue(undefined);
+    upstreamMock.markUpstreamDegraded.mockClear();
+
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    process.env.SSI_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.SCORECARDS_DELTA_ENABLED;
+    delete process.env.SCORECARDS_DELTA_MAX_AGE_SECONDS;
+    delete process.env.MATCH_PROBE_ENABLED;
+  });
+
+  it("attempts a delta merge on probe=changed for scorecards keys", async () => {
+    // Re-read to confirm cache schema version, then write the value.
+    const { CACHE_SCHEMA_VERSION } = await import("@/lib/constants");
+    const cachedAt = new Date(Date.now() - 30_000).toISOString(); // 30s ago — well within reconcile window
+    cacheMock.get.mockImplementation(async (k) => {
+      if (k === SIDECAR) {
+        return JSON.stringify({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org" });
+      }
+      if (k === KEY) {
+        const entry = JSON.parse(cachedScorecardsEntry(cachedAt));
+        entry.v = CACHE_SCHEMA_VERSION;
+        return JSON.stringify(entry);
+      }
+      return null;
+    });
+
+    fetchSpy
+      .mockResolvedValueOnce(probeResponse({ updated: "2026-04-28T10:05:00Z", status: "on", results: "org" }))
+      .mockResolvedValueOnce(
+        deltaResponse([
+          {
+            stage: { id: "100" },
+            points: 75,
+            hitfactor: 5.2,
+            competitor: { id: "c1", first_name: "F1", last_name: "L1" },
+          },
+        ]),
+      );
+
+    const { refreshCachedMatchQuery } = await import("@/lib/graphql");
+    await refreshCachedMatchQuery(KEY, QUERY, VARS, 90, MATCH);
+
+    // 2 fetches: probe + delta. NOT 3 (no full refetch).
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    // The merged snapshot was written back to KEY.
+    const writeCalls = cacheMock.set.mock.calls.filter((c) => c[0] === KEY);
+    expect(writeCalls.length).toBe(1);
+    const written = JSON.parse(writeCalls[0]![1] as string);
+    // Merged scorecard reflects the delta values.
+    const c1 = written.data.event.stages.find((s: { id: string }) => s.id === "100").scorecards.find((sc: { competitor: { id: string } }) => sc.competitor.id === "c1");
+    expect(c1.points).toBe(75);
+    // Original cachedAt must be preserved (reconcile timer).
+    expect(written.cachedAt).toBe(cachedAt);
+  });
+
+  it("forces a reconcile (full refetch) when the cached entry is older than SCORECARDS_DELTA_MAX_AGE_SECONDS", async () => {
+    process.env.SCORECARDS_DELTA_MAX_AGE_SECONDS = "120"; // 2 min ceiling
+    const { CACHE_SCHEMA_VERSION } = await import("@/lib/constants");
+    const staleCachedAt = new Date(Date.now() - 5 * 60_000).toISOString(); // 5 min ago
+    cacheMock.get.mockImplementation(async (k) => {
+      if (k === SIDECAR) {
+        return JSON.stringify({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org" });
+      }
+      if (k === KEY) {
+        const entry = JSON.parse(cachedScorecardsEntry(staleCachedAt));
+        entry.v = CACHE_SCHEMA_VERSION;
+        return JSON.stringify(entry);
+      }
+      return null;
+    });
+
+    fetchSpy
+      .mockResolvedValueOnce(probeResponse({ updated: "2026-04-28T10:05:00Z", status: "on", results: "org" }))
+      .mockResolvedValueOnce(fullResponse());
+
+    const { refreshCachedMatchQuery } = await import("@/lib/graphql");
+    await refreshCachedMatchQuery(KEY, QUERY, VARS, 90, MATCH);
+
+    // 2 fetches: probe + full refresh. No delta query.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to full refetch when merge fails (delta references unknown stage)", async () => {
+    const { CACHE_SCHEMA_VERSION } = await import("@/lib/constants");
+    const cachedAt = new Date(Date.now() - 30_000).toISOString();
+    cacheMock.get.mockImplementation(async (k) => {
+      if (k === SIDECAR) {
+        return JSON.stringify({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org" });
+      }
+      if (k === KEY) {
+        const entry = JSON.parse(cachedScorecardsEntry(cachedAt));
+        entry.v = CACHE_SCHEMA_VERSION;
+        return JSON.stringify(entry);
+      }
+      return null;
+    });
+
+    fetchSpy
+      .mockResolvedValueOnce(probeResponse({ updated: "2026-04-28T10:05:00Z", status: "on", results: "org" }))
+      .mockResolvedValueOnce(
+        deltaResponse([
+          { stage: { id: "999" }, points: 10, competitor: { id: "c9" } }, // unknown stage
+        ]),
+      )
+      .mockResolvedValueOnce(fullResponse());
+
+    const { refreshCachedMatchQuery } = await import("@/lib/graphql");
+    await refreshCachedMatchQuery(KEY, QUERY, VARS, 90, MATCH);
+
+    // 3 fetches: probe + failed delta + full refresh fallback.
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("kill switch SCORECARDS_DELTA_ENABLED=off skips the delta path entirely", async () => {
+    process.env.SCORECARDS_DELTA_ENABLED = "off";
+    const { CACHE_SCHEMA_VERSION } = await import("@/lib/constants");
+    const cachedAt = new Date(Date.now() - 30_000).toISOString();
+    cacheMock.get.mockImplementation(async (k) => {
+      if (k === SIDECAR) {
+        return JSON.stringify({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org" });
+      }
+      if (k === KEY) {
+        const entry = JSON.parse(cachedScorecardsEntry(cachedAt));
+        entry.v = CACHE_SCHEMA_VERSION;
+        return JSON.stringify(entry);
+      }
+      return null;
+    });
+
+    fetchSpy
+      .mockResolvedValueOnce(probeResponse({ updated: "2026-04-28T10:05:00Z", status: "on", results: "org" }))
+      .mockResolvedValueOnce(fullResponse());
+
+    const { refreshCachedMatchQuery } = await import("@/lib/graphql");
+    await refreshCachedMatchQuery(KEY, QUERY, VARS, 90, MATCH);
+
+    // 2 fetches: probe + full refresh. No delta query.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("force-refresh sentinel bypasses probe and delta entirely, then clears itself", async () => {
+    cacheMock.get.mockImplementation(async (k) => {
+      if (k === FORCE) return "1"; // sentinel set
+      return null;
+    });
+    fetchSpy.mockResolvedValueOnce(fullResponse());
+
+    const { refreshCachedMatchQuery } = await import("@/lib/graphql");
+    await refreshCachedMatchQuery(KEY, QUERY, VARS, 90, MATCH);
+
+    // Only one fetch — the full refresh — no probe.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // Sentinel must be cleared after the full refresh succeeds.
+    expect(cacheMock.del).toHaveBeenCalledWith(FORCE);
+  });
+
+  it("does NOT attempt delta on a match key (only scorecards keys are delta-eligible)", async () => {
+    const matchKey = 'gql:GetMatch:{"ct":22,"id":"26547"}';
+    cacheMock.get.mockImplementation(async (k) => {
+      if (k === SIDECAR) {
+        return JSON.stringify({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org" });
+      }
+      return null;
+    });
+
+    fetchSpy
+      .mockResolvedValueOnce(probeResponse({ updated: "2026-04-28T10:05:00Z", status: "on", results: "org" }))
+      .mockResolvedValueOnce(fullResponse());
+
+    const { refreshCachedMatchQuery } = await import("@/lib/graphql");
+    await refreshCachedMatchQuery(matchKey, "query GetMatch { x }", VARS, 90, MATCH);
+
+    // 2 fetches: probe + full refresh. No delta query was attempted.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Closes #362. Stacks on top of #361 (merged in #364).

## Summary

When the match-level probe (#361) reports `changed` for a `GetMatchScorecards` key, fetch only scorecards updated since the last known `match.updated` and merge into the cached snapshot. Validated empirically: at the match level, `match.updated` tracks scorecard activity (Django post_save), so the delta window is correct. Match metadata (`GetMatch`) keys still go through the existing full-refresh path -- only scorecards have a delta primitive.

## Belt-and-suspenders

- `SCORECARDS_DELTA_ENABLED=off` -- kill switch back to full refetch on every `changed` outcome.
- `SCORECARDS_DELTA_MAX_AGE_SECONDS` (default `600`) -- periodic full reconcile to self-heal from drift the delta cannot detect: upstream deletions, new stages, subtle merge bugs. Cached entry's *original* `cachedAt` is the reference -- delta merges intentionally do NOT bump it so the timer keeps ticking.
- **Force-refresh sentinel** + admin endpoint `POST /api/admin/cache/force-refresh?ct=&id=` -- recovery lever for live-match incidents. Sets a `force-refresh:{ct}:{id}` Redis key that bypasses probe and delta entirely; cleared automatically after a successful full refresh.
- Shared `SCORECARD_NODE_FIELDS` constant interpolated into both `SCORECARDS_QUERY` and `SCORECARDS_DELTA_QUERY` so the two cannot drift in fields silently.
- `mergeScorecardDelta` is pure (no I/O); fails closed on missing stage / competitor / event so callers fall back to full refetch instead of writing a corrupt snapshot.

## SSI schema drift detection

The delta path makes us coupled to SSI's scorecard structure. Added tooling to catch drift early:

- `scripts/check-ssi-schema.ts` -- introspects the live SSI schema, compares against `scripts/ssi-schema-snapshot.json`, reports added / removed / changed fields on `IpscMatchNode`, `IpscStageNode`, `IpscScoreCardNode`, `IpscCompetitorNode`, `IpscSquadNode`.
- `pnpm check:ssi-schema [--update | --json]`
- `.github/workflows/check-ssi-schema.yml` runs weekly Monday 06:00 UTC. Failure surfaces in the Actions tab.

CLAUDE.md → "Delta-merge contract" documents the full update checklist for whoever changes scorecard fields next.

## Telemetry

`cache-telemetry` `scorecards-delta` event with:

- `outcome`: `delta-merge` | `full-fallback` | `reconcile` | `error` | `disabled`
- `deltaCount` / `updatedCount` / `addedCount`
- `mergeMs` / `deltaBytes`
- `reason` (short string for non-success outcomes)

Combined with upstream `graphql-request` events (operation `GetMatchScorecardsDelta` vs `GetMatchScorecards`), DuckDB can compute the % of refetches replaced by deltas and bytes saved.

## Test plan

- [x] `pnpm -w run typecheck` -- clean
- [x] `pnpm -w run lint` -- clean
- [x] `pnpm -w test` -- 1550 tests passing (15 new across `scorecard-merge.test.ts` and `scorecards-delta-integration.test.ts`).
- [x] `pnpm check:ssi-schema` -- snapshot in sync with live SSI.
- [ ] Watch telemetry on the next active match: confirm `delta-merge` outcomes outnumber `full-fallback` / `reconcile`; verify `deltaBytes` is meaningfully smaller than the corresponding `GetMatchScorecards` payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)