### PR TITLE
Stage times export (JSON + CSV) for selected competitors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,8 +177,9 @@ the scenes from `scripts/screenshot-match.ts` that best showcase the new feature
 Each scene is captured at both mobile (390×844) and desktop (1280×900).
 
 Current catalogue: `comparison-table`, `degradation-chart`, `hf-level-bars`,
-`archetype-chart`, `style-fingerprint`, `shooter-dashboard`, `competitor-identity`,
-`tracked-shooters-sheet`, `whats-new-dialog`. Omit the field to capture all.
+`archetype-chart`, `style-fingerprint`, `stage-times-export`, `shooter-dashboard`,
+`competitor-identity`, `tracked-shooters-sheet`, `whats-new-dialog`. Omit the field
+to capture all.
 
 **When to add a new scene:** if a new chart or UI section isn't well-represented by any
 existing scene, add one to `scripts/screenshot-match.ts` (follow the existing `Scene`

--- a/app/api/compare/logic.ts
+++ b/app/api/compare/logic.ts
@@ -633,6 +633,7 @@ export function computeGroupRankings(
           stageClassification: null,
           hitLossPoints: null,
           penaltyLossPoints: 0,
+          scorecard_created: sc?.scorecard_created ?? null,
         };
       } else {
         const hf = effectiveHF(sc);
@@ -698,6 +699,7 @@ export function computeGroupRankings(
           ),
           hitLossPoints,
           penaltyLossPoints,
+          scorecard_created: sc.scorecard_created ?? null,
         };
       }
     }

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -46,7 +46,6 @@ import { useTrackedShooters } from "@/lib/hooks/use-tracked-shooters";
 import { MAX_COMPETITORS } from "@/lib/constants";
 import { PreMatchView } from "@/components/pre-match-view";
 import { StageTimesExport } from "@/components/stage-times-export";
-import { usePreviewFeature } from "@/hooks/use-preview-feature";
 
 // Stable empty array for useSyncExternalStore server snapshot — must be a
 // constant reference so React's referential equality check doesn't loop.
