### PR TITLE
Fix landing-page slowdown: scoring_completed regression + guardrails

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -161,9 +161,13 @@ export async function GET(req: Request) {
       // Text search: the API's search backend returns good results in one call.
       // 15s cap — search is interactive; no point making the user wait the
       // full 60s default if SSI is having a slow moment.
+      // includeScoring=false — search results don't display % progress, and
+      // requesting that field adds ~10s of upstream computation (see
+      // EVENTS_QUERY comment). Live mode below requests it because the live
+      // section actually needs the percentage.
       const data = await executeQuery<RawEventsData>(
         EVENTS_QUERY,
-        { starts_after: startsAfter, starts_before: startsBefore, firearms, search: q },
+        { starts_after: startsAfter, starts_before: startsBefore, firearms, search: q, includeScoring: false },
         3600,
         { timeoutMs: 15_000 },
       );
@@ -188,9 +192,12 @@ export async function GET(req: Request) {
       // fetch cache for that window — we accept that trade so the user
       // doesn't wait a full minute for one stuck call.
       const windows = buildSubWindows(startsAfter, startsBefore, firearms ? { firearms } : {});
+      // Only live mode actually displays the % progress; browse skips the
+      // server-side scoring_completed aggregate (saves ~10s per sub-window).
+      const includeScoring = liveMode;
       const settled = await Promise.allSettled(
         windows.map((vars) =>
-          executeQuery<RawEventsData>(EVENTS_QUERY, vars, 3600, { timeoutMs: 8_000 }),
+          executeQuery<RawEventsData>(EVENTS_QUERY, { ...vars, includeScoring }, 3600, { timeoutMs: 8_000 }),
         ),
       );
       const failures: string[] = [];

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -203,10 +203,12 @@ export async function GET(req: Request) {
         throw new Error(failures.join(" | "));
       }
       if (failures.length > 0) {
-        // Partial outage — flag upstream as degraded so the homepage banner
-        // surfaces it. The 60s TTL on the flag means it self-clears once SSI
-        // recovers, without us having to write a "healthy again" signal.
-        await markUpstreamDegraded("events-route-partial");
+        // Partial failure — log for telemetry but do NOT mark the upstream as
+        // degraded. The whole point of allSettled here is to absorb a single
+        // transient SSI hiccup; surfacing a "scoreboard is degraded" banner
+        // when 4 of 5 sub-windows came back with valid data contradicts that
+        // soft-fallback. Reserve the banner for the unambiguous signal:
+        // every window failed, or the search call failed (the catch below).
         console.warn(JSON.stringify({
           route: "events",
           partial_failure: true,

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -159,10 +159,13 @@ export async function GET(req: Request) {
   try {
     if (q) {
       // Text search: the API's search backend returns good results in one call.
+      // 15s cap — search is interactive; no point making the user wait the
+      // full 60s default if SSI is having a slow moment.
       const data = await executeQuery<RawEventsData>(
         EVENTS_QUERY,
         { starts_after: startsAfter, starts_before: startsBefore, firearms, search: q },
         3600,
+        { timeoutMs: 15_000 },
       );
       rawEvents = data.events;
     } else {
@@ -176,9 +179,19 @@ export async function GET(req: Request) {
       // 7-day gap) is far better UX than a 502 over the entire date range.
       // executeQuery already retries that specific transient internally; we
       // only land here if the retry also failed.
+      //
+      // Per-window timeout: 8s. allSettled waits for the *slowest* window,
+      // so a single hung sub-window otherwise blocks TTFB up to the global
+      // 60s timeout. 8s is well above the typical sub-window latency
+      // (~400ms warm, ~2s cold) but tight enough that one slow window can't
+      // tank the whole homepage. Cancelled fetches won't populate Next's
+      // fetch cache for that window — we accept that trade so the user
+      // doesn't wait a full minute for one stuck call.
       const windows = buildSubWindows(startsAfter, startsBefore, firearms ? { firearms } : {});
       const settled = await Promise.allSettled(
-        windows.map((vars) => executeQuery<RawEventsData>(EVENTS_QUERY, vars, 3600)),
+        windows.map((vars) =>
+          executeQuery<RawEventsData>(EVENTS_QUERY, vars, 3600, { timeoutMs: 8_000 }),
+        ),
       );
       const failures: string[] = [];
       const seen = new Set<string>();

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -801,8 +801,16 @@ async function fullRefresh<T>(
 // `region` is an ISO 3166-1 alpha-3 country code (e.g. "SWE", "NOR", "DNK",
 // "FIN"). Country filtering is done server-side in the route handler after
 // the GraphQL response is received — the SSI API has no region filter param.
+//
+// `scoring_completed` is gated behind a $includeScoring variable + @include
+// directive — it is a server-computed aggregate (scans every scorecard for
+// every match in the result set) that adds 10+ seconds to the worldwide
+// browse query. Live mode passes `includeScoring: true` because it needs the
+// progress percentage to filter active matches; browse and search pass false
+// because they only display name/date/venue/level. Empirically: same query,
+// same window, against SSI: 0.25s without scoring_completed, 11-13s with it.
 export const EVENTS_QUERY = `
-  query GetEvents($search: String, $starts_after: String, $starts_before: String, $firearms: String) {
+  query GetEvents($search: String, $starts_after: String, $starts_before: String, $firearms: String, $includeScoring: Boolean!) {
     events(rule: "ip", firearms: $firearms, search: $search, starts_after: $starts_after, starts_before: $starts_before) {
       id
       get_content_type_key
@@ -815,7 +823,7 @@ export const EVENTS_QUERY = `
       get_full_rule_display
       get_full_level_display
       ... on IpscMatchNode {
-        scoring_completed
+        scoring_completed @include(if: $includeScoring)
         registration_starts
         registration_closes
         squadding_starts

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -41,9 +41,18 @@ interface GraphQLResponse<T> {
   errors?: GraphQLError[];
 }
 
-/** Timeout for upstream GraphQL requests (ms). The SSI API can be slow
- *  for large matches with many scorecards, so we allow a generous window. */
+/** Default timeout for upstream GraphQL requests (ms). The SSI API can be
+ *  slow for large matches with many scorecards, so we allow a generous window
+ *  by default. Callers that know their query is small (e.g. /api/events
+ *  sub-windows) should pass a tighter timeout via the `timeoutMs` option. */
 const GRAPHQL_TIMEOUT_MS = 60_000;
+
+export interface ExecuteQueryOptions {
+  /** Override the default 60s timeout for this call. Triggers AbortController
+   *  on the underlying fetch, so the upstream request is genuinely cancelled
+   *  rather than just abandoned. */
+  timeoutMs?: number;
+}
 
 /** Error messages we treat as a transient upstream condition worth one retry.
  *  "Must provide document." is graphql-core's message when SSI's parser sees
@@ -58,16 +67,17 @@ export async function executeQuery<T>(
   query: string,
   variables?: Record<string, unknown>,
   revalidate: number | false = false,
+  options: ExecuteQueryOptions = {},
 ): Promise<T> {
   try {
-    return await executeQueryOnce<T>(query, variables, revalidate);
+    return await executeQueryOnce<T>(query, variables, revalidate, options);
   } catch (err) {
     const msg = err instanceof Error ? err.message : "";
     if (RETRY_GRAPHQL_MESSAGES.some((m) => msg.includes(m))) {
       // Single immediate retry. We don't back off — the failure mode is a
       // dropped body at SSI's gateway, not load shedding, so a retry helps
       // most when it goes out right behind the failed request.
-      return await executeQueryOnce<T>(query, variables, revalidate);
+      return await executeQueryOnce<T>(query, variables, revalidate, options);
     }
     throw err;
   }
@@ -77,6 +87,7 @@ async function executeQueryOnce<T>(
   query: string,
   variables: Record<string, unknown> | undefined,
   revalidate: number | false,
+  options: ExecuteQueryOptions,
 ): Promise<T> {
   const apiKey = process.env.SSI_API_KEY;
   if (!apiKey) throw new Error("SSI_API_KEY is not configured");
@@ -100,8 +111,9 @@ async function executeQueryOnce<T>(
     });
   };
 
+  const timeoutMs = options.timeoutMs ?? GRAPHQL_TIMEOUT_MS;
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), GRAPHQL_TIMEOUT_MS);
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   let response: Response;
   try {
@@ -120,8 +132,8 @@ async function executeQueryOnce<T>(
     clearTimeout(timeout);
     if (err instanceof DOMException && err.name === "AbortError") {
       emit("timeout", { errorClass: "AbortError" });
-      console.error(`[ssi-api] ${operationName} timed out after ${GRAPHQL_TIMEOUT_MS}ms | vars=${JSON.stringify(variables ?? {})}`);
-      throw new Error(`Upstream request timed out after ${GRAPHQL_TIMEOUT_MS / 1000}s`);
+      console.error(`[ssi-api] ${operationName} timed out after ${timeoutMs}ms | vars=${JSON.stringify(variables ?? {})}`);
+      throw new Error(`Upstream request timed out after ${timeoutMs / 1000}s`);
     }
     emit("fetch-error", { errorClass: err instanceof Error ? err.name : "unknown" });
     throw err;

--- a/lib/upstream-telemetry.ts
+++ b/lib/upstream-telemetry.ts
@@ -20,8 +20,10 @@
 //
 // degraded-marked fields:
 //   site        — call site that flagged the upstream as degraded
-//                 ("events-route-total" | "events-route-partial" |
-//                  "refresh-cached-query" | "refresh-cached-match-query")
+//                 ("events-route-total" | "refresh-cached-query" |
+//                  "refresh-cached-match-query"). Partial sub-window
+//                 failures intentionally do NOT mark degraded — that's
+//                 the case allSettled is built to absorb.
 //   errorClass  — short error class (e.g. "Error", "AbortError")
 //
 // status-checked fields:
@@ -40,7 +42,6 @@ export type UpstreamOutcome =
 
 export type DegradedSite =
   | "events-route-total"
-  | "events-route-partial"
   | "refresh-cached-query"
   | "refresh-cached-match-query";
 


### PR DESCRIPTION
## Summary

User-reported regression: latest \`main\` browses month-by-month *forever* on staging and on local docker, while \`38f84de\` (just before PR #367 Live Now) is instant. Three commits, ordered shallowest to deepest fix:

1. **\`fix(banner)\`** — Stop flagging upstream as degraded on partial sub-window failure. \`allSettled\` exists to absorb a single transient hiccup; surfacing the banner anyway negated the soft-fallback.
2. **\`perf(events)\`** — Per-sub-window timeout so one slow window can't block TTFB. Browse caps each sub-window at 8s (typical 250ms-2s); search caps at 15s. Triggers \`AbortController\` so the upstream fetch is genuinely cancelled. Defence in depth — protects prod too when SSI has a slow moment.
3. **\`fix(events)\` — root cause** — Make \`scoring_completed\` conditional on a \`$includeScoring\` variable + \`@include\` directive.

## The actual regression

Empirically, against SSI directly, same query, same 7-day window:

| Query | Latency |
|---|---|
| Without \`scoring_completed\` | **0.25s** |
| With \`scoring_completed\` | **11-13s** |

\`scoring_completed\` is a server-side aggregate — SSI scans every scorecard for every match in the result set. PR #367 (Live Now) added the field to \`EVENTS_QUERY\` for the progress display; PR #368's hotfix moved it inside the \`IpscMatchNode\` fragment but kept it in the query. Browse and search have been paying ~10s per sub-window × ~5 windows per month browse since #367 landed.

Browse and search don't display \`scoring_completed\` anywhere (verified by grep: \`event-search.tsx\` has zero references). Only the homepage live section needs it. Live mode passes \`includeScoring: true\`; browse and search pass \`false\`. SSI supports \`@include\` per the GraphQL spec.

No cache schema bump needed — cache entries are keyed by request body, which now includes the new variable, so old (different shape) entries naturally don't collide with new ones.

## Out of scope

The staging worker → SSI network path is also genuinely slower than prod's (different Smart Placement decisions even with identical worker config). After this fix that no longer matters in practice because a single sub-window drops from 11-13s to ~250ms, well under the 8s safety cap. If staging stays slow after deploy that's a separate operator-level question (CF placement / SSI rate-shaping).

## Test plan

- [x] \`pnpm lint\` / \`pnpm typecheck\` / \`pnpm test\` — all green
- [x] \`pnpm validate:ssi-queries\` — 6 queries valid against snapshot (validator handles \`@include\` directive)
- [ ] Deploy to staging, browse month-by-month, confirm reloads return instantly
- [ ] Confirm Live Now section still displays % progress on active matches
- [ ] Confirm banner stays hidden during normal partial-window timeouts on cold cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)