### PR TITLE
Track get_stage_times MCP tool usage

### DIFF
--- a/lib/mcp-tools.ts
+++ b/lib/mcp-tools.ts
@@ -4,6 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { EventSummary, MatchResponse, CompareResponse, PopularMatch, ShooterDashboardResponse, ShooterSearchResult } from "./types";
 import { buildStageTimesExport } from "./stage-times-export";
+import { usageTelemetry, bucketStageExportCompetitors } from "./usage-telemetry";
 
 // ---------------------------------------------------------------------------
 // Static resource content
@@ -456,6 +457,13 @@ export function registerMcpTools(server: McpServer, arg: string | DataProviders)
         competitors: match.competitors,
         squads: match.squads,
         selectedIds: competitor_ids,
+      });
+      const ctNum = parseInt(ct, 10);
+      usageTelemetry({
+        op: "stage-export",
+        surface: "mcp",
+        ct: Number.isFinite(ctNum) ? ctNum : 0,
+        nCompetitorsBucket: bucketStageExportCompetitors(competitor_ids.length),
       });
       return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
     },

--- a/lib/usage-telemetry.ts
+++ b/lib/usage-telemetry.ts
@@ -36,6 +36,15 @@ export function bucketScoring(scoringPct: number): "pre" | "active" | "complete"
   return "active";
 }
 
+/** Bucket competitor count for stage-export usage events. Mirrors the
+ *  scale used by mcp-telemetry's bucketCompetitors so dashboards can join
+ *  on the same labels. */
+export function bucketStageExportCompetitors(n: number): "1" | "2-4" | "5-12" {
+  if (n <= 1) return "1";
+  if (n <= 4) return "2-4";
+  return "5-12";
+}
+
 export type UsageEvent =
   | {
       op: "match-view";
@@ -78,6 +87,16 @@ export type UsageEvent =
       ct: number;
       variant: "overview" | "single" | "multi" | "fallback";
       nCompetitors: number;
+    }
+  | {
+      // Stage-times export was generated. surface:"mcp" covers the
+      // get_stage_times MCP tool (both HTTP and stdio transports).
+      // surface:"ui" is reserved for a future client-side download
+      // tracker; not currently emitted.
+      op: "stage-export";
+      surface: "mcp" | "ui";
+      ct: number;
+      nCompetitorsBucket: "1" | "2-4" | "5-12";
     };
 
 export function usageTelemetry(ev: UsageEvent): void {


### PR DESCRIPTION
Follow-up to #379. Adds a usage telemetry event so we can see how often the new \`get_stage_times\` MCP tool is called.

## Why
The HTTP MCP route emits an \`mcp.tool-call\` event automatically for every JSON-RPC call -- but that's HTTP-only. Stdio invocations from Claude Desktop / Claude Code skip the boundary event. Emitting a \`usage\` event inside the tool handler covers both transports and makes "stage-export was used" trivially queryable without joining mcp + usage domains.

## What
- New event in \`lib/usage-telemetry.ts\`: \`{ op: "stage-export", surface: "mcp" | "ui", ct, nCompetitorsBucket: "1" | "2-4" | "5-12" }\`
- \`surface: "ui"\` reserved for a later client-side download tracker; not currently emitted.
- \`bucketStageExportCompetitors\` mirrors the scale of \`mcp-telemetry.bucketCompetitors\` so dashboards can join on the same bucket labels.
- Emitted from inside \`get_stage_times\` handler in \`lib/mcp-tools.ts\` after the export is built.

## Privacy
- No competitor IDs, no shooter IDs, no IP/UA.
- ct is the public Django content_type (matches existing usage events).
- Competitor count is bucketed (matches existing convention).

## Test plan
- [ ] \`pnpm -w run lint\` clean
- [ ] \`pnpm -w run typecheck\` clean (apart from pre-existing graphql errors)
- [ ] \`cd mcp && pnpm run typecheck\` clean
- [ ] After deploy, call \`get_stage_times\` over MCP and verify a \`usage.stage-export\` event lands in R2 with \`surface:"mcp"\` and the right bucket label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)