### PR TITLE
Add MCP telemetry domain + via tag for downstream events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,9 @@ Lives in `lib/telemetry.ts` (transport) + per-domain typed wrappers:
 - `lib/upstream-telemetry.ts` — every SSI GraphQL fetch (latency, outcome, bytes)
 - `lib/error-telemetry.ts` — `reportError(site, err, extra)` for swallowed-catch sites; records error class + truncated message (no stack — avoids PII)
 - `lib/usage-telemetry.ts` — server-side product analytics (match views, comparisons, searches, OG renders, dashboard views)
+- `lib/mcp-telemetry.ts` — MCP-server-boundary events (JSON-RPC requests, tool calls, auth fails) emitted from `/api/mcp`.
+
+**`via:"mcp"` enrichment.** The MCP HTTP route opens an AsyncLocalStorage telemetry context (`lib/telemetry-context.ts`) so every event emitted while serving that request carries `via:"mcp"`. Stdio/Smithery MCP shims call REST endpoints directly with an `x-mcp-client` header; the six routes MCP tools hit (`/api/events`, `/api/match/[ct]/[id]`, `/api/compare`, `/api/popular-matches`, `/api/shooter/[shooterId]`, `/api/shooter/search`) call `maybeTagAsMcp(req)` at the top of the handler to open the same context. Result: any usage/cache/upstream/error/d1 event emitted under MCP traffic can be filtered with `select(.via == "mcp")` in jq/DuckDB. New REST routes that the MCP toolset reaches must add `maybeTagAsMcp(req)` to keep this property.
 
 **Privacy commitments — enforced by code review:**
 

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -17,6 +17,7 @@ import { decodeShooterId, indexMatchShooters } from "@/lib/shooter-index";
 import type { CompareMode, CompareResponse, CompetitorInfo, FieldFingerprintPoint, StageComparison, StageConditions } from "@/lib/types";
 import { fetchMatchWeatherRaw, getHourlySnapshot } from "@/lib/weather";
 import { geocodeVenueName } from "@/lib/geocoding";
