### PR TITLE
Revert 30-day filtered sub-window from #370 — SSI cap still bites

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -41,41 +41,46 @@ const ALLOWED_LEVELS: Record<string, Set<string> | null> = {
   l4plus: new Set(["Level IV", "Level V"]),
 };
 
+// ─── DO NOT WIDEN THIS WINDOW WITHOUT MEASURING ─────────────────────────────
+//
 // The SSI API applies an undocumented result cap per query when browsing
 // without a search term, silently dropping events further out in the date
-// window. We work around it by splitting the requested range into sub-windows
-// so each request stays well under the cap. Each sub-window gets its own
-// Next.js fetch-cache entry (revalidate: 3600), so they cache independently.
+// window. We work around it by splitting the requested range into 7-day
+// sub-windows so each request stays well under the cap. Each sub-window gets
+// its own Next.js fetch-cache entry (revalidate: 3600), so they cache
+// independently.
 //
-// Sub-window size is adaptive based on whether SSI is doing upstream
-// filtering for us:
+// History — every previous attempt to widen this has caused a user-visible
+// regression. Read these BEFORE changing the value:
 //
-//   No firearms filter ("All"): 7 days — country and minLevel are *post-fetch*
-//   filters here (the SSI GraphQL has no params for them), so the cap bites on
-//   the unfiltered worldwide IPSC count. Bug seen in the wild: browsing a
-//   month with discipline "All" + country=SWE + minLevel=L2+ used to show only
-//   the first ~9 days because the single 1-month query was already truncated
-//   before SWE/L2+ filtering ran. 7 days stays safely under that ceiling.
+//   #345 (5e9e63b, 2026-04-27) — shrunk from 30 days to 7 after browsing a
+//     month with discipline=All + country=SWE + minLevel=L2+ showed only
+//     the first ~9 days. SSI's cap bites on the unfiltered worldwide IPSC
+//     count, before our post-fetch country/minLevel filters run.
+//   #370 (cb57560, 2026-04-28) — widened back to 30 days when `firearms`
+//     was set, on the assumption SSI's upstream filter cut the count
+//     enough. It does not. Empirical check on staging: a 30-day worldwide
+//     query for firearms=hg returned 1 event; same range as 4× 7-day
+//     chunks returned 139. Reverted in #371.
 //
-//   Firearms filter set (Handgun / Rifle / Shotgun / PCC / etc.): 30 days —
-//   SSI filters upstream, the result count drops several-fold, and a 30-day
-//   window fits comfortably under the cap. This drops a typical filtered
-//   month browse from ~5 GraphQL calls to 1.
-const SUB_WINDOW_DAYS_FILTERED = 30;
-const SUB_WINDOW_DAYS_UNFILTERED = 7;
+// The cap bites on whatever SSI returns, regardless of whether we asked it
+// to filter upstream. The safe value is 7 days. If you want to widen it,
+// measure against the live API for every supported firearms value
+// (hg, rfl, shg, pcc, mr, prr, air) AND the unfiltered case, across a full
+// 30-day month, and confirm none of them get truncated. Don't guess.
+const SUB_WINDOW_DAYS = 7;
 
 function buildSubWindows(
   startsAfter: string,
   startsBefore: string,
   baseVars: Record<string, string>,
-  windowDays: number,
 ): Array<Record<string, string>> {
   const windows: Array<Record<string, string>> = [];
   let cur = new Date(startsAfter);
   const end = new Date(startsBefore);
   while (cur < end) {
     const next = new Date(cur);
-    next.setDate(next.getDate() + windowDays);
+    next.setDate(next.getDate() + SUB_WINDOW_DAYS);
     if (next > end) next.setTime(end.getTime());
     windows.push({
       ...baseVars,
@@ -170,11 +175,7 @@ export async function GET(req: Request) {
       // 7-day gap) is far better UX than a 502 over the entire date range.
       // executeQuery already retries that specific transient internally; we
       // only land here if the retry also failed.
-      // SSI filters by `firearms` upstream, so a filter cuts the unfiltered
-      // worldwide count enough that a single 30-day window fits under the cap.
-      // Without a filter we stay on 7-day chunks to dodge the cap entirely.
-      const windowDays = firearms ? SUB_WINDOW_DAYS_FILTERED : SUB_WINDOW_DAYS_UNFILTERED;
-      const windows = buildSubWindows(startsAfter, startsBefore, firearms ? { firearms } : {}, windowDays);
+      const windows = buildSubWindows(startsAfter, startsBefore, firearms ? { firearms } : {});
       const settled = await Promise.allSettled(
         windows.map((vars) => executeQuery<RawEventsData>(EVENTS_QUERY, vars, 3600)),
       );


### PR DESCRIPTION
## Summary

PR #370 widened sub-windows to 30 days when \`firearms\` was set, assuming SSI's upstream filter cut the count enough for a single window to fit under the cap. That assumption was wrong.

Empirical check on staging just now:

\`\`\`
firearms=hg, 2026-04-01..2026-04-30 (30-day window):  1 event
firearms=hg, 2026-04-01..2026-04-30 (4× 7-day chunks): 139 events (21+39+34+45)
\`\`\`

SSI's cap bites regardless of whether we asked it to filter upstream — so the user-visible symptom on staging was the filtered view returning effectively no matches.

Reverting all browse sub-windows back to 7 days. The "1 call per filtered month" perf claim was based on a faulty premise; ~5 calls is the correct trade-off because the alternative is showing 1 match when there are 139.

Comment updated with the empirical result so we don't widen this again without measuring against the live API for every supported firearms value (hg, rfl, shg, pcc, mr, prr, air).

## Test plan

- [x] \`pnpm lint\` / \`pnpm typecheck\` / \`pnpm test\` — all green
- [ ] Deploy to staging, confirm filtered browse (firearms=hg, country=SWE, minLevel=L2+) returns the expected match list

🤖 Generated with [Claude Code](https://claude.com/claude-code)