### PR TITLE
fix(events): scoring_completed must be inside IpscMatchNode fragment

### DIFF
--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -769,10 +769,10 @@ export const EVENTS_QUERY = `
       ends
       status
       region
-      scoring_completed
       get_full_rule_display
       get_full_level_display
       ... on IpscMatchNode {
+        scoring_completed
         registration_starts
         registration_closes
         squadding_starts


### PR DESCRIPTION
## Bug

After #367 deployed to staging, the entire `/api/events` route started 502'ing. SSI rejected every events query with:

```
'IpscSerie' object has no attribute 'scoring_completed'
```

User-visible impact: homepage event search returned nothing for any filter combination, Live Now card 502'd, filter-state UI looked reset because the failed query couldn't populate the dropdown.

## Cause

#367 added `scoring_completed` to `EVENTS_QUERY` at the top level. That works for `event()` (single match, always `IpscMatchNode`) but `events()` returns a mixed list of `IpscMatchNode` (ct=22) and `IpscSerieNode` (ct=43). `scoring_completed` exists on the former but not the latter, and the field has to be inside the `... on IpscMatchNode` fragment — not on the `EventInterface`.

My pre-merge curl test used a 2-day window that happened to return zero series nodes, so the bug didn't surface. The default browse window (±3 months) always includes some.

## Fix

Move `scoring_completed` inside the `... on IpscMatchNode` fragment. Series nodes get filtered out downstream via `ct === 22`, and the route handler already treats the field as nullable (`e.scoring_completed != null ? parseFloat(...) : 0`).

## Verification

Empirically tested against a 30-day window with mixed types: 90 events, 83 ct=22 + 7 ct=43, query succeeds, `scoring_completed` populated on matches only.

```
$ curl ... events { id ct ... on IpscMatchNode { scoring_completed } }
OK: 90 events, ct mix: {22: 83, 43: 7}
ct=22 sample: scoring_completed=100.0
ct=43 sample: scoring_completed key present? False
```

## Test plan

- [x] `pnpm -w run typecheck` -- clean
- [x] `pnpm -w run lint` -- clean
- [x] `pnpm -w test` -- 1550 tests passing
- [x] Manual GraphQL probe against live SSI with mixed-ct results -- query now returns 200
- [ ] Deploy to staging; verify event search dropdown returns results and Live Now no longer 502s

🤖 Generated with [Claude Code](https://claude.com/claude-code)