+import { maybeTagAsMcp } from "@/lib/telemetry-context";
 
 interface RawCompetitor {
   id: string;
@@ -69,6 +70,7 @@ interface RawMatchData {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export async function GET(req: Request) {
+  maybeTagAsMcp(req);
   const rl = await checkRateLimit(req, { prefix: "compare", limit: 30, windowSeconds: 60 });
   if (!rl.allowed) {
     return NextResponse.json(

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -3,6 +3,7 @@ import { executeQuery, EVENTS_QUERY } from "@/lib/graphql";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { usageTelemetry, bucketCount } from "@/lib/usage-telemetry";
 import { markUpstreamDegraded } from "@/lib/upstream-status";
+import { maybeTagAsMcp } from "@/lib/telemetry-context";
 
 import type { EventSummary } from "@/lib/types";
 
@@ -94,6 +95,7 @@ function buildSubWindows(
 }
 
 export async function GET(req: Request) {
+  maybeTagAsMcp(req);
   const rl = await checkRateLimit(req, { prefix: "events", limit: 30, windowSeconds: 60 });
   if (!rl.allowed) {
     return NextResponse.json(

--- a/app/api/match/[ct]/[id]/route.ts
+++ b/app/api/match/[ct]/[id]/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from "next/server";
 import { fetchMatchData } from "@/lib/match-data";
+import { maybeTagAsMcp } from "@/lib/telemetry-context";
 
 export async function GET(
-  _req: Request,
+  req: Request,
   { params }: { params: Promise<{ ct: string; id: string }> }
 ) {
+  maybeTagAsMcp(req);
   const t0 = performance.now();
   const { ct, id } = await params;
 

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -4,6 +4,8 @@ import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import { NextResponse } from "next/server";
 import { registerMcpTools, SERVER_INSTRUCTIONS } from "@/lib/mcp-tools";
 import * as directProviders from "@/lib/api-data";
+import { mcpTelemetry, bucketCompetitors } from "@/lib/mcp-telemetry";
+import { runWithTelemetryContext } from "@/lib/telemetry-context";
 
 /**
  * Promise-based single-request/response transport for Next.js App Router.
@@ -122,6 +124,7 @@ export async function POST(request: Request) {
   // unauthenticated clients receive 401 with WWW-Authenticate, complete the
   // OAuth dance, then retry with the token (per RFC 9728 / MCP OAuth spec).
   if (!auth?.startsWith("Bearer ")) {
+    mcpTelemetry({ op: "auth-fail", transport: "http", reason: "no-bearer" });
     return new Response("Unauthorized", {
       status: 401,
       headers: {
@@ -134,6 +137,7 @@ export async function POST(request: Request) {
   // If MCP_SECRET is configured, enforce it.  Otherwise accept any Bearer token
   // (public API — the token is a formality to satisfy the OAuth handshake).
   if (secret && auth !== `Bearer ${secret}`) {
+    mcpTelemetry({ op: "auth-fail", transport: "http", reason: "wrong-secret" });
     return new Response("Unauthorized", {
       status: 401,
       headers: {
@@ -150,32 +154,90 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400, headers: CORS });
   }
 
-  const transport = new SingleShotTransport();
-  const server = new McpServer({ name: "ssi-scoreboard", version: "0.1.0" }, { instructions: SERVER_INSTRUCTIONS });
-  // Pass direct data-provider functions instead of a baseUrl.  On Cloudflare,
-  // a Worker cannot subrequest its own custom-domain Pages deployment (returns
-  // 522).  Calling the route handlers in-process bypasses HTTP entirely.
-  registerMcpTools(server, directProviders);
-  await server.connect(transport);
+  // Wrap the rest of the request in a telemetry context so downstream
+  // events (usage/cache/upstream) carry via:"mcp".
+  return runWithTelemetryContext({ via: "mcp" }, async () => {
+    const transport = new SingleShotTransport();
+    const server = new McpServer({ name: "ssi-scoreboard", version: "0.1.0" }, { instructions: SERVER_INSTRUCTIONS });
+    // Pass direct data-provider functions instead of a baseUrl.  On Cloudflare,
+    // a Worker cannot subrequest its own custom-domain Pages deployment (returns
+    // 522).  Calling the route handlers in-process bypasses HTTP entirely.
+    registerMcpTools(server, directProviders);
+    await server.connect(transport);
 
-  // JSON-RPC notifications have no `id` field (e.g. notifications/initialized).
-  // They don't expect a response — acknowledge with 202 so clients don't treat
-  // the missing body as an error.
-  if (!("id" in body)) {
+    // JSON-RPC notifications have no `id` field (e.g. notifications/initialized).
+    // They don't expect a response — acknowledge with 202 so clients don't treat
+    // the missing body as an error.
+    if (!("id" in body)) {
+      transport.deliver(body);
+      return new Response(null, { status: 202, headers: CORS });
+    }
+
+    const startedAt = Date.now();
+    const method = typeof (body as { method?: unknown }).method === "string"
+      ? (body as { method: string }).method
+      : "unknown";
+    const params = (body as { params?: Record<string, unknown> }).params;
+
+    // Deliver the request and wait for the server's async response. Using a
+    // proper Promise (resolved when send() fires) rather than setTimeout(0) so
+    // that tool handlers which call fetch() have time to complete.
     transport.deliver(body);
-    return new Response(null, { status: 202, headers: CORS });
-  }
+    const response = await transport.waitForResponse(30_000);
+    const latencyMs = Date.now() - startedAt;
 
-  // Deliver the request and wait for the server's async response. Using a
-  // proper Promise (resolved when send() fires) rather than setTimeout(0) so
-  // that tool handlers which call fetch() have time to complete.
-  transport.deliver(body);
-  const response = await transport.waitForResponse(30_000);
-  if (response === null) {
-    return NextResponse.json(
-      { error: "No response from server" },
-      { status: 500, headers: CORS },
-    );
-  }
-  return NextResponse.json(response, { headers: CORS });
+    if (response === null) {
+      emitMcpEvents(method, params, false, latencyMs, null);
+      return NextResponse.json(
+        { error: "No response from server" },
+        { status: 500, headers: CORS },
+      );
+    }
+
+    const errorCode =
+      typeof (response as { error?: { code?: number } }).error?.code === "number"
+        ? ((response as { error: { code: number } }).error.code)
+        : null;
+    emitMcpEvents(method, params, errorCode === null, latencyMs, errorCode);
+    return NextResponse.json(response, { headers: CORS });
+  });
+}
+
+// Emit one mcp.request event for every JSON-RPC call, plus an mcp.tool-call
+// event with the tool name + bucketed args when method === "tools/call".
+function emitMcpEvents(
+  method: string,
+  params: Record<string, unknown> | undefined,
+  ok: boolean,
+  latencyMs: number,
+  errorCode: number | null,
+): void {
+  mcpTelemetry({ op: "request", transport: "http", method, ok, latencyMs, errorCode });
+
+  if (method !== "tools/call" || !params) return;
+  const toolName = typeof params.name === "string" ? params.name : "unknown";
+  const args = (params.arguments as Record<string, unknown> | undefined) ?? {};
+
+  const ct = parseInt(String(args.ct ?? ""), 10);
+  const ctValue = Number.isFinite(ct) ? ct : null;
+
+  const competitorIds = Array.isArray(args.competitor_ids) ? args.competitor_ids : null;
+  const nCompetitorsBucket = competitorIds ? bucketCompetitors(competitorIds.length) : null;
+
+  const queryLength =
+    typeof args.query === "string" ? args.query.length : null;
+  const minLevel = typeof args.min_level === "string" ? args.min_level : null;
+
+  mcpTelemetry({
+    op: "tool-call",
+    transport: "http",
+    tool: toolName,
+    ok,
+    latencyMs,
+    errorCode,
+    ct: ctValue,
+    nCompetitorsBucket,
+    queryLength,
+    minLevel,
+  });
 }

--- a/app/api/popular-matches/route.ts
+++ b/app/api/popular-matches/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import db from "@/lib/db-impl";
 import { getMatchDataWithFallback } from "@/lib/match-data-store";
+import { maybeTagAsMcp } from "@/lib/telemetry-context";
 import type { PopularMatch } from "@/lib/types";
 
 /** Maximum age (seconds) a match access must be within to qualify. */
@@ -35,7 +36,8 @@ interface MatchCacheEntry {
  * Works on both the ioredis (Docker/Node) and @upstash/redis (Cloudflare)
  * cache adapters. Returns [] on any cache error.
  */
-export async function GET() {
+export async function GET(req: Request) {
+  maybeTagAsMcp(req);
   try {
     const popular = await db.getPopularKeys(MAX_AGE_SECONDS, MAX_RESULTS);
 

--- a/app/api/shooter/[shooterId]/route.ts
+++ b/app/api/shooter/[shooterId]/route.ts
@@ -11,6 +11,7 @@ import { parseRawScorecards } from "@/lib/scorecard-data";
 import { extractDivision } from "@/lib/divisions";
 import { computeAggregateStats } from "@/lib/shooter-stats";
 import { evaluateAchievements } from "@/lib/achievements/evaluate";
+import { maybeTagAsMcp } from "@/lib/telemetry-context";
 import type {
   ShooterDashboardResponse,
   ShooterMatchSummary,
@@ -297,9 +298,10 @@ function computeMatchStats(
 // ─── Route handler ────────────────────────────────────────────────────────────
 
 export async function GET(
-  _req: Request,
+  req: Request,
   { params }: { params: Promise<{ shooterId: string }> },
 ) {
+  maybeTagAsMcp(req);
   const { shooterId: shooterIdStr } = await params;
   const shooterId = parseInt(shooterIdStr, 10);
   if (isNaN(shooterId) || shooterId <= 0) {

--- a/app/api/shooter/search/route.ts
+++ b/app/api/shooter/search/route.ts
@@ -2,8 +2,10 @@ import { NextResponse } from "next/server";
 import db from "@/lib/db-impl";
 import { reportError } from "@/lib/error-telemetry";
 import { usageTelemetry, bucketCount } from "@/lib/usage-telemetry";
+import { maybeTagAsMcp } from "@/lib/telemetry-context";
 
 export async function GET(req: Request) {
+  maybeTagAsMcp(req);
   const url = new URL(req.url);
   const q = (url.searchParams.get("q") ?? "").trim().slice(0, 100);
   const limitRaw = url.searchParams.get("limit");

--- a/lib/api-data.ts
+++ b/lib/api-data.ts
@@ -76,7 +76,7 @@ export async function compareCompetitors(
 }
 
 export async function getPopularMatches(): Promise<PopularMatch[]> {
-  const res = await popularGET();
+  const res = await popularGET(new Request("http://localhost/api/popular-matches"));
   return extractJson<PopularMatch[]>(res);
 }
 

--- a/lib/mcp-telemetry.ts
+++ b/lib/mcp-telemetry.ts
@@ -1,0 +1,65 @@
+// Server-only -- never import from client components.
+//
+// Typed helper for the "mcp" telemetry domain. Records MCP-server-boundary
+// events: JSON-RPC requests, tool calls, and auth failures over the
+// /api/mcp HTTP transport. Underlying REST endpoints called by tool
+// handlers emit their own usage/cache/upstream telemetry; events emitted
+// during an MCP-served request additionally carry via:"mcp" via the
+// request-scoped context in lib/telemetry-context.ts.
+//
+// Privacy commitments (same rules as usage):
+//   - NO IP addresses, no User-Agent
+//   - NO shooter IDs, NO competitor IDs (counts/buckets only)
+//   - NO raw search query text -- only queryLength and resultBucket
+//   - Match IDs ARE allowed (public events, IDs are not PII)
+//
+// Sampling: defaults to rate=1. MCP volume is small (a few requests per
+// active session); R2 PUT cost is negligible.
+
+import { telemetry } from "@/lib/telemetry";
+
+export type McpTransport = "http";
+
+/** Bucket competitor count for compare_competitors. */
+export function bucketCompetitors(n: number): "1" | "2-4" | "5-12" {
+  if (n <= 1) return "1";
+  if (n <= 4) return "2-4";
+  return "5-12";
+}
+
+export type McpEvent =
+  | {
+      op: "request";
+      transport: McpTransport;
+      /** JSON-RPC method, e.g. "initialize", "tools/list", "prompts/get". */
+      method: string;
+      ok: boolean;
+      latencyMs: number;
+      /** JSON-RPC error code (if the response carried an error). */
+      errorCode?: number | null;
+    }
+  | {
+      op: "tool-call";
+      transport: McpTransport;
+      tool: string;
+      ok: boolean;
+      latencyMs: number;
+      errorCode?: number | null;
+      /** content-type discriminator for match-bound tools. */
+      ct?: number | null;
+      /** competitor count bucket for compare_competitors. */
+      nCompetitorsBucket?: "1" | "2-4" | "5-12" | null;
+      /** raw queryLength for search_events / find_shooter (low cardinality). */
+      queryLength?: number | null;
+      /** min_level filter for search_events. */
+      minLevel?: string | null;
+    }
+  | {
+      op: "auth-fail";
+      transport: McpTransport;
+      reason: "no-bearer" | "wrong-secret";
+    };
+
+export function mcpTelemetry(ev: McpEvent): void {
+  telemetry({ domain: "mcp", ...ev });
+}

--- a/lib/mcp-tools.ts
+++ b/lib/mcp-tools.ts
@@ -310,8 +310,15 @@ export interface DataProviders {
   searchShooterProfiles: (params: { query: string; limit?: number }) => Promise<ShooterSearchResult[]>;
 }
 
+// Header sent on every REST call from the MCP stdio/Smithery shims so the
+// REST handlers can tag downstream telemetry with via:"mcp" (see
+// lib/telemetry-context.ts and the route handlers' isMcpRequest() check).
+const MCP_CLIENT_HEADER = "x-mcp-client";
+
 async function apiFetch<T>(baseUrl: string, path: string): Promise<T> {
-  const res = await fetch(`${baseUrl}${path}`);
+  const res = await fetch(`${baseUrl}${path}`, {
+    headers: { [MCP_CLIENT_HEADER]: "stdio" },
+  });
   if (!res.ok) throw new Error(`HTTP ${res.status} from ${baseUrl}${path}`);
   return res.json() as Promise<T>;
 }

--- a/lib/telemetry-context.ts
+++ b/lib/telemetry-context.ts
@@ -1,0 +1,42 @@
+// Server-only -- request-scoped context for telemetry enrichment.
+//
+// Lets a caller (e.g. /api/mcp) wrap a request in a context so that any
+// telemetry event emitted during that request gets enriched with extra
+// fields like via:"mcp". Backed by AsyncLocalStorage, which works on
+// Node.js and on Cloudflare Workers (nodejs_compat flag enabled in
+// wrangler.toml).
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface TelemetryContext {
+  /** Where the request entered the system. "mcp" = via /api/mcp or stdio MCP. */
+  via?: "mcp";
+}
+
+const storage = new AsyncLocalStorage<TelemetryContext>();
+
+export function runWithTelemetryContext<T>(ctx: TelemetryContext, fn: () => T): T {
+  return storage.run(ctx, fn);
+}
+
+export function getTelemetryContext(): TelemetryContext | undefined {
+  return storage.getStore();
+}
+
+/**
+ * If the request carries the `x-mcp-client` header (set by stdio/Smithery
+ * MCP shims in lib/mcp-tools.ts), tag the current request's telemetry
+ * context with via:"mcp" so downstream events are enriched.
+ *
+ * Uses AsyncLocalStorage.enterWith — the tag scopes to the current async
+ * chain, which in a Next.js route handler is the request's own task.
+ *
+ * Call this once at the top of any REST handler that MCP tools hit. The
+ * /api/mcp HTTP route opens its own context via runWithTelemetryContext,
+ * so it does not need this helper.
+ */
+export function maybeTagAsMcp(req: Request): void {
+  if (req.headers.get("x-mcp-client")) {
+    storage.enterWith({ via: "mcp" });
+  }
+}

--- a/lib/telemetry-sinks-cf.ts
+++ b/lib/telemetry-sinks-cf.ts
@@ -62,6 +62,7 @@ const DEFAULT_RATES: Record<string, number> = {
   d1: 1,
   background: 1,
   usage: 1,
+  mcp: 1,
 };
 
 // Catch-all for domains not listed above.

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -19,6 +19,7 @@
 //    default `lib/telemetry-sinks-impl.ts` (Docker/Node).
 
 import { extraSinks } from "@/lib/telemetry-sinks-impl";
+import { getTelemetryContext } from "@/lib/telemetry-context";
 
 export interface TelemetryEvent {
   /** Domain bucket — "cache", "ai", "ratelimit", etc. */
@@ -45,7 +46,12 @@ export function registerSink(sink: TelemetrySink): void {
 
 export function telemetry(ev: TelemetryEvent): void {
   if (!ENABLED) return;
-  const enriched: EnrichedEvent = { ts: new Date().toISOString(), ...ev };
+  const ctx = getTelemetryContext();
+  const enriched: EnrichedEvent = {
+    ts: new Date().toISOString(),
+    ...ev,
+    ...(ctx?.via ? { via: ctx.via } : {}),
+  };
   for (const s of sinks) {
     try {
       s(enriched);


### PR DESCRIPTION
## Summary

- New `mcp` telemetry domain (`lib/mcp-telemetry.ts`) with three event ops: `request` (every JSON-RPC method), `tool-call` (tool name + bucketed args), and `auth-fail` (`no-bearer` | `wrong-secret`). Wired into `app/api/mcp/route.ts` POST.
- Request-scoped `AsyncLocalStorage` context (`lib/telemetry-context.ts`) so any cache/upstream/usage/error/d1 event emitted while serving an MCP request carries `via:"mcp"`. Filter with `select(.via == "mcp")` in jq/DuckDB.
- Stdio/Smithery shims call REST endpoints directly: `createHttpProviders` sets `x-mcp-client: stdio`, and the six MCP-reachable routes (`/api/events`, `/api/match/[ct]/[id]`, `/api/compare`, `/api/popular-matches`, `/api/shooter/[shooterId]`, `/api/shooter/search`) call `maybeTagAsMcp(req)` at the top of the handler to open the same context.
- Privacy unchanged: bucketed competitor counts, `queryLength` only (no raw query strings), no shooter/competitor IDs.
- `mcp: 1` added to `DEFAULT_RATES` in `lib/telemetry-sinks-cf.ts`. CLAUDE.md documents the new domain and the `via` mechanism.

## Test plan

- [x] `pnpm -w run typecheck` clean
- [x] `pnpm -w test` (1558 tests) passes
- [x] `pnpm -w run lint` clean
- [x] `cd mcp && pnpm run typecheck` clean
- [ ] Hit `/api/mcp` from claude.ai / Claude Desktop and confirm `domain: "mcp"` events appear in R2 telemetry
- [ ] Hit a REST route from the stdio MCP shim and confirm downstream events carry `via: "mcp"`
- [ ] Confirm the existing web UI traffic does NOT carry `via: "mcp"` (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)