@@ -125,7 +124,6 @@ const DivisionDistributionChart = dynamic(
 );
 
 export default function MatchPageClient() {
-  const stageExportEnabled = usePreviewFeature("stage-export");
   const [showCoachingView, setShowCoachingView] = useState(false);
   const [showSimulator, setShowSimulator] = useState(false);
   const [showManage, setShowManage] = useState(false);
@@ -997,15 +995,13 @@ export default function MatchPageClient() {
                           <StageDegradationChart data={compareQuery.data} />
                         </div>
 
-                        {stageExportEnabled && (
-                          <StageTimesExport
-                            ct={ct}
-                            id={id}
-                            match={match}
-                            compareData={compareQuery.data}
-                            selectedIds={selectedIds}
-                          />
-                        )}
+                        <StageTimesExport
+                          ct={ct}
+                          id={id}
+                          match={match}
+                          compareData={compareQuery.data}
+                          selectedIds={selectedIds}
+                        />
                       </section>
                     </CollapsibleContent>
                   </Collapsible>

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -45,6 +45,8 @@ import { useMyIdentity } from "@/lib/hooks/use-my-identity";
 import { useTrackedShooters } from "@/lib/hooks/use-tracked-shooters";
 import { MAX_COMPETITORS } from "@/lib/constants";
 import { PreMatchView } from "@/components/pre-match-view";
+import { StageTimesExport } from "@/components/stage-times-export";
+import { usePreviewFeature } from "@/hooks/use-preview-feature";
 
 // Stable empty array for useSyncExternalStore server snapshot — must be a
 // constant reference so React's referential equality check doesn't loop.
@@ -123,6 +125,7 @@ const DivisionDistributionChart = dynamic(
 );
 
 export default function MatchPageClient() {
+  const stageExportEnabled = usePreviewFeature("stage-export");
   const [showCoachingView, setShowCoachingView] = useState(false);
   const [showSimulator, setShowSimulator] = useState(false);
   const [showManage, setShowManage] = useState(false);
@@ -993,6 +996,16 @@ export default function MatchPageClient() {
                           </div>
                           <StageDegradationChart data={compareQuery.data} />
                         </div>
+
+                        {stageExportEnabled && (
+                          <StageTimesExport
+                            ct={ct}
+                            id={id}
+                            match={match}
+                            compareData={compareQuery.data}
+                            selectedIds={selectedIds}
+                          />
+                        )}
                       </section>
                     </CollapsibleContent>
                   </Collapsible>

--- a/components/stage-times-export.tsx
+++ b/components/stage-times-export.tsx
@@ -3,7 +3,6 @@
 import { useCallback } from "react";
 import { Download, FileJson, FileSpreadsheet, HelpCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import {
   Popover,
   PopoverContent,
@@ -76,9 +75,6 @@ export function StageTimesExport({ ct, id, match, compareData, selectedIds }: Pr
     <div className="space-y-2">
       <div className="flex items-center gap-1.5 flex-wrap">
         <h3 className="text-sm font-semibold">Export stage times</h3>
-        <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
-          Preview
-        </Badge>
         <Popover>
           <PopoverTrigger asChild>
             <button

--- a/components/stage-times-export.tsx
+++ b/components/stage-times-export.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useCallback } from "react";
+import { Download, FileJson, FileSpreadsheet, HelpCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+} from "@/components/ui/popover";
+import {
+  buildStageTimesCsv,
+  buildStageTimesExport,
+  stageTimesFilenameStem,
+} from "@/lib/stage-times-export";
+import type { CompareResponse, MatchResponse } from "@/lib/types";
+
+interface Props {
+  ct: string;
+  id: string;
+  match: MatchResponse;
+  compareData: CompareResponse;
+  selectedIds: number[];
+}
+
+function downloadBlob(content: string, filename: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function StageTimesExport({ ct, id, match, compareData, selectedIds }: Props) {
+  const buildExport = useCallback(() => {
+    return buildStageTimesExport({
+      match: { ct, id, name: match.name },
+      compareData,
+      competitors: match.competitors,
+      squads: match.squads,
+      selectedIds,
+    });
+  }, [ct, id, match, compareData, selectedIds]);
+
+  const onDownloadJson = () => {
+    const data = buildExport();
+    const json = JSON.stringify(data, null, 2);
+    downloadBlob(
+      json,
+      `${stageTimesFilenameStem(data.match)}.json`,
+      "application/json;charset=utf-8",
+    );
+  };
+
+  const onDownloadCsv = () => {
+    const data = buildExport();
+    const csv = buildStageTimesCsv(data);
+    downloadBlob(
+      csv,
+      `${stageTimesFilenameStem(data.match)}.csv`,
+      "text/csv;charset=utf-8",
+    );
+  };
+
+  const disabled = selectedIds.length === 0;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-1.5 flex-wrap">
+        <h3 className="text-sm font-semibold">Export stage times</h3>
+        <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
+          Preview
+        </Badge>
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+              aria-label="About stage times export"
+            >
+              <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-80" side="bottom" align="start">
+            <PopoverHeader>
+              <PopoverTitle>Export stage times</PopoverTitle>
+              <PopoverDescription>
+                Per-stage time and timestamp for each selected competitor, formatted for video editing.
+              </PopoverDescription>
+            </PopoverHeader>
+            <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
+              <p>
+                <strong>JSON</strong> — one object per competitor with a stages array. Suitable for scripts that auto-cut a recording into per-stage clips.
+              </p>
+              <p>
+                <strong>CSV</strong> — flat rows sorted by competitor then stage. Opens in Excel and imports cleanly into Resolve / Premiere as markers.
+              </p>
+              <p>
+                Each row carries <code>time_seconds</code> (raw stage time) and <code>scorecard_updated_at</code> (ISO timestamp from the RO submission) — useful for aligning a stage run to a long match recording.
+              </p>
+              <p>
+                The export covers the competitors you have selected in the comparison view above.
+              </p>
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Stage times for the competitors you&apos;ve selected, formatted for video editing.
+      </p>
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onDownloadJson}
+          disabled={disabled}
+          className="gap-1.5"
+        >
+          <FileJson className="w-4 h-4" aria-hidden="true" />
+          Download JSON
+          <Download className="w-3.5 h-3.5 opacity-60" aria-hidden="true" />
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onDownloadCsv}
+          disabled={disabled}
+          className="gap-1.5"
+        >
+          <FileSpreadsheet className="w-4 h-4" aria-hidden="true" />
+          Download CSV
+          <Download className="w-3.5 h-3.5 opacity-60" aria-hidden="true" />
+        </Button>
+      </div>
+
+      {disabled && (
+        <p className="text-xs text-muted-foreground" role="status">
+          Select at least one competitor in the comparison above to enable export.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -31,5 +31,8 @@ export const MAX_COMPETITORS = 12;
  *       rule (daysSince > MATCH_COMPLETE_DAYS_SINCE before any pinning,
  *       even on SSI flag flips). Invalidates any D1 entries pinned via
  *       results=all or status=cp during a match's first 3 days.
+ *  14 → added scorecard_created to CompetitorSummary on CompareResponse
+ *       (powers the stage-times export feature so video editors can align
+ *       per-stage runs to a recording timeline).
  */
-export const CACHE_SCHEMA_VERSION = 13;
+export const CACHE_SCHEMA_VERSION = 14;

--- a/lib/feature-previews.ts
+++ b/lib/feature-previews.ts
@@ -1,7 +1,7 @@
 // Generic feature preview toggle system.
 // State stored in localStorage as a JSON array under key "ssi-preview-features".
 
-export const PREVIEW_FEATURES = [] as const;
+export const PREVIEW_FEATURES = ["stage-export"] as const;
 export type PreviewFeatureId = (typeof PREVIEW_FEATURES)[number];
 
 const STORAGE_KEY = "ssi-preview-features";

--- a/lib/feature-previews.ts
+++ b/lib/feature-previews.ts
@@ -1,7 +1,7 @@
 // Generic feature preview toggle system.
 // State stored in localStorage as a JSON array under key "ssi-preview-features".
 
-export const PREVIEW_FEATURES = ["stage-export"] as const;
+export const PREVIEW_FEATURES = [] as const;
 export type PreviewFeatureId = (typeof PREVIEW_FEATURES)[number];
 
 const STORAGE_KEY = "ssi-preview-features";

--- a/lib/mcp-tools.ts
+++ b/lib/mcp-tools.ts
@@ -3,6 +3,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { EventSummary, MatchResponse, CompareResponse, PopularMatch, ShooterDashboardResponse, ShooterSearchResult } from "./types";
+import { buildStageTimesExport } from "./stage-times-export";
 
 // ---------------------------------------------------------------------------
 // Static resource content
@@ -76,6 +77,12 @@ compare_competitors
   • Returns: scores, hit factors, penalties, efficiency, consistency,
     what-if rank simulations, and style fingerprints.
   • competitor_ids are numeric — always resolve names via get_match first.
+
+get_stage_times
+  Export raw per-stage times and ISO timestamps for a list of competitors.
+  • Use when an editor needs to auto-cut a long match recording into per-stage clips.
+  • Returns competitors[].stages[] with stage_number, stage_name, time_seconds, scorecard_updated_at.
+  • Same competitor-resolution pattern as compare_competitors (numeric IDs from get_match).
 
 get_popular_matches
   Returns recently-viewed matches from the server cache.
@@ -421,6 +428,35 @@ export function registerMcpTools(server: McpServer, arg: string | DataProviders)
     { readOnlyHint: true, openWorldHint: true },
     async ({ ct, id, competitor_ids }) => {
       const data = await providers.compareCompetitors(ct, id, competitor_ids);
+      return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    "get_stage_times",
+    "Export raw stage times for a list of competitors at a match — built for video editors who want to auto-cut a long match recording into per-stage clips. " +
+    "Returns one object per competitor with a stages[] array; each entry has stage_number, stage_name, time_seconds (raw stage time), and scorecard_updated_at (ISO timestamp of when the run was recorded). " +
+    "Stages within each competitor are sorted by stage_number. Competitors are returned in the order of `competitor_ids`. " +
+    "competitor_ids are numeric IDs from get_match — resolve names with get_match first.",
+    {
+      ct: z.string().describe("content_type value from search_events / get_match"),
+      id: z.string().describe("match id value from search_events / get_match"),
+      competitor_ids: z.array(z.number().int().positive()).min(1).max(12)
+        .describe("Numeric competitor IDs from get_match. Up to 12."),
+    },
+    { readOnlyHint: true, openWorldHint: true },
+    async ({ ct, id, competitor_ids }) => {
+      const [match, compare] = await Promise.all([
+        providers.getMatch(ct, id),
+        providers.compareCompetitors(ct, id, competitor_ids),
+      ]);
+      const data = buildStageTimesExport({
+        match: { ct, id, name: match.name },
+        compareData: compare,
+        competitors: match.competitors,
+        squads: match.squads,
+        selectedIds: competitor_ids,
+      });
       return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
     },
   );

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -11,12 +11,28 @@ import type { Release } from "@/lib/types";
  * differs from the value stored in localStorage("whats-new-seen-id").
  */
 /** The `id` of the newest release. Used by e2e tests to suppress the What's New dialog. */
-export const LATEST_RELEASE_ID = "2026-04-29";
+export const LATEST_RELEASE_ID = "2026-04-28-stage-export";
 
 export const RELEASES: Release[] = [
   {
     id: LATEST_RELEASE_ID,
-    date: "April 29, 2026",
+    date: "April 28, 2026",
+    title: "Stage times export",
+    screenshotScenes: ["stage-times-export"],
+    sections: [
+      {
+        heading: "New",
+        items: [
+          "Post-match coaching now includes a 'Export stage times' section with one-tap JSON and CSV downloads of the per-stage times for the competitors you've selected. Auto-cut a long match recording into per-stage clips, or import the CSV into Resolve / Premiere as markers.",
+          "Each row carries an ISO timestamp from the RO submission so editors can align a stage run to a recording timeline.",
+          "Same data is also available as the get_stage_times MCP tool for editors using Claude Desktop or Claude Code.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "2026-04-29",
+    date: "April 28, 2026",
     title: "Easier on the eyes",
     screenshotScenes: [
       "comparison-table",

--- a/lib/stage-times-export.ts
+++ b/lib/stage-times-export.ts
@@ -1,0 +1,166 @@
+// Pure builder for the stage-times export feature (issue #329).
+// Same data, two formats: JSON (one object per competitor with stages[])
+// and CSV (flat rows, competitor-blocked, stage-ordered).
+//
+// No I/O, no DOM. Used both client-side (download buttons) and server-side
+// (MCP get_stage_times tool).
+
+import type {
+  CompareResponse,
+  CompetitorInfo,
+  SquadInfo,
+} from "@/lib/types";
+
+export interface StageTimeEntry {
+  stage_number: number;
+  stage_name: string;
+  /** Raw stage time in seconds. Null when the competitor has no scorecard
+   *  for this stage, DNF'd, or the timer reading is missing. */
+  time_seconds: number | null;
+  /** ISO timestamp of when the scorecard was recorded. Null when unknown. */
+  scorecard_updated_at: string | null;
+}
+
+export interface CompetitorStageTimes {
+  competitor_id: number;
+  name: string;
+  division: string | null;
+  club: string | null;
+  squad: string | null;
+  stages: StageTimeEntry[];
+}
+
+export interface StageTimesMatchInfo {
+  ct: string;
+  id: string;
+  name: string;
+}
+
+export interface StageTimesExport {
+  match: StageTimesMatchInfo;
+  competitors: CompetitorStageTimes[];
+}
+
+interface BuildInput {
+  match: StageTimesMatchInfo;
+  compareData: Pick<CompareResponse, "stages">;
+  competitors: CompetitorInfo[];
+  squads: SquadInfo[];
+  selectedIds: readonly number[];
+}
+
+/**
+ * Build the structured JSON export for a set of selected competitors.
+ *
+ * Ordering:
+ *  - competitors[] follows `selectedIds` order (preserves user's selection order)
+ *  - each competitor's stages[] is sorted by stage_number ascending
+ *
+ * Competitors that don't appear in the match `competitors` list are skipped.
+ */
+export function buildStageTimesExport({
+  match,
+  compareData,
+  competitors,
+  squads,
+  selectedIds,
+}: BuildInput): StageTimesExport {
+  const competitorById = new Map<number, CompetitorInfo>();
+  for (const c of competitors) competitorById.set(c.id, c);
+
+  const squadById = new Map<number, string>();
+  for (const sq of squads) {
+    for (const cid of sq.competitorIds) squadById.set(cid, sq.name);
+  }
+
+  const sortedStages = [...compareData.stages].sort(
+    (a, b) => a.stage_num - b.stage_num,
+  );
+
+  const competitorEntries: CompetitorStageTimes[] = [];
+  for (const cid of selectedIds) {
+    const info = competitorById.get(cid);
+    if (!info) continue;
+
+    const stages: StageTimeEntry[] = sortedStages.map((stage) => {
+      const summary = stage.competitors[cid];
+      return {
+        stage_number: stage.stage_num,
+        stage_name: stage.stage_name,
+        time_seconds: summary?.time ?? null,
+        scorecard_updated_at: summary?.scorecard_created ?? null,
+      };
+    });
+
+    competitorEntries.push({
+      competitor_id: cid,
+      name: info.name,
+      division: info.division,
+      club: info.club,
+      squad: squadById.get(cid) ?? null,
+      stages,
+    });
+  }
+
+  return { match, competitors: competitorEntries };
+}
+
+/** RFC 4180 field escape: quote any field containing comma, quote, CR, or LF. */
+export function escapeCsvField(value: string | number | null): string {
+  if (value === null) return "";
+  const s = typeof value === "number" ? String(value) : value;
+  if (/[",\r\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+/**
+ * Build a flat CSV from the same export data. Rows are ordered competitor-then-stage.
+ * Includes a UTF-8 BOM so Excel detects the encoding correctly when double-clicking.
+ */
+export function buildStageTimesCsv(data: StageTimesExport): string {
+  const headers = [
+    "competitor",
+    "division",
+    "club",
+    "squad",
+    "stage_number",
+    "stage_name",
+    "time_seconds",
+    "scorecard_updated_at",
+  ];
+
+  const lines: string[] = [headers.join(",")];
+
+  for (const comp of data.competitors) {
+    for (const st of comp.stages) {
+      lines.push(
+        [
+          escapeCsvField(comp.name),
+          escapeCsvField(comp.division),
+          escapeCsvField(comp.club),
+          escapeCsvField(comp.squad),
+          escapeCsvField(st.stage_number),
+          escapeCsvField(st.stage_name),
+          escapeCsvField(st.time_seconds),
+          escapeCsvField(st.scorecard_updated_at),
+        ].join(","),
+      );
+    }
+  }
+
+  // Excel-friendly UTF-8 BOM + CRLF line endings.
+  // The BOM (﻿) is intentional — it's how Excel detects UTF-8.
+  return "﻿" + lines.join("\r\n") + "\r\n";
+}
+
+/** Suggested filename stem (no extension) for downloads. */
+export function stageTimesFilenameStem(match: StageTimesMatchInfo): string {
+  const slug = match.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60) || "match";
+  return `stage-times-${slug}-${match.ct}-${match.id}`;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -190,6 +190,10 @@ export interface CompetitorSummary {
   // Points lost to penalties (miss + no_shoot + procedural × 10 each).
   // Always 0 for DNF; always ≥ 0 for fired stages.
   penaltyLossPoints: number;
+  // ISO timestamp of when the scorecard was recorded (RO submission time).
+  // Useful for editors aligning a stage run to a long video recording.
+  // Null when the scorecard has no timestamp or this competitor did not fire the stage.
+  scorecard_created?: string | null;
 }
 
 // Per-stage HF distribution for a single division.

--- a/scripts/screenshot-match.ts
+++ b/scripts/screenshot-match.ts
@@ -209,6 +209,21 @@ const SCENES: Scene[] = [
     },
   },
   {
+    name: "stage-times-export",
+    description: "Stage times export download buttons inside the coaching analysis accordion",
+    suppressWhatsNew: true,
+    setup: async (page, matchPath) => {
+      await page.goto(`${matchPath}?competitors=${MOCK_IDS}`);
+      await page.waitForSelector("text=Stage results", { timeout: 10000 });
+      await openCoachingSection(page);
+      const heading = page.locator("h3", { hasText: "Export stage times" }).first();
+      await heading.waitFor({ timeout: 8000 }).catch(() => null);
+      await heading.evaluate(
+        (el) => el.scrollIntoView({ block: "start", behavior: "instant" })
+      ).catch(() => null);
+    },
+  },
+  {
     name: "shooter-dashboard",
     description: "Shooter dashboard with match history and performance trends",
     suppressWhatsNew: true,

--- a/tests/unit/stage-times-export.test.ts
+++ b/tests/unit/stage-times-export.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildStageTimesExport,
+  buildStageTimesCsv,
+  escapeCsvField,
+  stageTimesFilenameStem,
+} from "@/lib/stage-times-export";
+import type {
+  CompareResponse,
+  CompetitorInfo,
+  CompetitorSummary,
+  SquadInfo,
+  StageComparison,
+} from "@/lib/types";
+
+const BOM = "﻿";
+
+function summary(partial: Partial<CompetitorSummary> & { competitor_id: number }): CompetitorSummary {
+  return {
+    points: null,
+    hit_factor: null,
+    time: null,
+    group_rank: null,
+    group_percent: null,
+    div_rank: null,
+    div_percent: null,
+    overall_rank: null,
+    overall_percent: null,
+    overall_percentile: null,
+    dq: false,
+    zeroed: false,
+    dnf: false,
+    incomplete: false,
+    a_hits: null,
+    c_hits: null,
+    d_hits: null,
+    miss_count: null,
+    no_shoots: null,
+    procedurals: null,
+    stageClassification: null,
+    hitLossPoints: null,
+    penaltyLossPoints: 0,
+    ...partial,
+  };
+}
+
+function stage(num: number, name: string, comps: Record<number, CompetitorSummary>): StageComparison {
+  return {
+    stage_id: 1000 + num,
+    stage_name: name,
+    stage_num: num,
+    max_points: 100,
+    group_leader_hf: null,
+    group_leader_points: null,
+    overall_leader_hf: null,
+    field_median_hf: null,
+    field_competitor_count: 0,
+    field_median_accuracy: null,
+    field_cv: null,
+    stageDifficultyLevel: 3,
+    stageDifficultyLabel: "Medium",
+    stageSeparatorLevel: 2,
+    competitors: comps,
+  };
+}
+
+const competitors: CompetitorInfo[] = [
+  {
+    id: 11,
+    shooterId: 111,
+    name: "Alice Andersson",
+    competitor_number: "1",
+    club: "Club A",
+    division: "Production",
+    region: "SWE",
+    region_display: "Sweden",
+    category: null,
+    ics_alias: null,
+    license: null,
+  },
+  {
+    id: 22,
+    shooterId: 222,
+    name: 'Bob "Quoted, " Berg',
+    competitor_number: "2",
+    club: null,
+    division: "Open",
+    region: "SWE",
+    region_display: "Sweden",
+    category: null,
+    ics_alias: null,
+    license: null,
+  },
+  {
+    id: 33,
+    shooterId: 333,
+    name: "Carol Cederblom",
+    competitor_number: "3",
+    club: "Club C",
+    division: "Standard",
+    region: "SWE",
+    region_display: "Sweden",
+    category: null,
+    ics_alias: null,
+    license: null,
+  },
+];
+
+const squads: SquadInfo[] = [
+  { id: 1, number: 1, name: "Squad 1", competitorIds: [11, 22] },
+  { id: 2, number: 2, name: "Squad 2", competitorIds: [33] },
+];
+
+const compareData: Pick<CompareResponse, "stages"> = {
+  stages: [
+    // Intentionally out of order to verify sort
+    stage(2, "Beta", {
+      11: summary({ competitor_id: 11, time: 18.5, scorecard_created: "2026-04-27T11:00:00Z" }),
+      22: summary({ competitor_id: 22, time: 17.2, scorecard_created: "2026-04-27T11:05:00Z" }),
+    }),
+    stage(1, "Alpha, the first", {
+      11: summary({ competitor_id: 11, time: 12.3, scorecard_created: "2026-04-27T10:00:00Z" }),
+      22: summary({ competitor_id: 22, time: null, dnf: true }),
+    }),
+  ],
+};
+
+const matchInfo = { ct: "22", id: "26547", name: "Test Match" };
+
+describe("buildStageTimesExport", () => {
+  it("orders competitors by selectedIds and stages by stage_number", () => {
+    const out = buildStageTimesExport({
+      match: matchInfo,
+      compareData,
+      competitors,
+      squads,
+      selectedIds: [22, 11],
+    });
+
+    expect(out.competitors.map((c) => c.competitor_id)).toEqual([22, 11]);
+    expect(out.competitors[0].stages.map((s) => s.stage_number)).toEqual([1, 2]);
+    expect(out.competitors[1].stages.map((s) => s.stage_number)).toEqual([1, 2]);
+  });
+
+  it("attaches squad name for each competitor when known", () => {
+    const out = buildStageTimesExport({
+      match: matchInfo,
+      compareData,
+      competitors,
+      squads,
+      selectedIds: [11, 33],
+    });
+
+    expect(out.competitors[0].squad).toBe("Squad 1");
+    expect(out.competitors[1].squad).toBe("Squad 2");
+  });
+
+  it("sets squad to null when competitor is not in any squad", () => {
+    const orphan: CompetitorInfo = {
+      ...competitors[0],
+      id: 99,
+      name: "Orphan",
+    };
+    const out = buildStageTimesExport({
+      match: matchInfo,
+      compareData,
+      competitors: [...competitors, orphan],
+      squads,
+      selectedIds: [99],
+    });
+    expect(out.competitors[0].squad).toBeNull();
+  });
+
+  it("emits null time_seconds and scorecard_updated_at for DNF/missing scorecards", () => {
+    const out = buildStageTimesExport({
+      match: matchInfo,
+      compareData,
+      competitors,
+      squads,
+      selectedIds: [22],
+    });
+
+    const stage1 = out.competitors[0].stages[0];
+    expect(stage1.stage_number).toBe(1);
+    expect(stage1.time_seconds).toBeNull();
+    expect(stage1.scorecard_updated_at).toBeNull();
+
+    const stage2 = out.competitors[0].stages[1];
+    expect(stage2.time_seconds).toBe(17.2);
+    expect(stage2.scorecard_updated_at).toBe("2026-04-27T11:05:00Z");
+  });
+
+  it("skips selectedIds that are not in the match competitor list", () => {
+    const out = buildStageTimesExport({
+      match: matchInfo,
+      compareData,
+      competitors,
+      squads,
+      selectedIds: [11, 9999, 22],
+    });
+    expect(out.competitors.map((c) => c.competitor_id)).toEqual([11, 22]);
+  });
+
+  it("includes match info verbatim", () => {
+    const out = buildStageTimesExport({
+      match: matchInfo,
+      compareData,
+      competitors,
+      squads,
+      selectedIds: [11],
+    });
+    expect(out.match).toEqual(matchInfo);
+  });
+});
+
+describe("escapeCsvField", () => {
+  it("returns empty string for null", () => {
+    expect(escapeCsvField(null)).toBe("");
+  });
+
+  it("passes plain text through unchanged", () => {
+    expect(escapeCsvField("Hello world")).toBe("Hello world");
+  });
+
+  it("quotes and doubles internal quotes when value contains a comma", () => {
+    expect(escapeCsvField("a, b")).toBe('"a, b"');
+  });
+
+  it("quotes and doubles internal quotes when value contains a quote", () => {
+    expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it("quotes when value contains a newline", () => {
+    expect(escapeCsvField("line1\nline2")).toBe('"line1\nline2"');
+  });
+
+  it("converts numbers to strings without quoting", () => {
+    expect(escapeCsvField(12.34)).toBe("12.34");
+    expect(escapeCsvField(0)).toBe("0");
+  });
+});
+
+describe("buildStageTimesCsv", () => {
+  it("starts with a UTF-8 BOM", () => {
+    const out = buildStageTimesExport({
+      match: matchInfo,
+      compareData,
+      competitors,
+      squads,
+      selectedIds: [11],
+    });
+    expect(buildStageTimesCsv(out).startsWith(BOM)).toBe(true);
+  });
+
+  it("uses CRLF line endings", () => {
+    const out = buildStageTimesExport({
+      match: matchInfo,
+      compareData,
+      competitors,
+      squads,
+      selectedIds: [11],
+    });
+    const csv = buildStageTimesCsv(out);
+    expect(csv).toContain("\r\n");
+    expect(csv.includes("\n\n")).toBe(false);
+  });
+
+  it("emits the expected header row", () => {
+    const out = buildStageTimesExport({
+      match: matchInfo,
+      compareData,
+      competitors,
+      squads,
+      selectedIds: [11],
+    });
+    const csv = buildStageTimesCsv(out);
+    const firstLine = csv.slice(BOM.length).split("\r\n")[0];
+    expect(firstLine).toBe(
+      "competitor,division,club,squad,stage_number,stage_name,time_seconds,scorecard_updated_at",
+    );
+  });
+
+  it("blocks rows by competitor and orders stages within each block", () => {
+    const out = buildStageTimesExport({
+      match: matchInfo,
+      compareData,
+      competitors,
+      squads,
+      selectedIds: [11, 22],
+    });
+    const csv = buildStageTimesCsv(out);
+    const rows = csv.slice(BOM.length).trimEnd().split("\r\n").slice(1); // drop header
+    expect(rows).toHaveLength(4);
+
+    expect(rows[0]).toContain("Alice Andersson");
+    expect(rows[0]).toContain(",1,");
+    expect(rows[1]).toContain("Alice Andersson");
+    expect(rows[1]).toContain(",2,");
+
+    expect(rows[2]).toContain("Berg");
+    expect(rows[2]).toContain(",1,");
+    expect(rows[3]).toContain("Berg");
+    expect(rows[3]).toContain(",2,");
+  });
+
+  it("escapes fields with commas and quotes", () => {
+    const out = buildStageTimesExport({
+      match: matchInfo,
+      compareData,
+      competitors,
+      squads,
+      selectedIds: [22],
+    });
+    const csv = buildStageTimesCsv(out);
+    // Bob's name has a comma + quotes, must be quoted
+    expect(csv).toContain('"Bob ""Quoted, "" Berg"');
+    // Stage 1 name has a comma, must be quoted
+    expect(csv).toContain('"Alpha, the first"');
+  });
+
+  it("emits empty cells for null time and timestamp", () => {
+    const out = buildStageTimesExport({
+      match: matchInfo,
+      compareData,
+      competitors,
+      squads,
+      selectedIds: [22],
+    });
+    const csv = buildStageTimesCsv(out);
+    const rows = csv.slice(BOM.length).trimEnd().split("\r\n").slice(1);
+    // Bob's stage 1 is DNF — last two columns should be empty
+    expect(rows[0]).toMatch(/,$/);
+    expect(rows[0].endsWith(",,")).toBe(true);
+  });
+});
+
+describe("stageTimesFilenameStem", () => {
+  it("slugifies the match name", () => {
+    expect(
+      stageTimesFilenameStem({ ct: "22", id: "26547", name: "Sw Open IPSC 2026!" }),
+    ).toBe("stage-times-sw-open-ipsc-2026-22-26547");
+  });
+
+  it("falls back to 'match' when name slug is empty", () => {
+    expect(stageTimesFilenameStem({ ct: "22", id: "26547", name: "!!!" })).toBe(
+      "stage-times-match-22-26547",
+    );
+  });
+});


### PR DESCRIPTION
Closes #329.

## Summary
- Adds JSON + CSV download of per-stage times for the competitors already selected in the comparison view, intended for video editors auto-cutting a match recording into per-stage clips.
- Lives inside the post-match **Coaching analysis** accordion as a new "Export stage times" subsection. **Shipped to all users** -- the feature was tested in dev and the surface is small enough that an extra preview gate isn't justified.
- Adds a matching \`get_stage_times(ct, id, competitor_ids[])\` MCP tool exposed on both HTTP and stdio transports through the shared \`registerMcpTools\` registration.

## Shape
- **JSON**: \`{ match: { ct, id, name }, competitors: [{ competitor_id, name, division, club, squad, stages: [{ stage_number, stage_name, time_seconds, scorecard_updated_at }] }] }\` -- competitors in selection order, stages sorted by stage_number.
- **CSV**: \`competitor, division, club, squad, stage_number, stage_name, time_seconds, scorecard_updated_at\` -- competitor-blocked, stage-ordered, RFC 4180 escaped, UTF-8 BOM + CRLF so Excel and Resolve marker import open it cleanly.

## Implementation notes
- \`lib/stage-times-export.ts\` is pure (no I/O) and shared by the UI component and the MCP tool. Fully unit-tested (20 cases covering ordering, squad lookup, DNF nulls, CSV escaping, BOM/CRLF, filename slug).
- Threads \`scorecard_created\` through \`CompetitorSummary\` so the timestamp is available wherever \`CompareResponse\` is consumed. Bumps \`CACHE_SCHEMA_VERSION\` 13 -> 14; old cached entries self-evict on next read.
- The MCP tool composes \`getMatch\` + \`compareCompetitors\` (parallel) through the same builder. \`readOnlyHint: true, openWorldHint: true\`.
- Adds a \`stage-times-export\` screenshot scene and a What's New release entry (id 2026-04-29).

## Test plan
- [ ] \`pnpm -w run lint\` clean
- [ ] \`pnpm -w run typecheck\` clean (apart from pre-existing graphql-package errors in scripts/validate-ssi-queries.ts on main)
- [ ] \`pnpm -w test\` -- new \`tests/unit/stage-times-export.test.ts\` passes; full suite still 1578/1578
- [ ] \`cd mcp && pnpm run typecheck\` clean
- [ ] In dev, open any post-match page, expand "Coaching analysis", select competitors, click Download JSON / Download CSV; verify file contents and Excel/Resolve open.
- [ ] Hit \`POST /api/mcp\` with \`tools/call get_stage_times\` and verify the returned JSON shape matches the spec.

## Post-merge
- Trigger the **Publish to Smithery Registry** GitHub Actions workflow so the registry listing on smithery.ai picks up the new tool.

## Out of scope (per issue)
- Editor-specific formats (EDL, FCPXML, Premiere Marker CSV)
- Per-squad / whole-match dumps
- Shooting-order metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)