### PR TITLE
Static GraphQL query validator + landing-page SSI resilience

### DIFF
--- a/.github/workflows/check-ssi-schema.yml
+++ b/.github/workflows/check-ssi-schema.yml
@@ -38,3 +38,9 @@ jobs:
         env:
           SSI_API_KEY: ${{ secrets.SSI_API_KEY }}
         run: pnpm check:ssi-schema
+
+      # Belt-and-braces: even when drift detection passes, re-run the static
+      # query validator. Catches the case where someone updated the snapshot
+      # via `--update` without re-checking that our outbound queries still
+      # line up with what's now in the snapshot.
+      - run: pnpm validate:ssi-queries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
 
       - run: pnpm typecheck   # tsc --noEmit
 
+      - run: pnpm validate:ssi-queries   # static check vs scripts/ssi-schema-snapshot.json
+
       - run: pnpm test
 
       - run: pnpm build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,10 +264,23 @@ GraphQL query, the corresponding TypeScript type, and bump `CACHE_SCHEMA_VERSION
 pnpm check:ssi-schema           # report drift, exit 1 if any
 pnpm check:ssi-schema --update  # accept current schema as the new snapshot
 pnpm check:ssi-schema --json    # machine-readable output for CI
+
+pnpm validate:ssi-queries       # static check: every field/arg in every
+                                # outbound query exists on the parent type
+                                # in the snapshot. Zero network. Runs in CI.
 ```
 
