### PR TITLE
Clear notice when SSI hides Level I scorecards

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -297,6 +297,15 @@ export async function GET(req: Request) {
   // computeGroupRankings needs the full field to compute division and overall rankings.
   const rawScorecards = parseRawScorecards(scorecardsData);
 
+  // SSI hides per-shot scorecard detail on Level I (club) matches: it returns
+  // a non-zero `scoring_completed` but an empty `scorecards` array. Surface
+  // that as an explicit flag so the client can render a clear notice instead
+  // of a blank comparison table.
+  const scorecardsRestricted =
+    scoringPct > 0 &&
+    rawScorecards.length === 0 &&
+    (matchData.event.stages?.length ?? 0) > 0;
+
   // Surface max(scorecard_created) so the client can show how stale the
   // upstream itself is, independent of our cache age. On an active match
   // this answers "is RO submission falling behind?" — a question that
@@ -583,6 +592,7 @@ export async function GET(req: Request) {
     constraintPerformance,
     stageDegradationData,
     stageConditions,
+    ...(scorecardsRestricted ? { scorecardsRestricted: true } : {}),
     cacheInfo,
   };
 

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -676,7 +676,37 @@ export default function MatchPageClient() {
             </div>
           )}
 
-          {compareQuery.data && (
+          {compareQuery.data?.scorecardsRestricted && (
+            <div
+              role="status"
+              className="rounded-lg border bg-muted/40 p-4 space-y-2"
+            >
+              <h2 className="font-semibold">Detailed scores aren&apos;t available for this match</h2>
+              <p className="text-sm text-muted-foreground">
+                ShootnScoreIt shows that scoring is in progress
+                {match.scoring_completed > 0
+                  ? ` (${Math.round(match.scoring_completed)}% complete)`
+                  : ""}
+                , but they don&apos;t share the per-stage scorecards publicly for
+                club matches (Level I). You&apos;ll be able to see the official
+                results on shootnscoreit.com once the organiser publishes them.
+              </p>
+              {match.ssi_url && (
+                <p className="text-sm">
+                  <a
+                    href={match.ssi_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline underline-offset-2 hover:opacity-80"
+                  >
+                    Open on shootnscoreit.com
+                  </a>
+                </p>
+              )}
+            </div>
+          )}
+
+          {compareQuery.data && !compareQuery.data.scorecardsRestricted && (
             <>
               <div className="rounded-lg border p-4 space-y-3">
                 <div className="flex items-center justify-between">

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -536,6 +536,13 @@ export interface CompareResponse {
   stageDegradationData: StageDegradationData[] | null; // null in live mode
   /** Per-stage per-competitor conditions (weather + time), coaching mode only. Keyed stageId → competitorId. */
   stageConditions: Record<number, Record<number, StageConditions>> | null;
+  /**
+   * Set when SSI reports scoring progress for the match but returns an empty
+   * `scorecards` array. SSI gates per-shot detail on Level I (club) matches:
+   * `scorecards_count` is exposed but the actual scorecard records are not.
+   * The client should show a clear notice instead of an empty comparison.
+   */
+  scorecardsRestricted?: boolean;
   cacheInfo: CacheInfo;
 }
 


### PR DESCRIPTION
## Summary

- Detect the SSI-side restriction where Level I (club) matches advertise `scoring_completed` and `scorecards_count` but return an empty `scorecards` array, and show a plain-language notice instead of an empty comparison table.
- Set a new `scorecardsRestricted: boolean` on the `/api/compare` response when `scoring > 0%` but no scorecards came back across any stage.
- The notice explains the situation in non-technical wording and links out to the match page on shootnscoreit.com.

## Background

User report: matches in the homepage "Live now" section show e.g. "35% scored" but the match view renders no scores. They suspected the recent delta merge of scorecards (#366), but ground-truth queries against SSI's GraphQL with our API key proved otherwise:

- Match 28204 (NOR, L1): `IpscMatchNode.scorecards_count = 74`, every `IpscStageNode.scorecards_count > 0`, but every stage's `scorecards` array is `[]`.
- Match 28205 (SWE, L1): same pattern. Confirmed it's a level-I gating, not a region issue.

So the cache, probe, and delta-merge paths are all behaving correctly -- there is genuinely nothing to merge. The fix is a clearer empty state.

## Why not just filter Live now to L2+

Considered but rejected per discussion: that would assume which matches our API key can read, and silently hide matches some users were specifically courtside for. Detection on the actual response is more honest.

## Test plan

- [ ] On a current L1 live match (e.g. match 28204), the comparison area shows the new notice and a working link to shootnscoreit.com.
- [ ] On a current L2+ live match, the comparison renders normally (no false positive).
- [ ] On an upcoming match (scoring 0%), the existing pre-match flow still triggers (the new flag requires scoring > 0%).
- [ ] `pnpm -w run typecheck && pnpm -w run lint && pnpm -w test` all green (verified locally: 1566 tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)