### PR TITLE
Cache badge: scope stale-warning to live matches, stop row reflow

### DIFF
--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -478,24 +478,19 @@ export default function MatchPageClient() {
           All matches
         </Link>
         <div className="flex items-center gap-3">
-          {matchQuery.isFetching && (
-            <span
-              className="flex items-center gap-1 text-xs text-muted-foreground"
-              role="status"
-              aria-live="polite"
-            >
-              <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
-              Refreshing...
-            </span>
-          )}
           <CacheInfoBadge
             ct={ct}
             id={id}
             cachedAt={stalestCachedAt}
             lastScorecardAt={compareQuery.data?.cacheInfo.lastScorecardAt ?? null}
-            matchOngoing={
-              match.match_status !== "cp" && match.match_status !== "cs"
+            phase={
+              effectiveMode === "prematch"
+                ? "prematch"
+                : effectiveMode === "coaching"
+                  ? "finished"
+                  : "live"
             }
+            isRefreshing={matchQuery.isFetching || compareQuery.isFetching}
           />
           <ShareEventLink ct={ct} id={id} matchName={match.name} />
           <ShareButton title={match.name} competitorCount={selectedIds.length} />

--- a/components/cache-info-badge.tsx
+++ b/components/cache-info-badge.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { RefreshCw, Clock, AlertTriangle } from "lucide-react";
+import { RefreshCw, Clock, AlertTriangle, Loader2 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { cn } from "@/lib/utils";
 import {
@@ -23,10 +23,14 @@ interface CacheInfoBadgeProps {
    *  When this is much older than `cachedAt`, the cache is fresh but upstream itself
    *  is stale — useful signal that RO submissions may be backed up. */
   lastScorecardAt?: string | null;
-  /** True if the SSI match is still in scoring (status not "cp"/"cs"). Drives
-   *  the prominent stale-data warning — a 5-minute-old cache on a finished
-   *  match is fine, but on an ongoing match it deserves attention. */
-  matchOngoing?: boolean;
+  /** Coarse match phase. Drives the prominent stale-data warning — a 5-minute-old
+   *  cache is fine on a future or finished match, but on a *live* one it deserves
+   *  attention. Anything other than "live" suppresses the amber/red escalation. */
+  phase?: "prematch" | "live" | "finished";
+  /** True while a background refetch is in flight. When set, the badge swaps its
+   *  clock icon for a spinner so the row doesn't reflow when a sibling status
+   *  pill enters and leaves. */
+  isRefreshing?: boolean;
 }
 
 /** When the match is ongoing, escalate the badge styling once the cache age
@@ -61,7 +65,8 @@ export function CacheInfoBadge({
   id,
   cachedAt,
   lastScorecardAt,
-  matchOngoing,
+  phase,
+  isRefreshing,
 }: CacheInfoBadgeProps) {
   const [open, setOpen] = useState(false);
   const [password, setPassword] = useState("");
@@ -101,9 +106,10 @@ export function CacheInfoBadge({
   const cacheAgeSeconds = cachedAt
     ? Math.max(0, Math.floor((now - new Date(cachedAt).getTime()) / 1000))
     : 0;
-  const isAlert = matchOngoing && cachedAt && cacheAgeSeconds > STALE_ALERT_SECONDS;
+  const isLive = phase === "live";
+  const isAlert = isLive && cachedAt && cacheAgeSeconds > STALE_ALERT_SECONDS;
   const isWarning =
-    !isAlert && matchOngoing && cachedAt && cacheAgeSeconds > STALE_WARNING_SECONDS;
+    !isAlert && isLive && cachedAt && cacheAgeSeconds > STALE_WARNING_SECONDS;
 
   const label = cachedAt ? `Updated ${formatTimeAgo(cachedAt)}` : "Live";
   const buttonClass = cn(
@@ -129,12 +135,14 @@ export function CacheInfoBadge({
         className={buttonClass}
         aria-label={ariaLabel}
       >
-        {isAlert || isWarning ? (
+        {isRefreshing ? (
+          <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
+        ) : isAlert || isWarning ? (
           <AlertTriangle className="w-3 h-3" aria-hidden="true" />
         ) : (
           <Clock className="w-3 h-3" aria-hidden="true" />
         )}
-        <span>{label}</span>
+        <span>{isRefreshing ? "Refreshing..." : label}</span>
         <RefreshCw className="w-3 h-3" aria-hidden="true" />
       </button>
 


### PR DESCRIPTION
## Summary
- The "Updated Xh ago" badge escalated to red on any match whose SSI status wasn't `cp`/`cs` -- including matches scheduled far in the future. Replace the binary `matchOngoing` flag with the page's existing `phase` (`prematch` | `live` | `finished`) and only escalate when phase is `live`. Pre-match and finished matches stay neutral regardless of cache age.
- The separate "Refreshing..." flex sibling in the toolbar row mounted/unmounted on every background refetch, causing the badge and share buttons to jump rightward. Fold the spinner into the badge itself (clock icon swaps to a `Loader2` while refreshing). The row's element count and width are now stable across refetches.

## Test plan
- [ ] Open a future match -- badge stays neutral grey even after the cache ages past 10 min
- [ ] Open a finished match (results published / status `cp`) -- badge stays neutral grey
- [ ] Open a live match with stale cache -- badge still escalates to amber > 3 min and red > 10 min
- [ ] Trigger a background refetch -- badge swaps to a spinner in place; share buttons do not shift
- [ ] `pnpm -w run typecheck && pnpm -w run lint` (already green locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)