### PR TITLE
Faster competitor selection: favorites, clear/undo, squad replace, smart benchmarks

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -91,6 +91,10 @@ export default function AboutPage() {
                   with a five-second undo if you change your mind
                 </li>
                 <li>
+                  Reorder competitors right inside the comparison table — the
+                  column color follows, so you can pin yourself to column one
+                </li>
+                <li>
                   Live, Pre-match, and Coaching views — auto-selected to match
                   the phase of the event, with a manual override
                 </li>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -76,10 +76,19 @@ export default function AboutPage() {
                   and see which matches are live right now
                 </li>
                 <li>
-                  Compare up to 12 competitors side-by-side across every stage
+                  Compare up to 12 competitors side-by-side across every stage,
+                  with favorites pinned to the top of the picker and one-tap
+                  Clear / Undo
                 </li>
                 <li>
-                  Add an entire IPSC squad in one tap with the squad picker
+                  Smart benchmark presets — once you set &quot;this is me&quot;
+                  in My Shooters, one tap selects the person above or below
+                  you in your division, the division podium, your percentile
+                  cohort (p25/p50/p75/p95), or peers from the same club
+                </li>
+                <li>
+                  Replace your selection with an entire IPSC squad in one tap,
+                  with a five-second undo if you change your mind
                 </li>
                 <li>
                   Live, Pre-match, and Coaching views — auto-selected to match

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -663,7 +663,7 @@ export default function MatchPageClient() {
                 </PopoverDescription>
               </PopoverHeader>
               <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
-                <p><strong>Star</strong> — favorite a competitor. Stars live in the picker, in the comparison table header, and on the shooter dashboard.</p>
+                <p><strong>Star</strong> — favorite a competitor. Stars live in the picker, in the comparison table header, and on the shooter dashboard. The picker also has an &ldquo;Add all favorites&rdquo; pill so you can pull in everyone you track in one tap.</p>
                 <p><strong>Squad</strong> — replaces your selection with everyone in a squad. One tap to undo.</p>
                 <p><strong>Benchmark</strong> — once you set &ldquo;this is me&rdquo; in My Shooters, you unlock one-tap presets: one-above, one-below, division podium, percentile cohort, and same-club peers.</p>
                 <p><strong>Reorder</strong> — use the chevrons in each comparison-table column header to move a competitor left or right. Their column color follows the new position.</p>

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -21,7 +21,7 @@ import { UpstreamDegradedBanner } from "@/components/upstream-degraded-banner";
 import { LoadingBar } from "@/components/loading-bar";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Loader2, AlertCircle, ArrowLeft, RefreshCw, ChevronDown, ChevronUp, HelpCircle, ExternalLink, Info, ArrowUpDown } from "lucide-react";
+import { Loader2, AlertCircle, ArrowLeft, RefreshCw, ChevronDown, ChevronUp, HelpCircle, ExternalLink, Info, ArrowUpDown, Undo2, XCircle } from "lucide-react";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import {
   Popover,
@@ -369,11 +369,62 @@ export default function MatchPageClient() {
     }
   }
 
+  // Undo banner state — populated when a bulk action (clear, squad replace,
+  // smart benchmark preset) overwrites the user's selection. Auto-clears
+  // after UNDO_TIMEOUT_MS or on the next plain selection change.
+  const UNDO_TIMEOUT_MS = 5000;
+  const [pendingUndo, setPendingUndo] = useState<{
+    prevIds: number[];
+    message: string;
+    expiresAt: number;
+  } | null>(null);
+  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearPendingUndo = useCallback(() => {
+    if (undoTimerRef.current) {
+      clearTimeout(undoTimerRef.current);
+      undoTimerRef.current = null;
+    }
+    setPendingUndo(null);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+    };
+  }, []);
+
+  const writeSelection = useCallback(
+    (ids: number[]) => {
+      saveCompetitorSelection(ct, id, ids);
+      const qs = ids.length > 0 ? `?competitors=${ids.join(",")}` : "";
+      router.replace(`${window.location.pathname}${qs}`, { scroll: false });
+    },
+    [ct, id, router],
+  );
+
   function handleSelectionChange(ids: number[]) {
-    saveCompetitorSelection(ct, id, ids);
-    // Sync selection to URL so it can be bookmarked or shared.
-    const qs = ids.length > 0 ? `?competitors=${ids.join(",")}` : "";
-    router.replace(`${window.location.pathname}${qs}`, { scroll: false });
+    // Any plain selection change invalidates a pending undo.
+    if (pendingUndo) clearPendingUndo();
+    writeSelection(ids);
+  }
+
+  function replaceSelectionWithUndo(newIds: number[], message: string) {
+    // Capture the snapshot via the live store, not closure, to avoid stale prev.
+    const prev = getCompetitorSelectionSnapshot(ct, id);
+    writeSelection(newIds);
+    if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+    setPendingUndo({ prevIds: prev, message, expiresAt: Date.now() + UNDO_TIMEOUT_MS });
+    undoTimerRef.current = setTimeout(() => {
+      setPendingUndo(null);
+      undoTimerRef.current = null;
+    }, UNDO_TIMEOUT_MS);
+  }
+
+  function applyUndo() {
+    if (!pendingUndo) return;
+    writeSelection(pendingUndo.prevIds);
+    clearPendingUndo();
   }
 
   if (matchQuery.isLoading) {
@@ -583,10 +634,34 @@ export default function MatchPageClient() {
 
       {/* Competitor picker */}
       <div className="space-y-1">
-        <div className="flex items-center gap-3 flex-wrap">
+        <div className="flex items-center gap-1.5 flex-wrap">
           <p className="text-sm font-medium">Compare competitors</p>
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+                aria-label="How competitor selection works"
+              >
+                <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent className="w-80" side="bottom" align="start">
+              <PopoverHeader>
+                <PopoverTitle>Picking who to compare</PopoverTitle>
+                <PopoverDescription>
+                  Mix and match up to {MAX_COMPETITORS} competitors. Your favorites and &ldquo;you&rdquo; appear at the top of the picker.
+                </PopoverDescription>
+              </PopoverHeader>
+              <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
+                <p><strong>Star</strong> — favorite a competitor. Stars live in the picker, in the comparison table header, and on the shooter dashboard.</p>
+                <p><strong>Squad</strong> — replaces your selection with everyone in a squad. One tap to undo.</p>
+                <p><strong>Benchmark</strong> — once you set &ldquo;this is me&rdquo; in My Shooters, you unlock one-tap presets: one-above, one-below, division podium, percentile cohort, and same-club peers.</p>
+                <p><strong>Clear</strong> — wipes the selection. Undo lasts 5 seconds.</p>
+              </div>
+            </PopoverContent>
+          </Popover>
           {trackedInMatch && trackedInMatch.total > 0 && (
-            <span className="text-xs text-muted-foreground">
+            <span className="ml-1.5 text-xs text-muted-foreground">
               {trackedInMatch.present} of {trackedInMatch.total} tracked in this match
             </span>
           )}
@@ -606,7 +681,12 @@ export default function MatchPageClient() {
             <SquadPicker
               squads={match.squads}
               selectedIds={selectedIds}
-              onSelectionChange={handleSelectionChange}
+              onReplaceSelection={(ids, squadName) =>
+                replaceSelectionWithUndo(
+                  ids,
+                  `Replaced selection with ${squadName}`,
+                )
+              }
             />
           )}
           {selectedIds.length > 0 && (
@@ -617,10 +697,53 @@ export default function MatchPageClient() {
               competitors={match.competitors}
               selectedIds={selectedIds}
               onSelectionChange={handleSelectionChange}
+              myShooterId={identity?.shooterId ?? null}
+              onReplaceSelection={(ids, message) =>
+                replaceSelectionWithUndo(ids, message)
+              }
               disabled={!compareQuery.data}
             />
           )}
+          {selectedIds.length > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="gap-1.5 text-muted-foreground hover:text-foreground"
+              onClick={() => {
+                if (selectedIds.length === 0) return;
+                replaceSelectionWithUndo(
+                  [],
+                  `Cleared ${selectedIds.length} selected`,
+                );
+              }}
+              aria-label="Clear all selected competitors"
+            >
+              <XCircle className="w-4 h-4" aria-hidden="true" />
+              Clear
+            </Button>
+          )}
         </div>
+        {pendingUndo && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="mt-2 flex items-center justify-between gap-3 rounded-md border bg-muted/50 px-3 py-2 text-sm animate-fade-in"
+          >
+            <span className="text-muted-foreground truncate">
+              {pendingUndo.message}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5 shrink-0"
+              onClick={applyUndo}
+              aria-label="Undo last selection change"
+            >
+              <Undo2 className="w-3.5 h-3.5" aria-hidden="true" />
+              Undo
+            </Button>
+          </div>
+        )}
       </div>
 
       {/* Pre-match view — replaces comparison when no scores yet */}
@@ -730,6 +853,8 @@ export default function MatchPageClient() {
                   stageSort={stageSort}
                   onSortChange={setStageSort}
                   sortedStages={sortedStages}
+                  trackedShooterIds={trackedIds}
+                  onToggleTracked={handleToggleTracked}
                 />
               </div>
 

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -427,6 +427,16 @@ export default function MatchPageClient() {
     clearPendingUndo();
   }
 
+  function moveCompetitor(id: number, direction: "left" | "right") {
+    const idx = selectedIds.indexOf(id);
+    if (idx === -1) return;
+    const swapWith = direction === "left" ? idx - 1 : idx + 1;
+    if (swapWith < 0 || swapWith >= selectedIds.length) return;
+    const next = [...selectedIds];
+    [next[idx], next[swapWith]] = [next[swapWith], next[idx]];
+    handleSelectionChange(next);
+  }
+
   if (matchQuery.isLoading) {
     return (
       <>
@@ -656,6 +666,7 @@ export default function MatchPageClient() {
                 <p><strong>Star</strong> — favorite a competitor. Stars live in the picker, in the comparison table header, and on the shooter dashboard.</p>
                 <p><strong>Squad</strong> — replaces your selection with everyone in a squad. One tap to undo.</p>
                 <p><strong>Benchmark</strong> — once you set &ldquo;this is me&rdquo; in My Shooters, you unlock one-tap presets: one-above, one-below, division podium, percentile cohort, and same-club peers.</p>
+                <p><strong>Reorder</strong> — use the chevrons in each comparison-table column header to move a competitor left or right. Their column color follows the new position.</p>
                 <p><strong>Clear</strong> — wipes the selection. Undo lasts 5 seconds.</p>
               </div>
             </PopoverContent>
@@ -855,6 +866,7 @@ export default function MatchPageClient() {
                   sortedStages={sortedStages}
                   trackedShooterIds={trackedIds}
                   onToggleTracked={handleToggleTracked}
+                  onMove={moveCompetitor}
                 />
               </div>
 

--- a/app/shooter/[shooterId]/shooter-dashboard-client.tsx
+++ b/app/shooter/[shooterId]/shooter-dashboard-client.tsx
@@ -45,6 +45,7 @@ import {
   ExternalLink,
   CircleAlert,
   CircleCheck,
+  Star,
   type LucideIcon,
 } from "lucide-react";
 
@@ -71,6 +72,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { ShareDrawer } from "@/components/share-drawer";
+import { useTrackedShooters } from "@/lib/hooks/use-tracked-shooters";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useShooterDashboardQuery } from "@/lib/queries";
 import { triggerBackfill, addMatchToShooter } from "@/lib/api";
@@ -1606,6 +1608,7 @@ export function ShooterDashboardClient({ shooterId, from }: Props) {
   const { data, isLoading, isError, error } = useShooterDashboardQuery(
     shooterId,
   );
+  const { trackedIds, add: addTracked, remove: removeTracked } = useTrackedShooters();
   const [historyOpen, setHistoryOpen] = useState(true);
   const [upcomingOpen, setUpcomingOpen] = useState(true);
   const [trendsOpen, setTrendsOpen] = useState(false);
@@ -1701,14 +1704,51 @@ export function ShooterDashboardClient({ shooterId, from }: Props) {
           <ArrowLeft className="w-3.5 h-3.5" aria-hidden="true" />
           {from ? "Back to match" : "All matches"}
         </Link>
-        <ShareDrawer
-          title="Share shooter profile"
-          description="Share this shooter's dashboard — the link includes a rich preview image for social media."
-          sharePath={`/shooter/${String(shooterId)}`}
-          ogImageUrl={`${typeof window !== "undefined" ? window.location.origin : ""}/api/og/shooter/${String(shooterId)}`}
-          ogImageAlt={`Preview of ${displayName}'s profile on SSI Scoreboard`}
-          shareTitle={`${displayName} — SSI Scoreboard`}
-        />
+        <div className="flex items-center gap-1">
+          {shooterId !== null && (() => {
+            const isTracked = trackedIds.has(shooterId);
+            return (
+              <button
+                type="button"
+                onClick={() => {
+                  if (isTracked) {
+                    removeTracked(shooterId);
+                  } else {
+                    addTracked({
+                      shooterId,
+                      name: displayName,
+                      club: profile?.club ?? null,
+                      division: profile?.division ?? null,
+                    });
+                  }
+                }}
+                aria-pressed={isTracked}
+                aria-label={isTracked ? `Untrack ${displayName}` : `Track ${displayName}`}
+                className={cn(
+                  "rounded p-2 transition-colors",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  isTracked
+                    ? "text-amber-500 hover:text-amber-600 hover:bg-amber-500/10"
+                    : "text-muted-foreground hover:text-amber-500 hover:bg-amber-500/10",
+                )}
+              >
+                <Star
+                  className="w-4 h-4"
+                  aria-hidden="true"
+                  fill={isTracked ? "currentColor" : "none"}
+                />
+              </button>
+            );
+          })()}
+          <ShareDrawer
+            title="Share shooter profile"
+            description="Share this shooter's dashboard — the link includes a rich preview image for social media."
+            sharePath={`/shooter/${String(shooterId)}`}
+            ogImageUrl={`${typeof window !== "undefined" ? window.location.origin : ""}/api/og/shooter/${String(shooterId)}`}
+            ogImageAlt={`Preview of ${displayName}'s profile on SSI Scoreboard`}
+            shareTitle={`${displayName} — SSI Scoreboard`}
+          />
+        </div>
       </div>
       {/* ── Identity card ─────────────────────────────────────────────── */}
       <section

--- a/components/benchmark-picker.tsx
+++ b/components/benchmark-picker.tsx
@@ -1,24 +1,49 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { Check, Trophy } from "lucide-react";
+import {
+  ArrowDownToLine,
+  ArrowUpToLine,
+  Award,
+  Check,
+  Trophy,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
 import type { CompetitorInfo, FieldFingerprintPoint } from "@/lib/types";
 import { MAX_COMPETITORS } from "@/lib/constants";
+import {
+  computeSmartPresets,
+  type SmartPreset,
+  type SmartPresetKind,
+} from "@/lib/benchmark-presets";
 
 const TOP_N = 3;
 const ORDINALS = ["1st", "2nd", "3rd", "4th", "5th"];
+
+const PRESET_ICONS: Record<SmartPresetKind, LucideIcon> = {
+  "one-above": ArrowUpToLine,
+  "one-below": ArrowDownToLine,
+  podium: Trophy,
+  percentile: Award,
+  "same-club": Users,
+};
 
 interface BenchmarkPickerProps {
   fieldFingerprintPoints: FieldFingerprintPoint[];
   competitors: CompetitorInfo[];
   selectedIds: number[];
   onSelectionChange: (ids: number[]) => void;
+  /** ShooterId of the user's "this is me" identity. Required for smart presets. */
+  myShooterId?: number | null;
+  /** Replaces the current selection. Used by smart presets so the user can undo. */
+  onReplaceSelection?: (newIds: number[], message: string) => void;
   /** When true the trigger button is shown in a disabled state (e.g. while data is loading). */
   disabled?: boolean;
 }
@@ -28,6 +53,8 @@ export function BenchmarkPicker({
   competitors,
   selectedIds,
   onSelectionChange,
+  myShooterId,
+  onReplaceSelection,
   disabled = false,
 }: BenchmarkPickerProps) {
   const [open, setOpen] = useState(false);
@@ -37,17 +64,45 @@ export function BenchmarkPicker({
     ...new Set(fieldFingerprintPoints.map((p) => p.division).filter(Boolean)),
   ].sort() as string[];
 
-  if (divisions.length === 0 && !disabled) return null;
+  // Smart presets — only available when "this is me" is set and the user is
+  // entered in this match.
+  const myCompetitor = useMemo(
+    () =>
+      myShooterId != null
+        ? competitors.find((c) => c.shooterId === myShooterId) ?? null
+        : null,
+    [competitors, myShooterId],
+  );
+  const myPoint = useMemo(
+    () =>
+      myCompetitor
+        ? fieldFingerprintPoints.find((p) => p.competitorId === myCompetitor.id) ?? null
+        : null,
+    [fieldFingerprintPoints, myCompetitor],
+  );
+  const smartPresets = useMemo(() => {
+    if (!myCompetitor || !myPoint || !onReplaceSelection) return [];
+    return computeSmartPresets({
+      myCompetitor,
+      myPoint,
+      competitors,
+      fieldFingerprintPoints,
+    });
+  }, [myCompetitor, myPoint, competitors, fieldFingerprintPoints, onReplaceSelection]);
+
+  if (divisions.length === 0 && smartPresets.length === 0 && !disabled) return null;
 
   function handleOpenChange(nextOpen: boolean) {
     if (nextOpen) {
-      // Default to the division of the first selected competitor, otherwise the first division.
-      const firstDiv =
+      // Default to the user's division when set, else the first selected
+      // competitor's division, else the first division.
+      const myDiv = myPoint?.division ?? null;
+      const firstSelectedDiv =
         selectedIds.length > 0
           ? (fieldFingerprintPoints.find((p) => p.competitorId === selectedIds[0])
               ?.division ?? null)
           : null;
-      setSelectedDivision(firstDiv ?? divisions[0] ?? "");
+      setSelectedDivision(myDiv ?? firstSelectedDiv ?? divisions[0] ?? "");
     }
     setOpen(nextOpen);
   }
@@ -71,6 +126,12 @@ export function BenchmarkPicker({
     }
   }
 
+  function handleApplyPreset(preset: SmartPreset) {
+    if (!onReplaceSelection) return;
+    onReplaceSelection(preset.ids, `Applied benchmark: ${preset.label}`);
+    setOpen(false);
+  }
+
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
@@ -86,15 +147,73 @@ export function BenchmarkPicker({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="p-0 w-[min(20rem,calc(100vw-2rem))]"
+        className="p-0 w-[min(22rem,calc(100vw-2rem))] max-h-[80vh] overflow-y-auto"
         align="start"
       >
+        {smartPresets.length > 0 && (
+          <section
+            aria-labelledby="benchmark-smart-heading"
+            className="border-b"
+          >
+            <h3
+              id="benchmark-smart-heading"
+              className="px-3 pt-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              Smart presets
+            </h3>
+            <p className="px-3 pb-2 text-xs text-muted-foreground">
+              Replaces your selection. Tap Undo to restore.
+            </p>
+            <ul className="p-1">
+              {smartPresets.map((preset) => {
+                const Icon = PRESET_ICONS[preset.kind];
+                return (
+                <li key={preset.kind}>
+                  <button
+                    type="button"
+                    onClick={() => handleApplyPreset(preset)}
+                    className="w-full flex items-start gap-2 rounded-sm px-3 py-2 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+                    aria-label={`${preset.label}. ${preset.description}. Replaces current selection with ${preset.ids.length} competitors.`}
+                  >
+                    <span className="mt-0.5 shrink-0 text-muted-foreground">
+                      <Icon className="w-3.5 h-3.5" aria-hidden="true" />
+                    </span>
+                    <span className="flex-1 min-w-0">
+                      <span className="block font-medium leading-snug">
+                        {preset.label}
+                      </span>
+                      <span className="block text-xs text-muted-foreground leading-snug truncate">
+                        {preset.description}
+                      </span>
+                    </span>
+                    <span className="text-xs text-muted-foreground tabular-nums shrink-0 mt-0.5">
+                      {preset.ids.length}
+                    </span>
+                  </button>
+                </li>
+                );
+              })}
+            </ul>
+          </section>
+        )}
+        {smartPresets.length === 0 && myShooterId == null && (
+          <div className="px-3 pt-3 pb-2 border-b text-xs text-muted-foreground">
+            <p className="font-medium text-foreground mb-1">
+              Smart presets locked
+            </p>
+            <p>
+              Set &ldquo;this is me&rdquo; in My Shooters to unlock one-tap
+              benchmarks like &ldquo;one above me&rdquo; and &ldquo;my
+              percentile cohort&rdquo;.
+            </p>
+          </div>
+        )}
         <div className="p-3 border-b">
           <label
             htmlFor="benchmark-division-select"
             className="text-xs font-medium text-muted-foreground block mb-1.5"
           >
-            Division
+            Top 3 in division
           </label>
           <select
             id="benchmark-division-select"

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -12,7 +12,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { AlertTriangle, ArrowDown, ArrowRight, ArrowUp, ArrowUpDown, CheckCircle2, ChevronDown, ChevronUp, CloudSun, Crosshair, ExternalLink, Flame, Focus, Gauge, Hand, HandMetal, HelpCircle, Info, Layers, Shield, Target, Timer, TrendingUp, X, Zap } from "lucide-react";
+import { AlertTriangle, ArrowDown, ArrowRight, ArrowUp, ArrowUpDown, CheckCircle2, ChevronDown, ChevronUp, CloudSun, Crosshair, ExternalLink, Flame, Focus, Gauge, Hand, HandMetal, HelpCircle, Info, Layers, Shield, Star, Target, Timer, TrendingUp, X, Zap } from "lucide-react";
 import Link from "next/link";
 import { cn, formatHF, formatTime, formatPct, computePointsDelta, formatDelta } from "@/lib/utils";
 import { buildColorMap } from "@/lib/colors";
@@ -36,6 +36,10 @@ interface ComparisonTableProps {
   stageSort?: "stage" | number;
   onSortChange?: (sort: "stage" | number) => void;
   sortedStages?: StageComparison[];
+  /** ShooterIds the user has favorited; drives the star toggle in the header. */
+  trackedShooterIds?: Set<number>;
+  /** Toggle favorite state for a competitor; opens the star toggle in the header. */
+  onToggleTracked?: (c: CompetitorInfo) => void;
 }
 
 /**
@@ -915,7 +919,7 @@ function StageScorecardRow({
   );
 }
 
-export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable, isComplete, ct, matchId, stageSort = "stage", onSortChange = () => {}, sortedStages: sortedStagesProp }: ComparisonTableProps) {
+export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable, isComplete, ct, matchId, stageSort = "stage", onSortChange = () => {}, sortedStages: sortedStagesProp, trackedShooterIds, onToggleTracked }: ComparisonTableProps) {
   const { stages, competitors, penaltyStats, efficiencyStats, consistencyStats, lossBreakdownStats } = data;
   // When sortedStages is not provided by the parent, fall back to natural stage order.
   const sortedStages = sortedStagesProp ?? stages;
@@ -1229,6 +1233,28 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
                     style={{ borderBottom: `3px solid ${colorMap[comp.id]}` }}
                     aria-sort={isSortedByComp ? "ascending" : "none"}
                   >
+                    {onToggleTracked && comp.shooterId !== null && (() => {
+                      const isTracked = trackedShooterIds?.has(comp.shooterId!) ?? false;
+                      return (
+                        <button
+                          onClick={() => onToggleTracked(comp)}
+                          className={cn(
+                            "absolute top-0 left-0 p-2 rounded-br transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+                            isTracked
+                              ? "text-amber-500 hover:text-amber-600 hover:bg-amber-500/10"
+                              : "text-muted-foreground hover:text-amber-500 hover:bg-amber-500/10",
+                          )}
+                          aria-label={isTracked ? `Untrack ${comp.name}` : `Track ${comp.name}`}
+                          aria-pressed={isTracked}
+                        >
+                          <Star
+                            className="w-3 h-3"
+                            aria-hidden="true"
+                            fill={isTracked ? "currentColor" : "none"}
+                          />
+                        </button>
+                      );
+                    })()}
                     {onRemove && (
                       <button
                         onClick={() => onRemove(comp.id)}

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -12,7 +12,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { AlertTriangle, ArrowDown, ArrowRight, ArrowUp, ArrowUpDown, CheckCircle2, ChevronDown, ChevronUp, CloudSun, Crosshair, ExternalLink, Flame, Focus, Gauge, Hand, HandMetal, HelpCircle, Info, Layers, Shield, Star, Target, Timer, TrendingUp, X, Zap } from "lucide-react";
+import { AlertTriangle, ArrowDown, ArrowRight, ArrowUp, ArrowUpDown, CheckCircle2, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, CloudSun, Crosshair, ExternalLink, Flame, Focus, Gauge, Hand, HandMetal, HelpCircle, Info, Layers, Shield, Star, Target, Timer, TrendingUp, X, Zap } from "lucide-react";
 import Link from "next/link";
 import { cn, formatHF, formatTime, formatPct, computePointsDelta, formatDelta } from "@/lib/utils";
 import { buildColorMap } from "@/lib/colors";
@@ -40,6 +40,8 @@ interface ComparisonTableProps {
   trackedShooterIds?: Set<number>;
   /** Toggle favorite state for a competitor; opens the star toggle in the header. */
   onToggleTracked?: (c: CompetitorInfo) => void;
+  /** Move a competitor one column left or right. The parent owns selectedIds order. */
+  onMove?: (id: number, direction: "left" | "right") => void;
 }
 
 /**
@@ -919,7 +921,7 @@ function StageScorecardRow({
   );
 }
 
-export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable, isComplete, ct, matchId, stageSort = "stage", onSortChange = () => {}, sortedStages: sortedStagesProp, trackedShooterIds, onToggleTracked }: ComparisonTableProps) {
+export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable, isComplete, ct, matchId, stageSort = "stage", onSortChange = () => {}, sortedStages: sortedStagesProp, trackedShooterIds, onToggleTracked, onMove }: ComparisonTableProps) {
   const { stages, competitors, penaltyStats, efficiencyStats, consistencyStats, lossBreakdownStats } = data;
   // When sortedStages is not provided by the parent, fall back to natural stage order.
   const sortedStages = sortedStagesProp ?? stages;
@@ -1214,7 +1216,7 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
                   </TooltipContent>
                 </Tooltip>
               </th>
-              {competitors.map((comp) => {
+              {competitors.map((comp, compIndex) => {
                 const t = totals.find((x) => x.id === comp.id);
                 const hasClassifications = t &&
                   (t.solidCount + t.conservativeCount + t.overpushCount + t.meltdownCount) > 0;
@@ -1226,6 +1228,8 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
                 ].filter(Boolean).join(" · ") : "";
                 const canSortByComp = competitorHasShootingOrder.has(comp.id);
                 const isSortedByComp = stageSort === comp.id;
+                const canMoveLeft = onMove !== undefined && compIndex > 0;
+                const canMoveRight = onMove !== undefined && compIndex < competitors.length - 1;
                 return (
                   <th
                     key={comp.id}
@@ -1255,14 +1259,52 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
                         </button>
                       );
                     })()}
-                    {onRemove && (
-                      <button
-                        onClick={() => onRemove(comp.id)}
-                        className="absolute top-0 right-0 p-2 rounded-bl text-muted-foreground hover:text-foreground hover:bg-muted transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
-                        aria-label={`Remove ${comp.name}`}
+                    {(onMove || onRemove) && (
+                      <span
+                        className="absolute top-0 right-0 inline-flex items-center"
+                        role="group"
+                        aria-label={`Column actions for ${comp.name}`}
                       >
-                        <X className="w-3 h-3" aria-hidden="true" />
-                      </button>
+                        {onMove && (
+                          <button
+                            onClick={() => canMoveLeft && onMove(comp.id, "left")}
+                            disabled={!canMoveLeft}
+                            className={cn(
+                              "p-1.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+                              canMoveLeft
+                                ? "text-muted-foreground hover:text-foreground hover:bg-muted"
+                                : "text-muted-foreground/30 cursor-not-allowed",
+                            )}
+                            aria-label={`Move ${comp.name} left`}
+                          >
+                            <ChevronLeft className="w-3 h-3" aria-hidden="true" />
+                          </button>
+                        )}
+                        {onMove && (
+                          <button
+                            onClick={() => canMoveRight && onMove(comp.id, "right")}
+                            disabled={!canMoveRight}
+                            className={cn(
+                              "p-1.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+                              canMoveRight
+                                ? "text-muted-foreground hover:text-foreground hover:bg-muted"
+                                : "text-muted-foreground/30 cursor-not-allowed",
+                            )}
+                            aria-label={`Move ${comp.name} right`}
+                          >
+                            <ChevronRight className="w-3 h-3" aria-hidden="true" />
+                          </button>
+                        )}
+                        {onRemove && (
+                          <button
+                            onClick={() => onRemove(comp.id)}
+                            className="p-2 rounded-bl text-muted-foreground hover:text-foreground hover:bg-muted transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+                            aria-label={`Remove ${comp.name}`}
+                          >
+                            <X className="w-3 h-3" aria-hidden="true" />
+                          </button>
+                        )}
+                      </span>
                     )}
                     <div className="flex flex-col items-center gap-0.5">
                       <span className="font-mono text-xs text-muted-foreground">

--- a/components/competitor-picker.tsx
+++ b/components/competitor-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -15,6 +15,7 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandSeparator,
 } from "@/components/ui/command";
 import { Users, Check, Star, User, Settings2 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -35,6 +36,16 @@ interface CompetitorPickerProps {
   onToggleTracked?: (c: CompetitorInfo) => void;
   /** Called when user clicks "Manage tracked" in the footer. */
   onManage?: () => void;
+}
+
+function isFavorite(
+  c: CompetitorInfo,
+  trackedShooterIds: Set<number> | undefined,
+  myShooterId: number | null | undefined,
+): boolean {
+  if (c.shooterId === null) return false;
+  if (myShooterId != null && c.shooterId === myShooterId) return true;
+  return trackedShooterIds?.has(c.shooterId) ?? false;
 }
 
 export function CompetitorPicker({
@@ -60,6 +71,135 @@ export function CompetitorPicker({
     }
   }
 
+  // Split into favorites (you + tracked) and the rest. Pin "you" at the very
+  // top of favorites, then alpha-sort the remaining favorites for stable order.
+  const { favorites, rest } = useMemo(() => {
+    const favs: CompetitorInfo[] = [];
+    const others: CompetitorInfo[] = [];
+    for (const c of competitors) {
+      if (isFavorite(c, trackedShooterIds, myShooterId)) {
+        favs.push(c);
+      } else {
+        others.push(c);
+      }
+    }
+    favs.sort((a, b) => {
+      const aMe = myShooterId != null && a.shooterId === myShooterId;
+      const bMe = myShooterId != null && b.shooterId === myShooterId;
+      if (aMe && !bMe) return -1;
+      if (bMe && !aMe) return 1;
+      return a.name.localeCompare(b.name);
+    });
+    return { favorites: favs, rest: others };
+  }, [competitors, trackedShooterIds, myShooterId]);
+
+  const hasFavorites = favorites.length > 0;
+
+  function renderRow(c: CompetitorInfo) {
+    const isSelected = selectedSet.has(c.id);
+    const isDisabled = !isSelected && selectedIds.length >= MAX_COMPETITORS;
+    const isTracked = trackedShooterIds?.has(c.shooterId ?? -1) ?? false;
+    const isMe = c.shooterId !== null && c.shooterId === myShooterId;
+    const hasShooterId = c.shooterId !== null;
+
+    return (
+      <CommandItem
+        key={c.id}
+        value={`${c.competitor_number} ${c.name} ${c.club ?? ""}`}
+        onSelect={() => toggle(c.id)}
+        disabled={isDisabled}
+        className={cn(
+          "flex items-center gap-2 pr-1",
+          isDisabled && "opacity-50 cursor-not-allowed"
+        )}
+      >
+        <Check
+          className={cn(
+            "w-4 h-4 shrink-0",
+            isSelected ? "opacity-100" : "opacity-0"
+          )}
+        />
+        <span className="font-mono text-xs text-muted-foreground w-8 shrink-0">
+          #{c.competitor_number}
+        </span>
+        <span className="flex-1 truncate min-w-0">
+          {c.name}
+          {isMe && (
+            <span
+              className="ml-1.5 inline-flex items-center rounded-sm bg-primary/10 px-1 py-px text-[10px] font-medium uppercase tracking-wide text-primary align-middle"
+              aria-label="(you)"
+            >
+              You
+            </span>
+          )}
+        </span>
+
+        {hasTracking ? (
+          <span className="flex items-center gap-2 shrink-0" onClick={(e) => e.stopPropagation()}>
+            {onToggleTracked && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleTracked(c);
+                }}
+                disabled={!hasShooterId}
+                aria-label={isTracked ? `Untrack ${c.name}` : `Track ${c.name}`}
+                aria-pressed={isTracked}
+                className={cn(
+                  "p-2 rounded transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+                  hasShooterId
+                    ? isTracked
+                      ? "text-amber-500 hover:text-amber-600 hover:bg-amber-500/10"
+                      : "text-muted-foreground hover:text-amber-500 hover:bg-amber-500/10"
+                    : "text-muted-foreground/30 cursor-not-allowed"
+                )}
+              >
+                <Star
+                  className="w-3.5 h-3.5"
+                  aria-hidden="true"
+                  fill={isTracked ? "currentColor" : "none"}
+                />
+              </button>
+            )}
+            {onSetMyIdentity && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSetMyIdentity(c);
+                }}
+                disabled={!hasShooterId}
+                aria-label={`Set as my identity: ${c.name}`}
+                aria-pressed={isMe}
+                className={cn(
+                  "p-2 rounded transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+                  hasShooterId
+                    ? isMe
+                      ? "text-blue-500 hover:text-blue-600 hover:bg-blue-500/10"
+                      : "text-muted-foreground hover:text-blue-500 hover:bg-blue-500/10"
+                    : "text-muted-foreground/30 cursor-not-allowed"
+                )}
+              >
+                <User
+                  className="w-3.5 h-3.5"
+                  aria-hidden="true"
+                  fill={isMe ? "currentColor" : "none"}
+                />
+              </button>
+            )}
+          </span>
+        ) : (
+          c.club && (
+            <span className="text-xs text-muted-foreground truncate max-w-20">
+              {c.club}
+            </span>
+          )
+        )}
+      </CommandItem>
+    );
+  }
+
   return (
     <>
       <Popover open={open} onOpenChange={setOpen}>
@@ -79,102 +219,22 @@ export function CompetitorPicker({
             <CommandInput aria-label="Search competitors" placeholder="Search by name, number, or club…" />
             <CommandList>
               <CommandEmpty>No competitors found.</CommandEmpty>
-              <CommandGroup>
-                {competitors.map((c) => {
-                  const isSelected = selectedSet.has(c.id);
-                  const isDisabled = !isSelected && selectedIds.length >= MAX_COMPETITORS;
-                  const isTracked = trackedShooterIds?.has(c.shooterId ?? -1) ?? false;
-                  const isMe = c.shooterId !== null && c.shooterId === myShooterId;
-                  const hasShooterId = c.shooterId !== null;
-
-                  return (
-                    <CommandItem
-                      key={c.id}
-                      value={`${c.competitor_number} ${c.name} ${c.club ?? ""}`}
-                      onSelect={() => toggle(c.id)}
-                      disabled={isDisabled}
-                      className={cn(
-                        "flex items-center gap-2 pr-1",
-                        isDisabled && "opacity-50 cursor-not-allowed"
-                      )}
-                    >
-                      <Check
-                        className={cn(
-                          "w-4 h-4 shrink-0",
-                          isSelected ? "opacity-100" : "opacity-0"
-                        )}
-                      />
-                      <span className="font-mono text-xs text-muted-foreground w-8 shrink-0">
-                        #{c.competitor_number}
-                      </span>
-                      <span className="flex-1 truncate min-w-0">{c.name}</span>
-
-                      {hasTracking ? (
-                        /* Tracking action buttons — only shown when tracking props provided */
-                        <span className="flex items-center gap-2 shrink-0" onClick={(e) => e.stopPropagation()}>
-                          {onToggleTracked && (
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                onToggleTracked(c);
-                              }}
-                              disabled={!hasShooterId}
-                              aria-label={isTracked ? `Untrack ${c.name}` : `Track ${c.name}`}
-                              className={cn(
-                                "p-2 rounded transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
-                                hasShooterId
-                                  ? isTracked
-                                    ? "text-amber-500 hover:text-amber-600 hover:bg-amber-500/10"
-                                    : "text-muted-foreground hover:text-amber-500 hover:bg-amber-500/10"
-                                  : "text-muted-foreground/30 cursor-not-allowed"
-                              )}
-                            >
-                              <Star
-                                className="w-3.5 h-3.5"
-                                aria-hidden="true"
-                                fill={isTracked ? "currentColor" : "none"}
-                              />
-                            </button>
-                          )}
-                          {onSetMyIdentity && (
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                onSetMyIdentity(c);
-                              }}
-                              disabled={!hasShooterId}
-                              aria-label={`Set as my identity: ${c.name}`}
-                              className={cn(
-                                "p-2 rounded transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
-                                hasShooterId
-                                  ? isMe
-                                    ? "text-blue-500 hover:text-blue-600 hover:bg-blue-500/10"
-                                    : "text-muted-foreground hover:text-blue-500 hover:bg-blue-500/10"
-                                  : "text-muted-foreground/30 cursor-not-allowed"
-                              )}
-                            >
-                              <User
-                                className="w-3.5 h-3.5"
-                                aria-hidden="true"
-                                fill={isMe ? "currentColor" : "none"}
-                              />
-                            </button>
-                          )}
-                        </span>
-                      ) : (
-                        /* No tracking props — show club as before */
-                        c.club && (
-                          <span className="text-xs text-muted-foreground truncate max-w-20">
-                            {c.club}
-                          </span>
-                        )
-                      )}
-                    </CommandItem>
-                  );
-                })}
-              </CommandGroup>
+              {hasFavorites && (
+                <>
+                  <CommandGroup heading="Favorites">
+                    {favorites.map((c) => renderRow(c))}
+                  </CommandGroup>
+                  <CommandSeparator />
+                  <CommandGroup heading="All competitors">
+                    {rest.map((c) => renderRow(c))}
+                  </CommandGroup>
+                </>
+              )}
+              {!hasFavorites && (
+                <CommandGroup>
+                  {rest.map((c) => renderRow(c))}
+                </CommandGroup>
+              )}
             </CommandList>
             {onManage && (
               <div className="border-t p-1">

--- a/components/competitor-picker.tsx
+++ b/components/competitor-picker.tsx
@@ -17,7 +17,7 @@ import {
   CommandList,
   CommandSeparator,
 } from "@/components/ui/command";
-import { Users, Check, Star, User, Settings2 } from "lucide-react";
+import { Users, Check, Plus, Star, User, Settings2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { CompetitorInfo } from "@/lib/types";
 import { MAX_COMPETITORS } from "@/lib/constants";
@@ -94,6 +94,26 @@ export function CompetitorPicker({
   }, [competitors, trackedShooterIds, myShooterId]);
 
   const hasFavorites = favorites.length > 0;
+
+  // Favorites that are not yet selected — drives the "Add all" pill.
+  const addableFavorites = useMemo(
+    () => favorites.filter((c) => !selectedSet.has(c.id)),
+    // selectedSet is derived from selectedIds; depend on the array itself.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [favorites, selectedIds],
+  );
+  const remainingSlots = MAX_COMPETITORS - selectedIds.length;
+  const addAllCount = Math.min(addableFavorites.length, Math.max(remainingSlots, 0));
+  const showAddAllPill = addableFavorites.length >= 2;
+  const addAllDisabled = remainingSlots <= 0 || addableFavorites.length === 0;
+
+  function handleAddAllFavorites(e: React.MouseEvent | React.KeyboardEvent) {
+    e.stopPropagation();
+    if (addAllDisabled) return;
+    const idsToAdd = addableFavorites.slice(0, remainingSlots).map((c) => c.id);
+    if (idsToAdd.length === 0) return;
+    onSelectionChange([...selectedIds, ...idsToAdd]);
+  }
 
   function renderRow(c: CompetitorInfo) {
     const isSelected = selectedSet.has(c.id);
@@ -221,7 +241,38 @@ export function CompetitorPicker({
               <CommandEmpty>No competitors found.</CommandEmpty>
               {hasFavorites && (
                 <>
-                  <CommandGroup heading="Favorites">
+                  <div className="flex items-center justify-between gap-2 px-2 pt-2 pb-1">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      Favorites
+                    </span>
+                    {showAddAllPill && (
+                      <button
+                        type="button"
+                        onClick={handleAddAllFavorites}
+                        disabled={addAllDisabled}
+                        aria-label={
+                          addAllDisabled
+                            ? "Cannot add favorites — selection limit reached"
+                            : `Add ${addAllCount} favorite${addAllCount === 1 ? "" : "s"} to selection`
+                        }
+                        className={cn(
+                          "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium transition-colors",
+                          "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+                          addAllDisabled
+                            ? "border-muted text-muted-foreground/50 cursor-not-allowed"
+                            : "border-amber-500/40 text-amber-600 hover:bg-amber-500/10 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300",
+                        )}
+                      >
+                        <Plus className="w-3 h-3" aria-hidden="true" />
+                        {addAllDisabled
+                          ? "Limit reached"
+                          : addAllCount < addableFavorites.length
+                            ? `Add ${addAllCount} of ${addableFavorites.length}`
+                            : `Add all (${addAllCount})`}
+                      </button>
+                    )}
+                  </div>
+                  <CommandGroup>
                     {favorites.map((c) => renderRow(c))}
                   </CommandGroup>
                   <CommandSeparator />

--- a/components/squad-picker.tsx
+++ b/components/squad-picker.tsx
@@ -7,7 +7,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { Check, UsersRound } from "lucide-react";
+import { UsersRound } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { SquadInfo } from "@/lib/types";
 import { MAX_COMPETITORS } from "@/lib/constants";
@@ -15,133 +15,101 @@ import { MAX_COMPETITORS } from "@/lib/constants";
 interface SquadPickerProps {
   squads: SquadInfo[];
   selectedIds: number[];
-  onSelectionChange: (ids: number[]) => void;
+  /** Replaces the current selection with this squad's members.
+   *  The parent is responsible for capping at MAX_COMPETITORS and offering
+   *  an undo affordance (so the previous selection isn't lost). */
+  onReplaceSelection: (newIds: number[], squadName: string) => void;
 }
 
 export function SquadPicker({
   squads,
   selectedIds,
-  onSelectionChange,
+  onReplaceSelection,
 }: SquadPickerProps) {
   const [open, setOpen] = useState(false);
-  // Tracks per-squad add feedback while the popover is open.
-  // key = squad id, value = feedback string
-  const [feedback, setFeedback] = useState<Record<number, string>>({});
 
-  function handleOpenChange(nextOpen: boolean) {
-    setOpen(nextOpen);
-    if (!nextOpen) setFeedback({});
-  }
-
-  function handleAdd(squad: SquadInfo) {
-    const selectedSet = new Set(selectedIds);
-    const remaining = MAX_COMPETITORS - selectedIds.length;
-    const toAdd = squad.competitorIds.filter((cid) => !selectedSet.has(cid));
-
-    if (toAdd.length === 0) return;
-
-    const added = toAdd.slice(0, remaining);
-    const nextIds = [...selectedIds, ...added];
-    onSelectionChange(nextIds);
-
-    const limitReached = added.length < toAdd.length;
-    const msg = limitReached
-      ? `Added ${added.length} of ${toAdd.length} — limit reached`
-      : `Added ${added.length}`;
-    setFeedback((prev) => ({ ...prev, [squad.id]: msg }));
+  function handleSelect(squad: SquadInfo) {
+    const newIds = squad.competitorIds.slice(0, MAX_COMPETITORS);
+    if (newIds.length === 0) return;
+    onReplaceSelection(newIds, squad.name);
+    setOpen(false);
   }
 
   if (squads.length === 0) return null;
 
   const selectedSet = new Set(selectedIds);
-  const remaining = MAX_COMPETITORS - selectedIds.length;
 
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
           variant="outline"
           size="sm"
           className="gap-2"
-          aria-label="Add squad"
+          aria-label="Replace selection with a squad"
         >
           <UsersRound className="w-4 h-4" />
-          Add squad
+          Squad
         </Button>
       </PopoverTrigger>
       <PopoverContent
         className="p-0 w-[min(20rem,calc(100vw-2rem))]"
         align="start"
       >
+        <div className="px-3 py-2 border-b">
+          <p className="text-xs text-muted-foreground">
+            Picking a squad replaces your current selection.
+            {selectedIds.length > 0 && " You can undo right after."}
+          </p>
+        </div>
         <div className="max-h-72 overflow-y-auto">
           <div className="p-1">
-            {squads.length === 0 ? (
-              <p className="py-3 px-3 text-sm text-muted-foreground text-center">
-                No squads found
-              </p>
-            ) : (
-              squads.map((squad) => {
-                const memberCount = squad.competitorIds.length;
-                const tooLarge = memberCount > MAX_COMPETITORS;
-                const allSelected =
-                  !tooLarge &&
-                  squad.competitorIds.every((cid) => selectedSet.has(cid));
-                const hasFeedback = Boolean(feedback[squad.id]);
-                const isAddable =
-                  !tooLarge && !allSelected && remaining > 0;
+            {squads.map((squad) => {
+              const memberCount = squad.competitorIds.length;
+              const tooLarge = memberCount > MAX_COMPETITORS;
+              const allCurrentlySelected =
+                !tooLarge &&
+                memberCount === selectedIds.length &&
+                squad.competitorIds.every((cid) => selectedSet.has(cid));
 
-                return (
-                  <div
-                    key={squad.id}
-                    className={cn(
-                      "flex items-center justify-between gap-2 rounded-sm px-3 py-2 text-sm",
-                      tooLarge && "opacity-50"
-                    )}
-                  >
-                    <span className="flex-1 truncate">
-                      {squad.name}
-                      <span className="ml-1 text-xs text-muted-foreground">
-                        · {memberCount} member{memberCount !== 1 ? "s" : ""}
-                      </span>
+              return (
+                <button
+                  key={squad.id}
+                  type="button"
+                  disabled={memberCount === 0}
+                  onClick={() => handleSelect(squad)}
+                  className={cn(
+                    "w-full flex items-center justify-between gap-2 rounded-sm px-3 py-2 text-sm text-left",
+                    "hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
+                    "disabled:opacity-50 disabled:cursor-not-allowed",
+                    allCurrentlySelected && "bg-accent/40",
+                  )}
+                  aria-label={
+                    tooLarge
+                      ? `${squad.name} (${memberCount} members — will be capped to ${MAX_COMPETITORS})`
+                      : `Replace selection with ${squad.name} (${memberCount} members)`
+                  }
+                >
+                  <span className="flex-1 truncate">
+                    {squad.name}
+                    <span className="ml-1 text-xs text-muted-foreground">
+                      · {memberCount} member{memberCount !== 1 ? "s" : ""}
                     </span>
-
-                    {tooLarge ? (
-                      <span className="text-xs text-muted-foreground whitespace-nowrap">
-                        Exceeds {MAX_COMPETITORS}-competitor limit
-                      </span>
-                    ) : allSelected ? (
-                      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground whitespace-nowrap">
-                        <Check className="w-3 h-3" aria-hidden="true" />
-                        All added
-                      </span>
-                    ) : hasFeedback ? (
-                      <span className="text-xs text-muted-foreground whitespace-nowrap">
-                        {feedback[squad.id]}
-                      </span>
-                    ) : (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-7 px-2 text-xs"
-                        disabled={!isAddable}
-                        aria-label={`Add ${squad.name}`}
-                        onClick={() => handleAdd(squad)}
-                      >
-                        Add
-                      </Button>
-                    )}
-                  </div>
-                );
-              })
-            )}
+                  </span>
+                  {tooLarge && (
+                    <span className="text-xs text-muted-foreground whitespace-nowrap shrink-0">
+                      first {MAX_COMPETITORS}
+                    </span>
+                  )}
+                  {allCurrentlySelected && (
+                    <span className="text-xs text-muted-foreground whitespace-nowrap shrink-0">
+                      current
+                    </span>
+                  )}
+                </button>
+              );
+            })}
           </div>
-        </div>
-        <div className="border-t px-3 py-2">
-          <p className="text-xs text-muted-foreground">
-            {remaining > 0
-              ? `${remaining} slot${remaining !== 1 ? "s" : ""} remaining`
-              : `Limit of ${MAX_COMPETITORS} reached`}
-          </p>
         </div>
       </PopoverContent>
     </Popover>

--- a/lib/benchmark-presets.ts
+++ b/lib/benchmark-presets.ts
@@ -1,0 +1,127 @@
+import type { CompetitorInfo, FieldFingerprintPoint } from "@/lib/types";
+import { MAX_COMPETITORS } from "@/lib/constants";
+
+export type SmartPresetKind =
+  | "one-above"
+  | "one-below"
+  | "podium"
+  | "percentile"
+  | "same-club";
+
+export interface SmartPreset {
+  kind: SmartPresetKind;
+  label: string;
+  description: string;
+  /** Competitor IDs to apply, capped to MAX_COMPETITORS, "me" first when included. */
+  ids: number[];
+}
+
+/** Pick the rank closest to a given percentile (0-100) of N total. */
+export function rankAtPercentile(percentile: number, n: number): number {
+  if (n <= 0) return 1;
+  // Higher percentile = better = lower rank number.
+  const rank = Math.round(((100 - percentile) / 100) * (n - 1)) + 1;
+  return Math.max(1, Math.min(n, rank));
+}
+
+/** Compute the smart-preset rows for a given identity context. Pure. */
+export function computeSmartPresets(args: {
+  myCompetitor: CompetitorInfo;
+  myPoint: FieldFingerprintPoint;
+  competitors: CompetitorInfo[];
+  fieldFingerprintPoints: FieldFingerprintPoint[];
+}): SmartPreset[] {
+  const { myCompetitor, myPoint, competitors, fieldFingerprintPoints } = args;
+  const myDivision = myPoint.division;
+  if (!myDivision) return [];
+
+  const competitorMap = new Map(competitors.map((c) => [c.id, c]));
+
+  const divPoints = fieldFingerprintPoints
+    .filter((p) => p.division === myDivision && p.actualDivRank !== null)
+    .sort((a, b) => (a.actualDivRank ?? Infinity) - (b.actualDivRank ?? Infinity));
+
+  const myRank = myPoint.actualDivRank;
+  const divSize = divPoints.length;
+  const presets: SmartPreset[] = [];
+
+  if (myRank !== null && myRank > 1) {
+    const aboveId = divPoints[myRank - 2]?.competitorId;
+    if (aboveId != null) {
+      const aboveComp = competitorMap.get(aboveId);
+      presets.push({
+        kind: "one-above",
+        label: "One above me",
+        description: aboveComp
+          ? `Chasing target — ${aboveComp.name} (${myDivision} #${myRank - 1})`
+          : "Chasing target",
+        ids: [myCompetitor.id, aboveId],
+      });
+    }
+  }
+
+  if (myRank !== null && myRank < divSize) {
+    const belowId = divPoints[myRank]?.competitorId;
+    if (belowId != null) {
+      const belowComp = competitorMap.get(belowId);
+      presets.push({
+        kind: "one-below",
+        label: "One below me",
+        description: belowComp
+          ? `Defense gap — ${belowComp.name} (${myDivision} #${myRank + 1})`
+          : "Defense gap",
+        ids: [myCompetitor.id, belowId],
+      });
+    }
+  }
+
+  if (divSize >= 1) {
+    const podiumIds = divPoints.slice(0, 3).map((p) => p.competitorId);
+    const ids = Array.from(new Set([myCompetitor.id, ...podiumIds])).slice(
+      0,
+      MAX_COMPETITORS,
+    );
+    if (ids.length > 1) {
+      presets.push({
+        kind: "podium",
+        label: "My division podium",
+        description: `Aspirational ceiling — top ${Math.min(3, divSize)} in ${myDivision}`,
+        ids,
+      });
+    }
+  }
+
+  if (divSize >= 4) {
+    const cohortIds: number[] = [myCompetitor.id];
+    for (const pct of [95, 75, 50, 25]) {
+      const rank = rankAtPercentile(pct, divSize);
+      const id = divPoints[rank - 1]?.competitorId;
+      if (id != null && !cohortIds.includes(id)) cohortIds.push(id);
+    }
+    if (cohortIds.length > 2) {
+      presets.push({
+        kind: "percentile",
+        label: "My percentile cohort",
+        description: `Where do I sit? p25 · p50 · p75 · p95 of ${myDivision}`,
+        ids: cohortIds.slice(0, MAX_COMPETITORS),
+      });
+    }
+  }
+
+  if (myCompetitor.club) {
+    const clubIds = competitors
+      .filter((c) => c.club === myCompetitor.club && c.id !== myCompetitor.id)
+      .map((c) => c.id);
+    if (clubIds.length > 0) {
+      const ids = [myCompetitor.id, ...clubIds].slice(0, MAX_COMPETITORS);
+      presets.push({
+        kind: "same-club",
+        label: "Same club",
+        description: `Peers from ${myCompetitor.club} (${ids.length})`,
+        ids,
+      });
+    }
+  }
+
+  return presets;
+}

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -11,11 +11,34 @@ import type { Release } from "@/lib/types";
  * differs from the value stored in localStorage("whats-new-seen-id").
  */
 /** The `id` of the newest release. Used by e2e tests to suppress the What's New dialog. */
-export const LATEST_RELEASE_ID = "2026-04-28-stage-export";
+export const LATEST_RELEASE_ID = "2026-04-28-competitor-selection";
 
 export const RELEASES: Release[] = [
   {
     id: LATEST_RELEASE_ID,
+    date: "April 28, 2026",
+    title: "Faster competitor selection",
+    screenshotScenes: ["comparison-table", "tracked-shooters-sheet"],
+    sections: [
+      {
+        heading: "New",
+        items: [
+          "Smart benchmark presets — once you set 'this is me' in My Shooters, the Benchmark button gives one-tap shortcuts: One above me, One below me, My division podium, My percentile cohort (p25/p50/p75/p95), and Same club. Each preset replaces your current selection and you can undo right away.",
+          "Tap the star next to a competitor's name in the comparison table header to favorite or unfavorite them without leaving the page. The same star is now also on the shooter dashboard.",
+          "Squad picker now replaces your current selection (with a one-tap undo) instead of mixing the squad into what was already there.",
+          "Clear button next to the picker wipes your selection in one tap, with a 5-second undo.",
+        ],
+      },
+      {
+        heading: "Improved",
+        items: [
+          "The competitor dropdown now groups your favorites at the top — with you pinned first when 'this is me' is set — and the rest below.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "2026-04-28-stage-export",
     date: "April 28, 2026",
     title: "Stage times export",
     screenshotScenes: ["stage-times-export"],

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -24,6 +24,7 @@ export const RELEASES: Release[] = [
         heading: "New",
         items: [
           "Smart benchmark presets — once you set 'this is me' in My Shooters, the Benchmark button gives one-tap shortcuts: One above me, One below me, My division podium, My percentile cohort (p25/p50/p75/p95), and Same club. Each preset replaces your current selection and you can undo right away.",
+          "Reorder competitors directly in the comparison table — each column header has chevron buttons to move a competitor left or right. Column colors follow the new order, so you can put yourself in column 1 and keep the same color across matches.",
           "Tap the star next to a competitor's name in the comparison table header to favorite or unfavorite them without leaving the page. The same star is now also on the shooter dashboard.",
           "Squad picker now replaces your current selection (with a one-tap undo) instead of mixing the squad into what was already there.",
           "Clear button next to the picker wipes your selection in one tap, with a 5-second undo.",

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -34,6 +34,7 @@ export const RELEASES: Release[] = [
         heading: "Improved",
         items: [
           "The competitor dropdown now groups your favorites at the top — with you pinned first when 'this is me' is set — and the rest below.",
+          "Favorites section has an 'Add all' pill that pulls every favorite entered in the match into the comparison in a single tap.",
         ],
       },
     ],

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -322,7 +322,7 @@ test.describe("Scoreboard E2E", () => {
     await expect(page.getByRole("table").getByText("#116")).not.toBeVisible();
   });
 
-  test("squad picker adds all squad members", async ({ page }) => {
+  test("squad picker replaces selection with all squad members", async ({ page }) => {
     await page.route("/api/match/22/99999999", (route) =>
       route.fulfill({ json: MOCK_MATCH })
     );
@@ -333,12 +333,18 @@ test.describe("Scoreboard E2E", () => {
     await page.goto("/match/22/99999999");
     await expect(page.getByText("Test IPSC Match")).toBeVisible();
 
-    // Open the squad picker popover
-    await page.getByRole("button", { name: /add squad/i }).click();
-    await expect(page.getByRole("button", { name: /add squad 1/i })).toBeVisible();
+    // Open the squad picker popover (trigger label: "Replace selection with a squad")
+    await page
+      .getByRole("button", { name: /replace selection with a squad/i })
+      .click();
+    await expect(
+      page.getByRole("button", { name: /replace selection with squad 1/i }),
+    ).toBeVisible();
 
-    // Add Squad 1 (Alice + Bob)
-    await page.getByRole("button", { name: /add squad 1/i }).click();
+    // Pick Squad 1 (Alice + Bob)
+    await page
+      .getByRole("button", { name: /replace selection with squad 1/i })
+      .click();
 
     // Both competitor badges should now be visible
     await expect(page.getByRole("button", { name: /remove alice/i })).toBeVisible();

--- a/tests/unit/benchmark-presets.test.ts
+++ b/tests/unit/benchmark-presets.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeSmartPresets,
+  rankAtPercentile,
+} from "@/lib/benchmark-presets";
+import type { CompetitorInfo, FieldFingerprintPoint } from "@/lib/types";
+
+function comp(
+  id: number,
+  name: string,
+  opts: { club?: string | null; shooterId?: number | null } = {},
+): CompetitorInfo {
+  return {
+    id,
+    shooterId: opts.shooterId ?? id + 1000,
+    name,
+    competitor_number: String(id),
+    club: opts.club ?? null,
+    division: "Production",
+    region: null,
+    region_display: null,
+    category: null,
+    ics_alias: null,
+    license: null,
+  };
+}
+
+function point(id: number, division: string, rank: number): FieldFingerprintPoint {
+  return {
+    competitorId: id,
+    division,
+    alphaRatio: 0.6,
+    pointsPerSecond: 5,
+    penaltyRate: 0,
+    accuracyPercentile: 50,
+    speedPercentile: 50,
+    cv: null,
+    actualDivRank: rank,
+    actualOverallRank: rank,
+  };
+}
+
+describe("rankAtPercentile", () => {
+  it("returns top rank for p100 and bottom rank for p0", () => {
+    expect(rankAtPercentile(100, 10)).toBe(1);
+    expect(rankAtPercentile(0, 10)).toBe(10);
+  });
+
+  it("returns approximate median for p50", () => {
+    expect(rankAtPercentile(50, 10)).toBe(6); // round(0.5 * 9) + 1
+    expect(rankAtPercentile(50, 100)).toBe(51);
+  });
+
+  it("clamps to [1, n]", () => {
+    expect(rankAtPercentile(120, 5)).toBe(1);
+    expect(rankAtPercentile(-10, 5)).toBe(5);
+  });
+
+  it("handles n=1 without dividing by zero", () => {
+    expect(rankAtPercentile(50, 1)).toBe(1);
+  });
+
+  it("handles n=0 by returning 1 (helper guards downstream)", () => {
+    expect(rankAtPercentile(50, 0)).toBe(1);
+  });
+});
+
+describe("computeSmartPresets", () => {
+  const me = comp(10, "Mathias Axell", { club: "BSF" });
+  const myPoint = point(10, "Production", 5);
+
+  it("returns no presets when myPoint has no division", () => {
+    const result = computeSmartPresets({
+      myCompetitor: me,
+      myPoint: { ...myPoint, division: null },
+      competitors: [me],
+      fieldFingerprintPoints: [{ ...myPoint, division: null }],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("includes one-above and one-below in the middle of a division", () => {
+    const competitors = Array.from({ length: 10 }, (_, i) =>
+      comp(i + 1, `Shooter ${i + 1}`),
+    ).concat(me);
+    const points = competitors.map((c, i) =>
+      point(c.id, "Production", c.id === me.id ? 5 : i + 1 >= 5 ? i + 2 : i + 1),
+    );
+
+    const result = computeSmartPresets({
+      myCompetitor: me,
+      myPoint,
+      competitors,
+      fieldFingerprintPoints: points,
+    });
+
+    const above = result.find((p) => p.kind === "one-above");
+    const below = result.find((p) => p.kind === "one-below");
+    expect(above).toBeDefined();
+    expect(below).toBeDefined();
+    expect(above!.ids[0]).toBe(me.id);
+    expect(above!.ids).toHaveLength(2);
+    expect(below!.ids[0]).toBe(me.id);
+    expect(below!.ids).toHaveLength(2);
+  });
+
+  it("omits one-above when I'm at rank 1", () => {
+    const others = [comp(2, "B"), comp(3, "C"), comp(4, "D")];
+    const competitors = [me, ...others];
+    const points = [
+      point(me.id, "Production", 1),
+      point(2, "Production", 2),
+      point(3, "Production", 3),
+      point(4, "Production", 4),
+    ];
+    const result = computeSmartPresets({
+      myCompetitor: me,
+      myPoint: { ...myPoint, actualDivRank: 1 },
+      competitors,
+      fieldFingerprintPoints: points,
+    });
+    expect(result.find((p) => p.kind === "one-above")).toBeUndefined();
+    expect(result.find((p) => p.kind === "one-below")).toBeDefined();
+  });
+
+  it("omits one-below when I'm at the last rank", () => {
+    const others = [comp(2, "B"), comp(3, "C"), comp(4, "D")];
+    const competitors = [me, ...others];
+    const points = [
+      point(2, "Production", 1),
+      point(3, "Production", 2),
+      point(4, "Production", 3),
+      point(me.id, "Production", 4),
+    ];
+    const result = computeSmartPresets({
+      myCompetitor: me,
+      myPoint: { ...myPoint, actualDivRank: 4 },
+      competitors,
+      fieldFingerprintPoints: points,
+    });
+    expect(result.find((p) => p.kind === "one-above")).toBeDefined();
+    expect(result.find((p) => p.kind === "one-below")).toBeUndefined();
+  });
+
+  it("podium dedupes when I am in the top 3", () => {
+    const others = [comp(2, "B"), comp(3, "C"), comp(4, "D")];
+    const competitors = [me, ...others];
+    const points = [
+      point(me.id, "Production", 1),
+      point(2, "Production", 2),
+      point(3, "Production", 3),
+      point(4, "Production", 4),
+    ];
+    const result = computeSmartPresets({
+      myCompetitor: me,
+      myPoint: { ...myPoint, actualDivRank: 1 },
+      competitors,
+      fieldFingerprintPoints: points,
+    });
+    const podium = result.find((p) => p.kind === "podium");
+    expect(podium).toBeDefined();
+    // [me, 2, 3] — me is included once even though me is also in top 3
+    expect(podium!.ids).toEqual([me.id, 2, 3]);
+  });
+
+  it("percentile cohort needs at least 4 ranked competitors", () => {
+    const others = [comp(2, "B"), comp(3, "C")];
+    const competitors = [me, ...others];
+    const points = [
+      point(me.id, "Production", 1),
+      point(2, "Production", 2),
+      point(3, "Production", 3),
+    ];
+    const result = computeSmartPresets({
+      myCompetitor: me,
+      myPoint: { ...myPoint, actualDivRank: 1 },
+      competitors,
+      fieldFingerprintPoints: points,
+    });
+    expect(result.find((p) => p.kind === "percentile")).toBeUndefined();
+  });
+
+  it("percentile cohort picks p25/p50/p75/p95 plus me", () => {
+    const competitors: CompetitorInfo[] = [me];
+    const points: FieldFingerprintPoint[] = [point(me.id, "Production", 5)];
+    for (let r = 1; r <= 20; r++) {
+      if (r === 5) continue;
+      const id = 100 + r;
+      competitors.push(comp(id, `R${r}`));
+      points.push(point(id, "Production", r));
+    }
+    const result = computeSmartPresets({
+      myCompetitor: me,
+      myPoint,
+      competitors,
+      fieldFingerprintPoints: points,
+    });
+    const cohort = result.find((p) => p.kind === "percentile");
+    expect(cohort).toBeDefined();
+    // me is always first; cohort length 2..5 depending on dedup with rank 5.
+    expect(cohort!.ids[0]).toBe(me.id);
+    expect(cohort!.ids.length).toBeGreaterThanOrEqual(3);
+    expect(cohort!.ids.length).toBeLessThanOrEqual(5);
+  });
+
+  it("includes same-club only when peers exist with the same club", () => {
+    const peers = [
+      comp(2, "Peer 1", { club: "BSF" }),
+      comp(3, "Peer 2", { club: "BSF" }),
+    ];
+    const others = [comp(4, "Other", { club: "Other" })];
+    const competitors = [me, ...peers, ...others];
+    const points = [
+      point(me.id, "Production", 1),
+      point(2, "Production", 2),
+      point(3, "Production", 3),
+      point(4, "Production", 4),
+    ];
+    const result = computeSmartPresets({
+      myCompetitor: me,
+      myPoint: { ...myPoint, actualDivRank: 1 },
+      competitors,
+      fieldFingerprintPoints: points,
+    });
+    const club = result.find((p) => p.kind === "same-club");
+    expect(club).toBeDefined();
+    expect(club!.ids).toEqual([me.id, 2, 3]);
+  });
+
+  it("omits same-club when my club is null", () => {
+    const meNoClub = { ...me, club: null };
+    const others = [comp(2, "B", { club: "BSF" })];
+    const competitors = [meNoClub, ...others];
+    const points = [
+      point(meNoClub.id, "Production", 1),
+      point(2, "Production", 2),
+    ];
+    const result = computeSmartPresets({
+      myCompetitor: meNoClub,
+      myPoint: { ...myPoint, actualDivRank: 1 },
+      competitors,
+      fieldFingerprintPoints: points,
+    });
+    expect(result.find((p) => p.kind === "same-club")).toBeUndefined();
+  });
+
+  it("respects MAX_COMPETITORS for very large clubs", () => {
+    const peers = Array.from({ length: 30 }, (_, i) =>
+      comp(i + 100, `Peer ${i}`, { club: "BSF" }),
+    );
+    const competitors = [me, ...peers];
+    const points = competitors.map((c, i) =>
+      point(c.id, "Production", i + 1),
+    );
+    const result = computeSmartPresets({
+      myCompetitor: me,
+      myPoint: { ...myPoint, actualDivRank: 1 },
+      competitors,
+      fieldFingerprintPoints: points,
+    });
+    const club = result.find((p) => p.kind === "same-club")!;
+    // MAX_COMPETITORS = 12
+    expect(club.ids.length).toBe(12);
+    expect(club.ids[0]).toBe(me.id);
+  });
+
+  it("ignores points from other divisions", () => {
+    const others = [
+      comp(2, "Same", { club: null }),
+      comp(3, "Other-div", { club: null }),
+    ];
+    const competitors = [me, ...others];
+    const points = [
+      point(me.id, "Production", 1),
+      point(2, "Production", 2),
+      point(3, "Open", 1), // different division — must be ignored
+    ];
+    const result = computeSmartPresets({
+      myCompetitor: me,
+      myPoint: { ...myPoint, actualDivRank: 1 },
+      competitors,
+      fieldFingerprintPoints: points,
+    });
+    const podium = result.find((p) => p.kind === "podium");
+    expect(podium!.ids).toEqual([me.id, 2]);
+  });
+});


### PR DESCRIPTION
## Summary
- Group favorites (and "you") at the top of the competitor picker.
- Clear button next to the picker with a 5s undo.
- Squad picker now **replaces** the current selection (with undo) instead of mixing.
- Star toggles in the comparison table header and shooter dashboard.
- Benchmark popover gets five smart presets when "this is me" is set: One above me, One below me, My division podium, My percentile cohort (p25/p50/p75/p95), Same club. Each replaces the selection in one tap; undo restores it.
- New help popover next to "Compare competitors" walks through the picker, squad-replace, smart presets, and clear.
- Release notes + About page updated.

## What changed
- `components/competitor-picker.tsx` — split into Favorites / All competitors with a separator; "You" badge for the identified shooter.
- `components/squad-picker.tsx` — picking a squad calls `onReplaceSelection(ids, squadName)`; the parent renders the undo banner.
- `components/benchmark-picker.tsx` — pulls smart-preset rows from `lib/benchmark-presets.ts`; trigger button shows them above the existing "Top 3 in division" group.
- `components/comparison-table.tsx` — accepts `trackedShooterIds` + `onToggleTracked`, renders an `aria-pressed` star button at top-left of each header chip.
- `app/match/[ct]/[id]/match-page-client.tsx` — owns the shared undo banner (`role="status"` / `aria-live="polite"`, 5s timeout); wires Clear, Squad replace, and Smart presets through `replaceSelectionWithUndo()`. New help popover next to the "Compare competitors" heading.
- `app/shooter/[shooterId]/shooter-dashboard-client.tsx` — star button in the back-nav row using `useTrackedShooters`.
- `lib/benchmark-presets.ts` — pure helpers `computeSmartPresets()` and `rankAtPercentile()`; no I/O.
- `tests/unit/benchmark-presets.test.ts` — 16 tests covering missing identity, rank-1 / rank-N edges, podium dedup, percentile cohort minimum size, same-club, MAX_COMPETITORS clamp, cross-division isolation.
- `lib/releases.ts` — new What's New entry (`2026-04-28-competitor-selection`).
- `app/about/page.tsx` — bullets updated to reflect favorites, smart presets, and squad replace+undo.

## Test plan
- [x] `pnpm -w run typecheck` — zero errors
- [x] `pnpm -w run lint` — zero warnings
- [x] `pnpm -w test` — 1602/1602 passing (16 new)
- [ ] Manual: open a match where you appear, set "this is me", verify favorites/you appear pinned at the top of the picker.
- [ ] Manual: tap Clear, verify undo banner appears for ~5s and restores the previous selection.
- [ ] Manual: tap Squad → pick a squad, verify it replaces (not appends) and undo restores.
- [ ] Manual: open Benchmark, verify smart presets appear; tap "One above me" / "Percentile cohort" and confirm the selection swaps with undo.
- [ ] Manual: tap the star in a comparison-table header chip and on the shooter dashboard — both should toggle the favorite state and persist across reloads.
- [ ] Manual: 390px viewport — picker, undo banner, and smart-presets popover stay within the viewport without horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)