-The script introspects `IpscMatchNode`, `IpscStageNode`, `IpscScoreCardNode`,
-`IpscCompetitorNode`, and `IpscSquadNode` from the live SSI GraphQL endpoint and compares against
+`validate:ssi-queries` parses each query in `lib/graphql.ts`, walks the AST
+against `scripts/ssi-schema-snapshot.json`, and fails on missing fields,
+undeclared arguments, or fields whose parent type doesn't declare them. It
+catches snapshot/query drift and typos. It **does not** catch resolver-level
+bugs where the schema advertises a field on an interface but the underlying
+Django model on a subtype throws `AttributeError` at runtime (the #367 class) —
+that gap needs a live dry-run smoke test, not static introspection.
+
+The script introspects `RootQuery`, `EventInterface`, `IpscMatchNode`,
+`IpscStageNode`, `IpscScoreCardNode`, `IpscCompetitorNode`, and `IpscSquadNode`
+from the live SSI GraphQL endpoint and compares against
 `scripts/ssi-schema-snapshot.json`. Run it weekly (manually or via cron) to catch silent
 upstream changes. If it reports drift:
 

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -152,19 +152,47 @@ export async function GET(req: Request) {
       // No search text: work around the API's per-request result cap by
       // splitting the date range into small sub-windows, fetching in
       // parallel, then deduplicating by event ID.
+      //
+      // Use allSettled so one transient SSI hiccup doesn't blank the whole
+      // page. SSI occasionally drops POST bodies and surfaces "Must provide
+      // document." for a single window; degrading to a partial result (one
+      // 7-day gap) is far better UX than a 502 over the entire date range.
+      // executeQuery already retries that specific transient internally; we
+      // only land here if the retry also failed.
       const windows = buildSubWindows(startsAfter, startsBefore, firearms ? { firearms } : {});
-      const results = await Promise.all(
+      const settled = await Promise.allSettled(
         windows.map((vars) => executeQuery<RawEventsData>(EVENTS_QUERY, vars, 3600)),
       );
+      const failures: string[] = [];
       const seen = new Set<string>();
       rawEvents = [];
-      for (const result of results) {
-        for (const event of result.events) {
-          if (!seen.has(event.id)) {
-            seen.add(event.id);
-            rawEvents.push(event);
+      for (let i = 0; i < settled.length; i++) {
+        const r = settled[i];
+        if (r.status === "fulfilled") {
+          for (const event of r.value.events) {
+            if (!seen.has(event.id)) {
+              seen.add(event.id);
+              rawEvents.push(event);
+            }
           }
+        } else {
+          const w = windows[i];
+          failures.push(`${w.starts_after}..${w.starts_before}: ${r.reason instanceof Error ? r.reason.message : String(r.reason)}`);
         }
+      }
+      // If every sub-window failed there's nothing useful to return — surface
+      // the original 502 so the client error path runs (existing behaviour).
+      if (failures.length > 0 && failures.length === windows.length) {
+        throw new Error(failures.join(" | "));
+      }
+      if (failures.length > 0) {
+        console.warn(JSON.stringify({
+          route: "events",
+          partial_failure: true,
+          failed_windows: failures.length,
+          total_windows: windows.length,
+          first_error: failures[0],
+        }));
       }
     }
   } catch (err) {

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -43,32 +43,39 @@ const ALLOWED_LEVELS: Record<string, Set<string> | null> = {
 
 // The SSI API applies an undocumented result cap per query when browsing
 // without a search term, silently dropping events further out in the date
-// window. We work around it by splitting the requested range into small
-// sub-windows so each request stays well under the cap.
+// window. We work around it by splitting the requested range into sub-windows
+// so each request stays well under the cap. Each sub-window gets its own
+// Next.js fetch-cache entry (revalidate: 3600), so they cache independently.
 //
-// 7 days is chosen to stay safe even when no firearms filter is set: country
-// and minLevel are *post-fetch* filters in this route (the SSI GraphQL has no
-// params for them), so the cap bites on the unfiltered upstream count, not on
-// what the user sees. Bug seen in the wild: browsing a month with discipline
-// "All" + country=SWE + minLevel=L2+ used to show only the first ~9 days
-// because the single 1-month query was already truncated before SWE/L2+
-// filtering ran.
+// Sub-window size is adaptive based on whether SSI is doing upstream
+// filtering for us:
 //
-// Each sub-window gets its own Next.js fetch-cache entry (revalidate: 3600),
-// so the extra requests are cached independently.
-const SUB_WINDOW_DAYS = 7;
+//   No firearms filter ("All"): 7 days — country and minLevel are *post-fetch*
+//   filters here (the SSI GraphQL has no params for them), so the cap bites on
+//   the unfiltered worldwide IPSC count. Bug seen in the wild: browsing a
+//   month with discipline "All" + country=SWE + minLevel=L2+ used to show only
+//   the first ~9 days because the single 1-month query was already truncated
+//   before SWE/L2+ filtering ran. 7 days stays safely under that ceiling.
+//
+//   Firearms filter set (Handgun / Rifle / Shotgun / PCC / etc.): 30 days —
+//   SSI filters upstream, the result count drops several-fold, and a 30-day
+//   window fits comfortably under the cap. This drops a typical filtered
+//   month browse from ~5 GraphQL calls to 1.
+const SUB_WINDOW_DAYS_FILTERED = 30;
+const SUB_WINDOW_DAYS_UNFILTERED = 7;
 
 function buildSubWindows(
   startsAfter: string,
   startsBefore: string,
   baseVars: Record<string, string>,
+  windowDays: number,
 ): Array<Record<string, string>> {
   const windows: Array<Record<string, string>> = [];
   let cur = new Date(startsAfter);
   const end = new Date(startsBefore);
   while (cur < end) {
     const next = new Date(cur);
-    next.setDate(next.getDate() + SUB_WINDOW_DAYS);
+    next.setDate(next.getDate() + windowDays);
     if (next > end) next.setTime(end.getTime());
     windows.push({
       ...baseVars,
@@ -96,12 +103,16 @@ export async function GET(req: Request) {
   // Query params: q (search), starts_after, starts_before (ISO dates),
   // firearms (default "hg"), country (ISO 3166-1 alpha-3, e.g. "SWE"),
   // minLevel (default "all" — callers omit the param when they want everything).
-  // Caller may override the date window; fall back to ±3 months from today.
+  //
+  // The browse UI (components/event-search.tsx) always sends an explicit
+  // 1-month window, so the default below is a fallback only for off-path
+  // callers (admin curls, scripts, MCP tools). Kept tight at ±1 month so a
+  // bare `GET /api/events` doesn't pull half a year of data.
   const now = new Date();
   const defaultAfter = new Date(now);
-  defaultAfter.setMonth(defaultAfter.getMonth() - 3);
+  defaultAfter.setMonth(defaultAfter.getMonth() - 1);
   const defaultBefore = new Date(now);
-  defaultBefore.setMonth(defaultBefore.getMonth() + 3);
+  defaultBefore.setMonth(defaultBefore.getMonth() + 1);
 
   const country = searchParams.get("country");
   const minLevel = searchParams.get("minLevel") ?? "all";
@@ -113,7 +124,7 @@ export async function GET(req: Request) {
   // When a text query is present the caller is searching for a specific event
   // and we should not silently clip results to a narrow date window — use a
   // wide fallback (5 years back / 2 years forward) so past matches are found.
-  // The narrow ±3-month default applies only to browse mode (no q) where we
+  // The narrow ±1-month default applies only to browse mode (no q) where we
   // need the sub-window strategy to work around the SSI API result cap.
   const wideAfter = new Date(now);
   wideAfter.setFullYear(wideAfter.getFullYear() - 5);
@@ -159,7 +170,11 @@ export async function GET(req: Request) {
       // 7-day gap) is far better UX than a 502 over the entire date range.
       // executeQuery already retries that specific transient internally; we
       // only land here if the retry also failed.
-      const windows = buildSubWindows(startsAfter, startsBefore, firearms ? { firearms } : {});
+      // SSI filters by `firearms` upstream, so a filter cuts the unfiltered
+      // worldwide count enough that a single 30-day window fits under the cap.
+      // Without a filter we stay on 7-day chunks to dodge the cap entirely.
+      const windowDays = firearms ? SUB_WINDOW_DAYS_FILTERED : SUB_WINDOW_DAYS_UNFILTERED;
+      const windows = buildSubWindows(startsAfter, startsBefore, firearms ? { firearms } : {}, windowDays);
       const settled = await Promise.allSettled(
         windows.map((vars) => executeQuery<RawEventsData>(EVENTS_QUERY, vars, 3600)),
       );

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -45,10 +45,38 @@ interface GraphQLResponse<T> {
  *  for large matches with many scorecards, so we allow a generous window. */
 const GRAPHQL_TIMEOUT_MS = 60_000;
 
+/** Error messages we treat as a transient upstream condition worth one retry.
+ *  "Must provide document." is graphql-core's message when SSI's parser sees
+ *  an empty query string — observed in production when SSI's gateway
+ *  occasionally drops the POST body on a busy isolate. A second attempt with
+ *  the same payload almost always succeeds. */
+const RETRY_GRAPHQL_MESSAGES = [
+  "Must provide document.",
+];
+
 export async function executeQuery<T>(
   query: string,
   variables?: Record<string, unknown>,
   revalidate: number | false = false,
+): Promise<T> {
+  try {
+    return await executeQueryOnce<T>(query, variables, revalidate);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "";
+    if (RETRY_GRAPHQL_MESSAGES.some((m) => msg.includes(m))) {
+      // Single immediate retry. We don't back off — the failure mode is a
+      // dropped body at SSI's gateway, not load shedding, so a retry helps
+      // most when it goes out right behind the failed request.
+      return await executeQueryOnce<T>(query, variables, revalidate);
+    }
+    throw err;
+  }
+}
+
+async function executeQueryOnce<T>(
+  query: string,
+  variables: Record<string, unknown> | undefined,
+  revalidate: number | false,
 ): Promise<T> {
   const apiKey = process.env.SSI_API_KEY;
   if (!apiKey) throw new Error("SSI_API_KEY is not configured");

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "warm-cache": "tsx scripts/warm-cache.ts",
     "release:post": "tsx scripts/generate-release-post.ts",
     "release:screenshots": "tsx scripts/screenshot-match.ts",
-    "check:ssi-schema": "tsx scripts/check-ssi-schema.ts"
+    "check:ssi-schema": "tsx scripts/check-ssi-schema.ts",
+    "validate:ssi-queries": "tsx scripts/validate-ssi-queries.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
@@ -67,6 +68,7 @@
     "@vitejs/plugin-react": "5.1.4",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
+    "graphql": "16.13.2",
     "jsdom": "28.1.0",
     "shadcn": "^4.0.6",
     "tailwindcss": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       eslint-config-next:
         specifier: 16.2.4
         version: 16.2.4(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      graphql:
+        specifier: 16.13.2
+        version: 16.13.2
       jsdom:
         specifier: 28.1.0
         version: 28.1.0(@noble/hashes@1.8.0)
@@ -10321,8 +10324,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -10344,7 +10347,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10355,22 +10358,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10381,7 +10384,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/scripts/check-ssi-schema.ts
+++ b/scripts/check-ssi-schema.ts
@@ -27,7 +27,14 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_PATH = resolve(__dirname, "ssi-schema-snapshot.json");
 
 // Types we depend on. If you start consuming new types from SSI, add them here.
+//
+// `RootQuery` and `EventInterface` are tracked so the static query validator
+// (scripts/validate-ssi-queries.ts) can verify field selections at the top
+// level of `event(...)` and `events(...)` — that's where the #367 regression
+// hid (`scoring_completed` selected on EventInterface instead of IpscMatchNode).
 const TRACKED_TYPES = [
+  "RootQuery",
+  "EventInterface",
   "IpscMatchNode",
   "IpscStageNode",
   "IpscScoreCardNode",
@@ -48,21 +55,30 @@ interface FieldEntry {
 
 type Snapshot = Record<string, FieldEntry[]>;
 
-function typeRef(t: { name: string | null; kind: string; ofType?: { name: string | null; kind: string } | null }): string {
+interface RawType {
+  name: string | null;
+  kind: string;
+  ofType?: RawType | null;
+}
+
+function typeRef(t: RawType): string {
   if (t.kind === "NON_NULL" && t.ofType) return `${typeRef(t.ofType)}!`;
   if (t.kind === "LIST" && t.ofType) return `[${typeRef(t.ofType)}]`;
   return t.name ?? t.kind;
 }
 
 async function introspectType(typeName: string, endpoint: string, token: string): Promise<FieldEntry[]> {
-  const query = `{ __type(name: "${typeName}") { fields { name type { name kind ofType { name kind ofType { name kind } } } args { name type { name kind ofType { name kind } } } } } }`;
+  // Five levels of `ofType` lets us name types like `[ChronoCardNode!]!`
+  // (NON_NULL → LIST → NON_NULL → ChronoCardNode), which the previous
+  // three-level walk reduced to the placeholder `[NON_NULL]!`.
+  const query = `{ __type(name: "${typeName}") { fields { name type { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind } } } } } args { name type { name kind ofType { name kind ofType { name kind ofType { name kind } } } } } } } }`;
   const r = await fetch(endpoint, {
     method: "POST",
     headers: { "Content-Type": "application/json", Authorization: `Token ${token}` },
     body: JSON.stringify({ query }),
   });
   if (!r.ok) throw new Error(`SSI HTTP ${r.status}`);
-  const json = (await r.json()) as { data?: { __type?: { fields?: { name: string; type: { name: string | null; kind: string; ofType?: { name: string | null; kind: string; ofType?: { name: string | null; kind: string } | null } | null }; args: { name: string; type: { name: string | null; kind: string; ofType?: { name: string | null; kind: string } | null } }[] }[] | null } | null } };
+  const json = (await r.json()) as { data?: { __type?: { fields?: { name: string; type: RawType; args: { name: string; type: RawType }[] }[] | null } | null } };
   const fields = json.data?.__type?.fields ?? [];
   return fields
     .map((f): FieldEntry => ({

--- a/scripts/ssi-schema-snapshot.json
+++ b/scripts/ssi-schema-snapshot.json
@@ -1,4 +1,1927 @@
 {
+  "RootQuery": [
+    {
+      "name": "ammunition",
+      "type": "AmmunitionNode!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "ammunitions",
+      "type": "[AmmunitionNode!]!",
+      "args": [
+        {
+          "name": "search",
+          "type": "String"
+        },
+        {
+          "name": "caliber",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "competitor",
+      "type": "CompetitorInterface!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "event",
+      "type": "EventInterface!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "event_scoring_progress_for_string",
+      "type": "ScoringProgressNode!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
+        },
+        {
+          "name": "index",
+          "type": "Int!"
+        }
+      ]
+    },
+    {
+      "name": "events",
+      "type": "[EventInterface!]!",
+      "args": [
+        {
+          "name": "search",
+          "type": "String"
+        },
+        {
+          "name": "starts_after",
+          "type": "String"
+        },
+        {
+          "name": "starts_before",
+          "type": "String"
+        },
+        {
+          "name": "status",
+          "type": "String"
+        },
+        {
+          "name": "region",
+          "type": "String"
+        },
+        {
+          "name": "state",
+          "type": "String"
+        },
+        {
+          "name": "rule",
+          "type": "String"
+        },
+        {
+          "name": "sub_rule",
+          "type": "String"
+        },
+        {
+          "name": "firearms",
+          "type": "String"
+        },
+        {
+          "name": "level",
+          "type": "String"
+        },
+        {
+          "name": "levels",
+          "type": "String"
+        },
+        {
+          "name": "has_role",
+          "type": "Boolean"
+        }
+      ]
+    },
+    {
+      "name": "firearm",
+      "type": "FirearmNode!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "firearms",
+      "type": "[FirearmNode!]!",
+      "args": [
+        {
+          "name": "search",
+          "type": "String"
+        },
+        {
+          "name": "caliber",
+          "type": "String"
+        },
+        {
+          "name": "make",
+          "type": "String"
+        },
+        {
+          "name": "weapon_generic",
+          "type": "String"
+        },
+        {
+          "name": "weapon_type",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "friend",
+      "type": "FriendNode!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "get_abstract_ammunition",
+      "type": "AmmunitionNode!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_event",
+      "type": "EventInterface!",
+      "args": [
+        {
+          "name": "rule",
+          "type": "String!"
+        },
+        {
+          "name": "sub_rule",
+          "type": "String!"
+        },
+        {
+          "name": "serie_type",
+          "type": "String"
+        },
+        {
+          "name": "firearms",
+          "type": "String"
+        },
+        {
+          "name": "classifier",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "get_abstract_firearm",
+      "type": "FirearmNode!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_handload_recipe",
+      "type": "HandloadRecipeNode!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_logentry",
+      "type": "LogEntryNode!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_merchandize",
+      "type": "MerchandizeNode!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_organization",
+      "type": "OrganizationNode!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_sight",
+      "type": "SightNode!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_suppressor",
+      "type": "SuppressorNode!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_user",
+      "type": "ShooterNode!",
+      "args": []
+    },
+    {
+      "name": "get_active_roles",
+      "type": "[String!]!",
+      "args": [
+        {
+          "name": "su_ct",
+          "type": "Int!"
+        },
+        {
+          "name": "su_id",
+          "type": "Int!"
+        },
+        {
+          "name": "tg_ct",
+          "type": "Int!"
+        },
+        {
+          "name": "tg_id",
+          "type": "Int!"
+        }
+      ]
+    },
+    {
+      "name": "get_current_active_roles",
+      "type": "[String!]!",
+      "args": [
+        {
+          "name": "tg_ct",
+          "type": "Int!"
+        },
+        {
+          "name": "tg_id",
+          "type": "Int!"
+        }
+      ]
+    },
+    {
+      "name": "group",
+      "type": "GroupNode!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "group_member",
+      "type": "GroupMemberNode!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "handload_recipe",
+      "type": "HandloadRecipeNode!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "handload_recipes",
+      "type": "[HandloadRecipeNode!]!",
+      "args": [
+        {
+          "name": "search",
+          "type": "String"
+        },
+        {
+          "name": "caliber",
+          "type": "String"
+        },
+        {
+          "name": "bullet_weight_gram",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "has_current_extended_permission",
+      "type": "Boolean!",
+      "args": [
+        {
+          "name": "ob_ct",
+          "type": "Int!"
+        },
+        {
+          "name": "ob_id",
+          "type": "Int!"
+        },
+        {
+          "name": "operation",
+          "type": "String!"
+        },
+        {
+          "name": "tg_ct",
+          "type": "Int!"
+        },
+        {
+          "name": "tg_id",
+          "type": "Int!"
+        }
+      ]
+    },
+    {
+      "name": "has_current_permission_wrt_group",
+      "type": "Boolean!",
+      "args": [
+        {
+          "name": "ob_ct",
+          "type": "Int!"
+        },
+        {
+          "name": "ob_id",
+          "type": "Int!"
+        },
+        {
+          "name": "operation",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "has_permission",
+      "type": "Boolean!",
+      "args": [
+        {
+          "name": "ob_ct",
+          "type": "Int!"
+        },
+        {
+          "name": "ob_id",
+          "type": "Int!"
+        },
+        {
+          "name": "operation",
+          "type": "String!"
+        },
+        {
+          "name": "su_ct",
+          "type": "Int!"
+        },
+        {
+          "name": "su_id",
+          "type": "Int!"
+        },
+        {
+          "name": "tg_ct",
+          "type": "Int!"
+        },
+        {
+          "name": "tg_id",
+          "type": "Int!"
+        }
+      ]
+    },
+    {
+      "name": "logentry",
+      "type": "LogEntryNode!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "me",
+      "type": "ShooterNode",
+      "args": []
+    },
+    {
+      "name": "merchandize",
+      "type": "MerchandizeNode!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "merchandize_order",
+      "type": "MerchandizeOrderNode!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "organization",
+      "type": "OrganizationNode!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "organization_member",
+      "type": "OrganizationMemberNode!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "organizations",
+      "type": "[OrganizationNode!]!",
+      "args": [
+        {
+          "name": "search",
+          "type": "String!"
+        },
+        {
+          "name": "region",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "payment",
+      "type": "PaymentInterface!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "scorecard",
+      "type": "ScoreCardInterface!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "shooter",
+      "type": "ShooterNode!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "shooters",
+      "type": "[ShooterNode!]!",
+      "args": [
+        {
+          "name": "first_name",
+          "type": "String"
+        },
+        {
+          "name": "last_name",
+          "type": "String"
+        },
+        {
+          "name": "email",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "sight",
+      "type": "SightNode!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "sights",
+      "type": "[SightNode!]!",
+      "args": [
+        {
+          "name": "search",
+          "type": "String"
+        },
+        {
+          "name": "make",
+          "type": "String"
+        },
+        {
+          "name": "model",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "squad",
+      "type": "SquadInterface!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "squad_competitors_indexed_w_wo_scorecards",
+      "type": "[CompetitorScoringNode!]!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "sq_id",
+          "type": "String!"
+        },
+        {
+          "name": "st_content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "st_id",
+          "type": "String!"
+        },
+        {
+          "name": "shift_on",
+          "type": "Int!"
+        },
+        {
+          "name": "incl_dnf",
+          "type": "Boolean!"
+        },
+        {
+          "name": "incl_dqed",
+          "type": "Boolean!"
+        }
+      ]
+    },
+    {
+      "name": "squad_competitors_w_wo_scorecards",
+      "type": "[CompetitorScoringNode!]!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "sq_id",
+          "type": "String!"
+        },
+        {
+          "name": "st_content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "st_id",
+          "type": "String!"
+        },
+        {
+          "name": "incl_dnf",
+          "type": "Boolean!"
+        },
+        {
+          "name": "incl_dqed",
+          "type": "Boolean!"
+        }
+      ]
+    },
+    {
+      "name": "squad_scoring_progress_at_stage",
+      "type": "ScoringProgressNode!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "sq_id",
+          "type": "String!"
+        },
+        {
+          "name": "st_content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "st_id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "squad_scoring_progress_for_string",
+      "type": "ScoringProgressNode!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "Int!"
+        },
+        {
+          "name": "index",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "stage",
+      "type": "StageInterface!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "stage_competitors_indexed_w_wo_scorecards",
+      "type": "[CompetitorScoringNode!]!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "st_id",
+          "type": "String!"
+        },
+        {
+          "name": "sq_content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "sq_id",
+          "type": "String!"
+        },
+        {
+          "name": "shift_on",
+          "type": "Int!"
+        },
+        {
+          "name": "incl_dnf",
+          "type": "Boolean!"
+        },
+        {
+          "name": "incl_dqed",
+          "type": "Boolean!"
+        }
+      ]
+    },
+    {
+      "name": "stage_competitors_w_wo_scorecards",
+      "type": "[CompetitorScoringNode!]!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "st_id",
+          "type": "String!"
+        },
+        {
+          "name": "sq_content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "sq_id",
+          "type": "String!"
+        },
+        {
+          "name": "incl_dnf",
+          "type": "Boolean!"
+        },
+        {
+          "name": "incl_dqed",
+          "type": "Boolean!"
+        }
+      ]
+    },
+    {
+      "name": "suppressor",
+      "type": "SuppressorNode!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "suppressors",
+      "type": "[SuppressorNode!]!",
+      "args": [
+        {
+          "name": "search",
+          "type": "String"
+        },
+        {
+          "name": "make",
+          "type": "String"
+        },
+        {
+          "name": "model",
+          "type": "String"
+        },
+        {
+          "name": "caliber",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "team",
+      "type": "TeamInterface!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "teammember",
+      "type": "TeamMemberInterface!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    }
+  ],
+  "EventInterface": [
+    {
+      "name": "accreditation_status",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "accreditor",
+      "type": "DjangoModelType",
+      "args": []
+    },
+    {
+      "name": "allow_team_self_management",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "allow_teams",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "allows_spotter_shooter_teams",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "available_standard_stages",
+      "type": "[StandardStageInterface!]!",
+      "args": []
+    },
+    {
+      "name": "banner",
+      "type": "SafeImageType",
+      "args": []
+    },
+    {
+      "name": "banner_url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "can_be_deleted",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "chrono_progress",
+      "type": "ChronoProgressNode!",
+      "args": []
+    },
+    {
+      "name": "chrono_progress_unsquadded",
+      "type": "ChronoProgressNode!",
+      "args": []
+    },
+    {
+      "name": "chronocards",
+      "type": "[ChronoCardInterface!]!",
+      "args": [
+        {
+          "name": "updated_after",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "chronocards_failed",
+      "type": "[ChronoCardInterface!]!",
+      "args": []
+    },
+    {
+      "name": "comment",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "competitor_payment",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "competitors",
+      "type": "[CompetitorInterface!]!",
+      "args": [
+        {
+          "name": "updated_after",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "competitors_approved_w_wo_results_not_dnf",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "competitors_approved_w_wo_results_wo_squad_not_dnf",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "competitors_count",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "competitors_did_not_finish",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "competitors_dq",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "competitors_indexed",
+      "type": "[CompetitorInterface!]!",
+      "args": [
+        {
+          "name": "sqs",
+          "type": "String!"
+        },
+        {
+          "name": "shift_on",
+          "type": "Int!"
+        },
+        {
+          "name": "incl_dnf",
+          "type": "Boolean!"
+        },
+        {
+          "name": "incl_dqed",
+          "type": "Boolean!"
+        }
+      ]
+    },
+    {
+      "name": "competitors_unscored_list",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "competitors_w_warning",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "component_matches",
+      "type": "[ComponentMatchInterface!]!",
+      "args": []
+    },
+    {
+      "name": "created",
+      "type": "DateTime!",
+      "args": []
+    },
+    {
+      "name": "created_by",
+      "type": "ShooterNode!",
+      "args": []
+    },
+    {
+      "name": "currency",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "custom_data",
+      "type": "JSON!",
+      "args": []
+    },
+    {
+      "name": "description",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "deviating_competitors",
+      "type": "[DeviatingCompetitorNode!]!",
+      "args": []
+    },
+    {
+      "name": "deviating_scorecards",
+      "type": "[DeviatingScoreCardNode!]!",
+      "args": []
+    },
+    {
+      "name": "do_chrono",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "do_equipment_check",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "do_index_competitor_when_scoring",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "does_current_user_get_result",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "ends",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "f1",
+      "type": "DjangoFileType",
+      "args": []
+    },
+    {
+      "name": "f1_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "f2",
+      "type": "DjangoFileType",
+      "args": []
+    },
+    {
+      "name": "f2_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "f3",
+      "type": "DjangoFileType",
+      "args": []
+    },
+    {
+      "name": "f3_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "f4",
+      "type": "DjangoFileType",
+      "args": []
+    },
+    {
+      "name": "f4_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "f5",
+      "type": "DjangoFileType",
+      "args": []
+    },
+    {
+      "name": "f5_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "f6",
+      "type": "DjangoFileType",
+      "args": []
+    },
+    {
+      "name": "f6_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "firearms",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "gcal_uid",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_chronocard",
+      "type": "ChronoCardInterface!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_competitor",
+      "type": "CompetitorInterface!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_squad",
+      "type": "SquadInterface!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_stage",
+      "type": "StageInterface!",
+      "args": []
+    },
+    {
+      "name": "get_abstract_team",
+      "type": "TeamInterface!",
+      "args": []
+    },
+    {
+      "name": "get_content_type_key",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "get_content_type_model",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_currency_choices",
+      "type": "[ChoiceNode!]!",
+      "args": []
+    },
+    {
+      "name": "get_currency_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_current_rbac_operations",
+      "type": "[String!]!",
+      "args": []
+    },
+    {
+      "name": "get_full_absolute_url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_full_level_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_full_rule_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_organizer_choices",
+      "type": "[ChoiceNode!]!",
+      "args": []
+    },
+    {
+      "name": "get_prematch_choices",
+      "type": "[ChoiceNode!]!",
+      "args": []
+    },
+    {
+      "name": "get_prematch_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_region_choices",
+      "type": "[ChoiceNode!]!",
+      "args": []
+    },
+    {
+      "name": "get_region_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_registration_choices",
+      "type": "[ChoiceNode!]!",
+      "args": []
+    },
+    {
+      "name": "get_registration_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_results_choices",
+      "type": "[ChoiceNode!]!",
+      "args": []
+    },
+    {
+      "name": "get_results_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_standard_stage_selection",
+      "type": "[StandardStageInterface!]!",
+      "args": []
+    },
+    {
+      "name": "get_state_choices",
+      "type": "[ChoiceNode!]!",
+      "args": []
+    },
+    {
+      "name": "get_state_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_status_choices",
+      "type": "[ChoiceNode!]!",
+      "args": []
+    },
+    {
+      "name": "get_status_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_unique_select_result_choices",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_verify_using_choices",
+      "type": "[ChoiceNode!]!",
+      "args": []
+    },
+    {
+      "name": "get_verify_using_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "get_visibility_choices",
+      "type": "[ChoiceNode!]!",
+      "args": []
+    },
+    {
+      "name": "get_visibility_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "group",
+      "type": "DjangoModelType!",
+      "args": []
+    },
+    {
+      "name": "has_accepted_event_data_ass_agreement",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "has_geopos",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "has_prematch",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "has_prematch_included",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "id",
+      "type": "ID!",
+      "args": []
+    },
+    {
+      "name": "image",
+      "type": "SafeImageType",
+      "args": []
+    },
+    {
+      "name": "information",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "is_component_match",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_current_role_admin",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_current_role_assistant",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_current_role_staff",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_imported_event",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_live_scores_accessible",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_locked",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_match",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_pm_squadding_possible",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_premium_activated",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_premium_fully_valid",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_rated",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_registration_possible",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_series",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_squadding_possible",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "is_tournament_match",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "lat",
+      "type": "Decimal",
+      "args": []
+    },
+    {
+      "name": "lng",
+      "type": "Decimal",
+      "args": []
+    },
+    {
+      "name": "lock_changed",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "lock_changed_by",
+      "type": "ShooterNode",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_approved",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_approved_w_wo_results",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_approved_w_wo_results_wo_squad",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_approved_wo_results",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_declined",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_deleted",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_pending",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_registered",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "mainmatch_competitors_waiting",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "max_competitors",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "max_prematch_competitors",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "merchandize_orders",
+      "type": "[MerchandizeOrderNode!]!",
+      "args": []
+    },
+    {
+      "name": "merchandizes",
+      "type": "[MerchandizeNode!]!",
+      "args": []
+    },
+    {
+      "name": "merchandizes_on_registration",
+      "type": "[MerchandizeNode!]!",
+      "args": []
+    },
+    {
+      "name": "minimum_rounds",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "multiple_reg_allowed",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "name",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "number_of_mainmatch_competitors_approved",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_mainmatch_competitors_approved_w_wo_results",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_mainmatch_competitors_pending",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_mainmatch_competitors_registered",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_mainmatch_competitors_waiting",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_prematch_competitors_approved",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_prematch_competitors_approved_w_wo_results",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_prematch_competitors_pending",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_prematch_competitors_registered",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_prematch_competitors_waiting",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_rounds_per_string",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "number_of_strings",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "number_of_team_members",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "obfuscated_kongsberg_api_key",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "order_payments",
+      "type": "[PaymentInterface!]!",
+      "args": []
+    },
+    {
+      "name": "organization_enabled_event_premium",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "organizer",
+      "type": "OrganizationNode",
+      "args": []
+    },
+    {
+      "name": "payment_methods",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "pm_registration_closes",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "pm_registration_starts",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "pm_squadding_starts",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "prematch",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_approved",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_approved_w_wo_results",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_approved_w_wo_results_wo_squad",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_approved_wo_results",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_declined",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_deleted",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_pending",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_registered",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "prematch_competitors_waiting",
+      "type": "[CompetitorInterface!]!",
+      "args": []
+    },
+    {
+      "name": "premium_currency",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "premium_payments",
+      "type": "[PaymentInterface!]!",
+      "args": []
+    },
+    {
+      "name": "rated",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "region",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "registration",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "registration_closes",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "registration_starts",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "result_from_team_members",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "results",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "role_names",
+      "type": "[String!]!",
+      "args": []
+    },
+    {
+      "name": "rule",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "scorecards",
+      "type": "[ScoreCardInterface!]!",
+      "args": [
+        {
+          "name": "updated_after",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "scorecards_count",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "scorecards_dq",
+      "type": "[ScoreCardInterface!]!",
+      "args": []
+    },
+    {
+      "name": "scorecards_w_warning",
+      "type": "[ScoreCardInterface!]!",
+      "args": []
+    },
+    {
+      "name": "scoring_completed",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "serie_type",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "short_url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "squadding_closes",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "squadding_starts",
+      "type": "DateTime",
+      "args": []
+    },
+    {
+      "name": "squads",
+      "type": "[SquadInterface!]!",
+      "args": []
+    },
+    {
+      "name": "squads_count",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "stages",
+      "type": "[StageInterface!]!",
+      "args": []
+    },
+    {
+      "name": "stages_count",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "starts",
+      "type": "DateTime!",
+      "args": []
+    },
+    {
+      "name": "state",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "status",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "sub_rule",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "supports_bulk_scoring",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "supports_rating",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "supports_score_all_in_squad_at_stage",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "supports_score_string_for_squad",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "supports_shoot_off_strings",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "supports_standard_stages",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "teams",
+      "type": "[TeamInterface!]",
+      "args": []
+    },
+    {
+      "name": "teams_count",
+      "type": "Int!",
+      "args": []
+    },
+    {
+      "name": "third_party_scoring_mode",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "third_party_scoring_url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "total_fee",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "total_net",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "total_tax",
+      "type": "Decimal!",
+      "args": []
+    },
+    {
+      "name": "transfer_mode",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "updated",
+      "type": "DateTime!",
+      "args": []
+    },
+    {
+      "name": "updated_by",
+      "type": "ShooterNode",
+      "args": []
+    },
+    {
+      "name": "url",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "url_display",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "uses_pin_verification",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "uses_shoot_off_stages",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "uses_signature_verification",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "uses_stages",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "uses_strings",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
+      "name": "venue",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "verify_using",
+      "type": "String!",
+      "args": []
+    },
+    {
+      "name": "visibility",
+      "type": "String!",
+      "args": []
+    }
+  ],
   "IpscMatchNode": [
     {
       "name": "accreditation_status",
@@ -32,7 +1955,7 @@
     },
     {
       "name": "available_standard_stages",
-      "type": "[NON_NULL]!",
+      "type": "[StandardStageInterface!]!",
       "args": []
     },
     {
@@ -72,7 +1995,7 @@
     },
     {
       "name": "chronocards",
-      "type": "[NON_NULL]!",
+      "type": "[ChronoCardInterface!]!",
       "args": [
         {
           "name": "updated_after",
@@ -82,7 +2005,7 @@
     },
     {
       "name": "chronocards_failed",
-      "type": "[NON_NULL]!",
+      "type": "[ChronoCardInterface!]!",
       "args": []
     },
     {
@@ -97,7 +2020,7 @@
     },
     {
       "name": "competitors",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": [
         {
           "name": "updated_after",
@@ -107,12 +2030,12 @@
     },
     {
       "name": "competitors_approved_w_wo_results_not_dnf",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "competitors_approved_w_wo_results_wo_squad_not_dnf",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
@@ -122,17 +2045,17 @@
     },
     {
       "name": "competitors_did_not_finish",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "competitors_dq",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "competitors_indexed",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": [
         {
           "name": "sqs",
@@ -154,17 +2077,17 @@
     },
     {
       "name": "competitors_unscored_list",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "competitors_w_warning",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "component_matches",
-      "type": "[NON_NULL]!",
+      "type": "[ComponentMatchInterface!]!",
       "args": []
     },
     {
@@ -194,12 +2117,12 @@
     },
     {
       "name": "deviating_competitors",
-      "type": "[NON_NULL]!",
+      "type": "[DeviatingCompetitorNode!]!",
       "args": []
     },
     {
       "name": "deviating_scorecards",
-      "type": "[NON_NULL]!",
+      "type": "[DeviatingScoreCardNode!]!",
       "args": []
     },
     {
@@ -324,7 +2247,7 @@
     },
     {
       "name": "get_air_divs_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -334,7 +2257,7 @@
     },
     {
       "name": "get_categories_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -354,7 +2277,7 @@
     },
     {
       "name": "get_currency_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -364,12 +2287,12 @@
     },
     {
       "name": "get_current_rbac_operations",
-      "type": "[NON_NULL]!",
+      "type": "[String!]!",
       "args": []
     },
     {
       "name": "get_disqualified",
-      "type": "[NON_NULL]!",
+      "type": "[IpscScoreCardNode!]!",
       "args": [
         {
           "name": "division",
@@ -388,7 +2311,7 @@
     },
     {
       "name": "get_firearms_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -413,7 +2336,7 @@
     },
     {
       "name": "get_handgun_divs_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -423,7 +2346,7 @@
     },
     {
       "name": "get_level_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -433,7 +2356,7 @@
     },
     {
       "name": "get_mini_rifle_divs_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -443,12 +2366,12 @@
     },
     {
       "name": "get_organizer_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
       "name": "get_pcc_divs_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -458,7 +2381,7 @@
     },
     {
       "name": "get_prec_rifle_divs_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -468,7 +2391,7 @@
     },
     {
       "name": "get_prematch_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -478,7 +2401,7 @@
     },
     {
       "name": "get_region_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -488,7 +2411,7 @@
     },
     {
       "name": "get_registration_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -498,7 +2421,7 @@
     },
     {
       "name": "get_results",
-      "type": "[NON_NULL]!",
+      "type": "[IpscMatchResultNode!]!",
       "args": [
         {
           "name": "division",
@@ -512,7 +2435,7 @@
     },
     {
       "name": "get_results_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -522,7 +2445,7 @@
     },
     {
       "name": "get_rifle_divs_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -537,7 +2460,7 @@
     },
     {
       "name": "get_shotgun_divs_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -547,12 +2470,12 @@
     },
     {
       "name": "get_standard_stage_selection",
-      "type": "[NON_NULL]!",
+      "type": "[StandardStageInterface!]!",
       "args": []
     },
     {
       "name": "get_state_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -562,7 +2485,7 @@
     },
     {
       "name": "get_status_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -572,7 +2495,7 @@
     },
     {
       "name": "get_tournament_divisions_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -587,7 +2510,7 @@
     },
     {
       "name": "get_verify_using_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -597,7 +2520,7 @@
     },
     {
       "name": "get_visibility_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -772,52 +2695,52 @@
     },
     {
       "name": "mainmatch_competitors",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "mainmatch_competitors_approved",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "mainmatch_competitors_approved_w_wo_results",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "mainmatch_competitors_approved_w_wo_results_wo_squad",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "mainmatch_competitors_approved_wo_results",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "mainmatch_competitors_declined",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "mainmatch_competitors_deleted",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "mainmatch_competitors_pending",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "mainmatch_competitors_registered",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "mainmatch_competitors_waiting",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
@@ -832,17 +2755,17 @@
     },
     {
       "name": "merchandize_orders",
-      "type": "[NON_NULL]!",
+      "type": "[MerchandizeOrderNode!]!",
       "args": []
     },
     {
       "name": "merchandizes",
-      "type": "[NON_NULL]!",
+      "type": "[MerchandizeNode!]!",
       "args": []
     },
     {
       "name": "merchandizes_on_registration",
-      "type": "[NON_NULL]!",
+      "type": "[MerchandizeNode!]!",
       "args": []
     },
     {
@@ -947,7 +2870,7 @@
     },
     {
       "name": "order_payments",
-      "type": "[NON_NULL]!",
+      "type": "[PaymentInterface!]!",
       "args": []
     },
     {
@@ -997,52 +2920,52 @@
     },
     {
       "name": "prematch_competitors",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "prematch_competitors_approved",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "prematch_competitors_approved_w_wo_results",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "prematch_competitors_approved_w_wo_results_wo_squad",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "prematch_competitors_approved_wo_results",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "prematch_competitors_declined",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "prematch_competitors_deleted",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "prematch_competitors_pending",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "prematch_competitors_registered",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
       "name": "prematch_competitors_waiting",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": []
     },
     {
@@ -1052,7 +2975,7 @@
     },
     {
       "name": "premium_payments",
-      "type": "[NON_NULL]!",
+      "type": "[PaymentInterface!]!",
       "args": []
     },
     {
@@ -1097,7 +3020,7 @@
     },
     {
       "name": "role_names",
-      "type": "[NON_NULL]!",
+      "type": "[String!]!",
       "args": []
     },
     {
@@ -1107,7 +3030,7 @@
     },
     {
       "name": "scorecards",
-      "type": "[NON_NULL]!",
+      "type": "[ScoreCardInterface!]!",
       "args": [
         {
           "name": "updated_after",
@@ -1122,12 +3045,12 @@
     },
     {
       "name": "scorecards_dq",
-      "type": "[NON_NULL]!",
+      "type": "[ScoreCardInterface!]!",
       "args": []
     },
     {
       "name": "scorecards_w_warning",
-      "type": "[NON_NULL]!",
+      "type": "[ScoreCardInterface!]!",
       "args": []
     },
     {
@@ -1162,7 +3085,7 @@
     },
     {
       "name": "squads",
-      "type": "[NON_NULL]!",
+      "type": "[SquadInterface!]!",
       "args": []
     },
     {
@@ -1172,7 +3095,7 @@
     },
     {
       "name": "stages",
-      "type": "[NON_NULL]!",
+      "type": "[StageInterface!]!",
       "args": []
     },
     {
@@ -1364,7 +3287,7 @@
     },
     {
       "name": "competitors_indexed",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": [
         {
           "name": "sqs",
@@ -1446,7 +3369,7 @@
     },
     {
       "name": "get_course_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -1456,7 +3379,7 @@
     },
     {
       "name": "get_disqualified",
-      "type": "[NON_NULL]!",
+      "type": "[IpscScoreCardNode!]!",
       "args": [
         {
           "name": "division",
@@ -1470,7 +3393,7 @@
     },
     {
       "name": "get_firearm_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -1495,7 +3418,7 @@
     },
     {
       "name": "get_results",
-      "type": "[NON_NULL]!",
+      "type": "[IpscStageResultNode!]!",
       "args": [
         {
           "name": "division",
@@ -1514,7 +3437,7 @@
     },
     {
       "name": "get_scoring_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -1524,7 +3447,7 @@
     },
     {
       "name": "get_shotgun_ammo_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -1714,7 +3637,7 @@
     },
     {
       "name": "scorecards",
-      "type": "[NON_NULL]!",
+      "type": "[ScoreCardInterface!]!",
       "args": [
         {
           "name": "updated_after",
@@ -1729,12 +3652,12 @@
     },
     {
       "name": "scorecards_dq",
-      "type": "[NON_NULL]!",
+      "type": "[ScoreCardInterface!]!",
       "args": []
     },
     {
       "name": "scorecards_w_warning",
-      "type": "[NON_NULL]!",
+      "type": "[ScoreCardInterface!]!",
       "args": []
     },
     {
@@ -1774,7 +3697,7 @@
     },
     {
       "name": "squad_scoring_progress",
-      "type": "[NON_NULL]!",
+      "type": "[SquadScoringProgressNode!]!",
       "args": []
     },
     {
@@ -1976,7 +3899,7 @@
     },
     {
       "name": "get_dq_reason_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -1991,17 +3914,17 @@
     },
     {
       "name": "get_scoring_analytics",
-      "type": "[NON_NULL]!",
+      "type": "[String!]!",
       "args": []
     },
     {
       "name": "get_scoring_history",
-      "type": "[NON_NULL]!",
+      "type": "[VersionNode!]!",
       "args": []
     },
     {
       "name": "get_scoring_history_as_list",
-      "type": "[NON_NULL]!",
+      "type": "[String!]!",
       "args": []
     },
     {
@@ -2263,7 +4186,7 @@
     },
     {
       "name": "category_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2273,7 +4196,7 @@
     },
     {
       "name": "classification_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2373,7 +4296,7 @@
     },
     {
       "name": "get_air_div_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2383,12 +4306,12 @@
     },
     {
       "name": "get_category_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
       "name": "get_cc_calling_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2398,7 +4321,7 @@
     },
     {
       "name": "get_classification_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2413,7 +4336,7 @@
     },
     {
       "name": "get_club_member_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2423,7 +4346,7 @@
     },
     {
       "name": "get_code_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2453,7 +4376,7 @@
     },
     {
       "name": "get_handgun_div_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2463,7 +4386,7 @@
     },
     {
       "name": "get_handgun_pf_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2473,7 +4396,7 @@
     },
     {
       "name": "get_mini_rifle_div_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2483,7 +4406,7 @@
     },
     {
       "name": "get_pcc_div_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2493,7 +4416,7 @@
     },
     {
       "name": "get_prec_rifle_div_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2503,7 +4426,7 @@
     },
     {
       "name": "get_prec_rifle_pf_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2513,7 +4436,7 @@
     },
     {
       "name": "get_region_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2528,7 +4451,7 @@
     },
     {
       "name": "get_rifle_div_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2538,7 +4461,7 @@
     },
     {
       "name": "get_rifle_pf_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2548,7 +4471,7 @@
     },
     {
       "name": "get_sex_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2558,7 +4481,7 @@
     },
     {
       "name": "get_shotgun_div_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2568,7 +4491,7 @@
     },
     {
       "name": "get_squad_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2578,7 +4501,7 @@
     },
     {
       "name": "get_state_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2588,7 +4511,7 @@
     },
     {
       "name": "get_status_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2598,7 +4521,7 @@
     },
     {
       "name": "get_tournament_division_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {
@@ -2723,7 +4646,7 @@
     },
     {
       "name": "merchandize_orders",
-      "type": "[NON_NULL]!",
+      "type": "[MerchandizeOrderNode!]!",
       "args": []
     },
     {
@@ -2753,7 +4676,7 @@
     },
     {
       "name": "payments",
-      "type": "[NON_NULL]!",
+      "type": "[PaymentInterface!]!",
       "args": []
     },
     {
@@ -2803,7 +4726,7 @@
     },
     {
       "name": "scorecards",
-      "type": "[NON_NULL]!",
+      "type": "[ScoreCardInterface!]!",
       "args": [
         {
           "name": "updated_after",
@@ -2818,7 +4741,7 @@
     },
     {
       "name": "scoring_history",
-      "type": "[NON_NULL]!",
+      "type": "[VersionNode!]!",
       "args": []
     },
     {
@@ -2965,7 +4888,7 @@
     },
     {
       "name": "competitors",
-      "type": "[NON_NULL]!",
+      "type": "[IpscCompetitorNode!]!",
       "args": []
     },
     {
@@ -2975,7 +4898,7 @@
     },
     {
       "name": "competitors_indexed",
-      "type": "[NON_NULL]!",
+      "type": "[CompetitorInterface!]!",
       "args": [
         {
           "name": "shift_on",
@@ -3043,7 +4966,7 @@
     },
     {
       "name": "get_squad_registration_choices",
-      "type": "[NON_NULL]!",
+      "type": "[ChoiceNode!]!",
       "args": []
     },
     {

--- a/scripts/validate-ssi-queries.ts
+++ b/scripts/validate-ssi-queries.ts
@@ -1,0 +1,254 @@
+#!/usr/bin/env tsx
+/**
+ * Static validation of our outbound GraphQL queries against the SSI schema
+ * snapshot (scripts/ssi-schema-snapshot.json).
+ *
+ * WHY: caches and call sites assume the queries we send are well-formed against
+ * the schema we mirror. When a field is renamed, removed, or moved between an
+ * interface and a subtype upstream, our queries silently start returning errors
+ * the next time the schema snapshot is refreshed. This script walks each query
+ * AST against the snapshot and refuses to pass if a selection or argument
+ * doesn't line up.
+ *
+ * USAGE:
+ *   pnpm validate:ssi-queries          # report errors, exit 1 if any
+ *   pnpm validate:ssi-queries --json   # machine-readable output
+ *
+ * SCOPE / KNOWN GAPS:
+ *   - Catches: missing fields, missing arguments, fields on a type that does
+ *     not exist in the snapshot.
+ *   - Does NOT catch resolver-level bugs (e.g. #367) where a field is declared
+ *     on an interface in the schema but the underlying Django model on a
+ *     subtype throws AttributeError at runtime. That class of bug requires a
+ *     live dry-run smoke test, not static schema introspection.
+ *   - For types that aren't in the snapshot (e.g. SafeImageType, ShooterNode,
+ *     CompetitorInterface), the walker descends but skips field-existence
+ *     checks rather than erroring — keeps the validator focused without
+ *     requiring the snapshot to mirror the entire SSI schema.
+ *
+ * To extend coverage, add the relevant type names to TRACKED_TYPES in
+ * scripts/check-ssi-schema.ts and refresh the snapshot.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { parse, Kind } from "graphql";
+import type {
+  DocumentNode,
+  SelectionSetNode,
+  OperationDefinitionNode,
+  FieldNode,
+  InlineFragmentNode,
+} from "graphql";
+
+import {
+  MATCH_QUERY,
+  MATCH_UPDATED_PROBE_QUERY,
+  EVENTS_QUERY,
+  UPCOMING_STATUS_QUERY,
+  SCORECARDS_QUERY,
+  SCORECARDS_DELTA_QUERY,
+} from "../lib/graphql";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SNAPSHOT_PATH = resolve(__dirname, "ssi-schema-snapshot.json");
+
+interface FieldArg {
+  name: string;
+  type: string;
+}
+
+interface FieldEntry {
+  name: string;
+  type: string;
+  args: FieldArg[];
+}
+
+type Snapshot = Record<string, FieldEntry[]>;
+
+export interface ValidationError {
+  query: string;
+  path: string;
+  message: string;
+}
+
+const QUERIES: { name: string; src: string }[] = [
+  { name: "MATCH_QUERY", src: MATCH_QUERY },
+  { name: "MATCH_UPDATED_PROBE_QUERY", src: MATCH_UPDATED_PROBE_QUERY },
+  { name: "EVENTS_QUERY", src: EVENTS_QUERY },
+  { name: "UPCOMING_STATUS_QUERY", src: UPCOMING_STATUS_QUERY },
+  { name: "SCORECARDS_QUERY", src: SCORECARDS_QUERY },
+  { name: "SCORECARDS_DELTA_QUERY", src: SCORECARDS_DELTA_QUERY },
+];
+
+export function loadSnapshot(): Snapshot {
+  if (!existsSync(SNAPSHOT_PATH)) {
+    throw new Error(`snapshot missing at ${SNAPSHOT_PATH} — run \`pnpm check:ssi-schema --update\` first`);
+  }
+  return JSON.parse(readFileSync(SNAPSHOT_PATH, "utf8")) as Snapshot;
+}
+
+/** Strip GraphQL type wrappers (`!`, `[]`) to get the named type, e.g.
+ *  "[EventInterface!]!" -> "EventInterface". */
+function namedType(t: string): string {
+  return t.replace(/[![\]]/g, "");
+}
+
+function operationRootType(op: OperationDefinitionNode): string {
+  switch (op.operation) {
+    case "mutation": return "RootMutation";
+    case "subscription": return "RootSubscription";
+    case "query":
+    default: return "RootQuery";
+  }
+}
+
+function validateSelectionSet(
+  set: SelectionSetNode,
+  parentType: string,
+  snapshot: Snapshot,
+  path: string[],
+  errors: Omit<ValidationError, "query">[],
+): void {
+  const parentFields = snapshot[parentType];
+  // Type isn't tracked — skip field validation but still walk into nested
+  // selections so a `... on TrackedType` deeper down still gets checked.
+  const tracked = parentFields != null;
+  const fieldByName: Map<string, FieldEntry> | null = tracked
+    ? new Map(parentFields.map((f) => [f.name, f]))
+    : null;
+
+  for (const sel of set.selections) {
+    if (sel.kind === Kind.FIELD) {
+      validateField(sel, parentType, fieldByName, snapshot, path, errors);
+    } else if (sel.kind === Kind.INLINE_FRAGMENT) {
+      validateInlineFragment(sel, snapshot, path, errors);
+    }
+    // FRAGMENT_SPREAD: we don't use named fragments anywhere, so skip.
+  }
+}
+
+function validateField(
+  field: FieldNode,
+  parentType: string,
+  fieldByName: Map<string, FieldEntry> | null,
+  snapshot: Snapshot,
+  path: string[],
+  errors: Omit<ValidationError, "query">[],
+): void {
+  const fieldName = field.name.value;
+  const fieldPath = [...path, fieldName];
+
+  // Skip introspection meta-fields.
+  if (fieldName.startsWith("__")) return;
+
+  let returnType: string | null = null;
+  if (fieldByName != null) {
+    const entry = fieldByName.get(fieldName);
+    if (!entry) {
+      errors.push({
+        path: fieldPath.join("."),
+        message: `field \`${fieldName}\` not found on type \`${parentType}\``,
+      });
+      return;
+    }
+
+    // Validate provided arguments exist on the field signature. We do not
+    // type-check argument values — variable types come from the operation
+    // definition and would need a separate walk.
+    if (field.arguments && field.arguments.length > 0) {
+      const argByName = new Map(entry.args.map((a) => [a.name, a]));
+      for (const arg of field.arguments) {
+        if (!argByName.has(arg.name.value)) {
+          errors.push({
+            path: fieldPath.join("."),
+            message: `argument \`${arg.name.value}\` not declared on \`${parentType}.${fieldName}\` (declared args: ${entry.args.map((a) => a.name).join(", ") || "none"})`,
+          });
+        }
+      }
+    }
+
+    returnType = namedType(entry.type);
+  }
+
+  if (field.selectionSet) {
+    // If we couldn't resolve the return type (parent type untracked), pass an
+    // unknown sentinel so descendant fragments still validate themselves.
+    validateSelectionSet(
+      field.selectionSet,
+      returnType ?? "__unknown__",
+      snapshot,
+      fieldPath,
+      errors,
+    );
+  }
+}
+
+function validateInlineFragment(
+  frag: InlineFragmentNode,
+  snapshot: Snapshot,
+  path: string[],
+  errors: Omit<ValidationError, "query">[],
+): void {
+  const typeName = frag.typeCondition?.name.value;
+  if (!typeName) return; // unconditional inline fragment — rare, skip
+
+  const fragPath = [...path, `... on ${typeName}`];
+  // If the named type is in the snapshot, validate; otherwise descend with
+  // unknown parent so deeper tracked fragments still get checked.
+  validateSelectionSet(frag.selectionSet, typeName, snapshot, fragPath, errors);
+}
+
+export function validateQuery(name: string, src: string, snapshot: Snapshot): ValidationError[] {
+  let doc: DocumentNode;
+  try {
+    doc = parse(src);
+  } catch (err) {
+    return [{ query: name, path: "(parse)", message: err instanceof Error ? err.message : String(err) }];
+  }
+  const errors: Omit<ValidationError, "query">[] = [];
+  for (const def of doc.definitions) {
+    if (def.kind !== Kind.OPERATION_DEFINITION) continue;
+    const rootType = operationRootType(def);
+    validateSelectionSet(def.selectionSet, rootType, snapshot, [rootType], errors);
+  }
+  return errors.map((e) => ({ query: name, ...e }));
+}
+
+function main(): void {
+  const jsonMode = process.argv.includes("--json");
+  const snapshot = loadSnapshot();
+
+  const allErrors: ValidationError[] = [];
+  for (const q of QUERIES) {
+    allErrors.push(...validateQuery(q.name, q.src, snapshot));
+  }
+
+  if (jsonMode) {
+    console.log(JSON.stringify(allErrors, null, 2));
+    process.exit(allErrors.length > 0 ? 1 : 0);
+  }
+
+  if (allErrors.length === 0) {
+    console.log(`[validate-ssi-queries] OK — ${QUERIES.length} queries valid against snapshot`);
+    return;
+  }
+
+  console.error(`[validate-ssi-queries] ${allErrors.length} error(s):\n`);
+  for (const err of allErrors) {
+    console.error(`  ${err.query}  ${err.path}`);
+    console.error(`    -> ${err.message}\n`);
+  }
+  console.error(
+    "If the snapshot is stale, run `pnpm check:ssi-schema --update` to refresh it.\n" +
+    "If the schema actually changed, update the affected query and bump\n" +
+    "CACHE_SCHEMA_VERSION as described in CLAUDE.md -> 'Delta-merge contract'.",
+  );
+  process.exit(1);
+}
+
+// Run as CLI when invoked directly; stay quiet when imported by tests.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main();
+}

--- a/tests/unit/validate-ssi-queries.test.ts
+++ b/tests/unit/validate-ssi-queries.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { validateQuery } from "@/scripts/validate-ssi-queries";
+
+// Minimal hand-rolled snapshot for tests. Mirrors the relevant slice of
+// scripts/ssi-schema-snapshot.json without the test depending on the live
+// snapshot file (that one shifts when SSI ships schema changes; the tests
+// should stay stable regardless).
+const snapshot = {
+  RootQuery: [
+    {
+      name: "event",
+      type: "EventInterface!",
+      args: [
+        { name: "content_type", type: "Int!" },
+        { name: "id", type: "String!" },
+      ],
+    },
+    {
+      name: "events",
+      type: "[EventInterface!]!",
+      args: [
+        { name: "search", type: "String" },
+        { name: "rule", type: "String" },
+      ],
+    },
+  ],
+  EventInterface: [
+    { name: "id", type: "ID!", args: [] },
+    { name: "name", type: "String!", args: [] },
+    { name: "scoring_completed", type: "Decimal!", args: [] },
+  ],
+  IpscMatchNode: [
+    { name: "id", type: "ID!", args: [] },
+    { name: "name", type: "String!", args: [] },
+    { name: "scoring_completed", type: "Decimal!", args: [] },
+    { name: "sub_rule", type: "String!", args: [] },
+    { name: "level", type: "String!", args: [] },
+    {
+      name: "scorecards",
+      type: "[IpscScoreCardNode!]!",
+      args: [{ name: "updated_after", type: "String!" }],
+    },
+  ],
+  IpscScoreCardNode: [
+    { name: "points", type: "Decimal!", args: [] },
+    { name: "hitfactor", type: "Decimal!", args: [] },
+  ],
+};
+
+describe("validateQuery", () => {
+  it("accepts a query whose every field exists on the parent type", () => {
+    const src = `query Q($ct: Int!, $id: String!) {
+      event(content_type: $ct, id: $id) {
+        id
+        name
+        ... on IpscMatchNode {
+          sub_rule
+          level
+        }
+      }
+    }`;
+    expect(validateQuery("Q", src, snapshot)).toEqual([]);
+  });
+
+  it("flags a field not on the parent interface", () => {
+    const src = `query Q($ct: Int!, $id: String!) {
+      event(content_type: $ct, id: $id) {
+        id
+        bogus_field_xyz
+      }
+    }`;
+    const errs = validateQuery("Q", src, snapshot);
+    expect(errs).toHaveLength(1);
+    expect(errs[0].message).toContain("bogus_field_xyz");
+    expect(errs[0].message).toContain("EventInterface");
+  });
+
+  it("flags a subtype field selected outside its inline fragment", () => {
+    // `sub_rule` is on IpscMatchNode but not on EventInterface in this snapshot.
+    const src = `query Q($ct: Int!, $id: String!) {
+      event(content_type: $ct, id: $id) {
+        id
+        sub_rule
+      }
+    }`;
+    const errs = validateQuery("Q", src, snapshot);
+    expect(errs).toHaveLength(1);
+    expect(errs[0].message).toContain("sub_rule");
+    expect(errs[0].message).toContain("EventInterface");
+  });
+
+  it("flags an undeclared argument", () => {
+    const src = `query Q($ct: Int!, $id: String!) {
+      event(content_type: $ct, id: $id, nonexistent_arg: "x") {
+        id
+      }
+    }`;
+    const errs = validateQuery("Q", src, snapshot);
+    expect(errs).toHaveLength(1);
+    expect(errs[0].message).toContain("nonexistent_arg");
+  });
+
+  it("descends into nested selection sets via the field's return type", () => {
+    const src = `query Q($ct: Int!, $id: String!) {
+      event(content_type: $ct, id: $id) {
+        ... on IpscMatchNode {
+          scorecards(updated_after: "2026-04-01T00:00:00Z") {
+            points
+            bogus_card_field
+          }
+        }
+      }
+    }`;
+    const errs = validateQuery("Q", src, snapshot);
+    expect(errs).toHaveLength(1);
+    expect(errs[0].message).toContain("bogus_card_field");
+    expect(errs[0].message).toContain("IpscScoreCardNode");
+  });
+
+  it("skips field validation for types not in the snapshot", () => {
+    // `image` would return SafeImageType which isn't tracked — descendants
+    // shouldn't trigger errors.
+    const limited = {
+      ...snapshot,
+      IpscMatchNode: [
+        ...snapshot.IpscMatchNode,
+        { name: "image", type: "SafeImageType", args: [] },
+      ],
+    };
+    const src = `query Q($ct: Int!, $id: String!) {
+      event(content_type: $ct, id: $id) {
+        ... on IpscMatchNode {
+          image { url width height }
+        }
+      }
+    }`;
+    expect(validateQuery("Q", src, limited)).toEqual([]);
+  });
+
+  it("returns a single parse error when the query is malformed", () => {
+    const src = `query { event { id `; // unbalanced braces
+    const errs = validateQuery("Q", src, snapshot);
+    expect(errs).toHaveLength(1);
+    expect(errs[0].path).toBe("(parse)");
+  });
+});


### PR DESCRIPTION
## Summary

Three stacked commits, all touching the GraphQL data path on the landing page:

- **Static query validator (#369)** — `pnpm validate:ssi-queries` parses every outbound GraphQL query in `lib/graphql.ts` and walks the AST against `scripts/ssi-schema-snapshot.json`. Catches missing fields, undeclared arguments, and fields whose parent type doesn't declare them. Wired into CI between typecheck and test, and into the weekly `check-ssi-schema` workflow as a follow-up gate. Honest about scope: it does **not** catch resolver-level bugs where the schema declares a field on an interface but the underlying Django model on a subtype throws `AttributeError` at runtime (the original #367 class) — that requires a live dry-run smoke test, documented in CLAUDE.md.
- **502 fix on flaky SSI gateway** — staging surfaced intermittent `502 Bad Gateway` on `/api/events` with the upstream error `"Must provide document."` (graphql-core's message when SSI's parser sees an empty body). `executeQuery` now retries once on that exact message, and the events route's no-search browse path switches from `Promise.all` to `Promise.allSettled` so one transient sub-window failure doesn't blank the whole month.
- **Adaptive sub-window size** — the browse UI sends an explicit 1-month window which the route used to fan out into ~5 SSI calls. When `firearms` is set, SSI filters upstream and a single 30-day window fits comfortably under the cap, so we drop to 1 call per filtered browse. Unfiltered (firearms = All) keeps 7-day chunks because the cap-bypass reasoning still applies. Also tightened the route's default fallback from ±3 months to ±1 month — the browse UI always sends explicit dates, the default only applied to off-path callers.

## Net effect on landing page SSI traffic (cold cache, per month browse)

| Filter state | Before | After |
|---|---|---|
| firearms = All | 5 calls | 5 calls (unchanged — cap-bypass still needed) |
| firearms = Handgun / Rifle / etc. | 5 calls | **1 call** |

Search mode (single call) and live mode (36h, 1 call) are untouched.

## Schema snapshot diff

`scripts/ssi-schema-snapshot.json` grew by ~2k lines because the validator needs `RootQuery` and `EventInterface` to resolve top-level field types. Introspection depth also bumped from 3 to 5 levels of `ofType`, which resolves the previously-opaque `[NON_NULL]!` placeholders to named types like `[CompetitorInterface!]!`. No removals.

## Test plan

- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test` — 1557 tests passing (7 new tests for the validator)
- [x] `pnpm validate:ssi-queries` — 6 queries valid against snapshot
- [ ] Deploy to staging, exercise landing page (browse, search, live mode), confirm 502s drop and filtered browse fires fewer SSI calls
- [ ] Reproduce a transient `Must provide document.` against staging via CF logs to confirm the retry path engages

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)