### PR TITLE
Use official IPSC points formula for match %

### DIFF
--- a/app/api/compare/logic.ts
+++ b/app/api/compare/logic.ts
@@ -102,6 +102,104 @@ function pct(hf: number | null, leaderHF: number | null): number | null {
 }
 
 /**
+ * IPSC match-point totals across all stages for a match.
+ *
+ * For each (competitor, stage), `stage_points = (HF / division_stage_winner_HF) × stage.max_points`.
+ * Sum per competitor → match points. Returns the highest match-points figure
+ * within each division and across the full field — the anchors that define
+ * 100% in division and overall mode respectively.
+ *
+ * A competitor with any DQ scorecard (whole-match DQ in IPSC) is excluded
+ * from the leader pool. DNF / zeroed stages contribute 0 stage points.
+ */
+export function computeMatchPointTotals(allScorecards: RawScorecard[]): {
+  /** division string → leader's total IPSC match points (max across the division). */
+  divisionLeaderMatchPts: Record<string, number>;
+  /** Highest match-points figure across the full field (any division). Null when no valid data. */
+  overallLeaderMatchPts: number | null;
+} {
+  // Per-stage division winner HF (excludes DNF/DQ/zeroed and ≤0 HF cards).
+  // Keyed by `${division}::${stageId}`.
+  const divStageWinnerHF = new Map<string, number>();
+  for (const sc of allScorecards) {
+    if (sc.dnf || sc.dq || sc.zeroed) continue;
+    if (sc.hit_factor == null || sc.hit_factor <= 0) continue;
+    const div = sc.competitor_division;
+    if (!div) continue;
+    const key = `${div}::${sc.stage_id}`;
+    const cur = divStageWinnerHF.get(key) ?? 0;
+    if (sc.hit_factor > cur) divStageWinnerHF.set(key, sc.hit_factor);
+  }
+
+  // Overall stage winner HF (across all divisions).
+  const overallStageWinnerHF = new Map<number, number>();
+  for (const sc of allScorecards) {
+    if (sc.dnf || sc.dq || sc.zeroed) continue;
+    if (sc.hit_factor == null || sc.hit_factor <= 0) continue;
+    const cur = overallStageWinnerHF.get(sc.stage_id) ?? 0;
+    if (sc.hit_factor > cur) overallStageWinnerHF.set(sc.stage_id, sc.hit_factor);
+  }
+
+  // Sum match-points per competitor in two reference frames:
+  //   - division-relative: stage anchor = divStageWinnerHF
+  //   - overall-relative: stage anchor = overallStageWinnerHF
+  const divisionMatchPts = new Map<number, number>();
+  const overallMatchPts = new Map<number, number>();
+  const competitorDivision = new Map<number, string | null>();
+  const dqCompetitors = new Set<number>();
+
+  for (const sc of allScorecards) {
+    competitorDivision.set(sc.competitor_id, sc.competitor_division);
+    if (sc.dq) dqCompetitors.add(sc.competitor_id);
+    if (sc.dnf || sc.dq || sc.zeroed) continue;
+    if (sc.hit_factor == null || sc.hit_factor <= 0) continue;
+    if (sc.max_points == null || sc.max_points <= 0) continue;
+
+    const overallWinner = overallStageWinnerHF.get(sc.stage_id) ?? 0;
+    if (overallWinner > 0) {
+      const pts = (sc.hit_factor / overallWinner) * sc.max_points;
+      overallMatchPts.set(
+        sc.competitor_id,
+        (overallMatchPts.get(sc.competitor_id) ?? 0) + pts,
+      );
+    }
+
+    if (sc.competitor_division) {
+      const divWinner =
+        divStageWinnerHF.get(`${sc.competitor_division}::${sc.stage_id}`) ?? 0;
+      if (divWinner > 0) {
+        const pts = (sc.hit_factor / divWinner) * sc.max_points;
+        divisionMatchPts.set(
+          sc.competitor_id,
+          (divisionMatchPts.get(sc.competitor_id) ?? 0) + pts,
+        );
+      }
+    }
+  }
+
+  // Reduce to per-division leaders and the overall leader.
+  const divisionLeaderMatchPts: Record<string, number> = {};
+  for (const [compId, pts] of divisionMatchPts) {
+    if (dqCompetitors.has(compId)) continue;
+    const div = competitorDivision.get(compId);
+    if (!div) continue;
+    if (pts > (divisionLeaderMatchPts[div] ?? 0)) {
+      divisionLeaderMatchPts[div] = pts;
+    }
+  }
+
+  let overallLeaderMatchPts: number | null = null;
+  for (const [compId, pts] of overallMatchPts) {
+    if (dqCompetitors.has(compId)) continue;
+    if (overallLeaderMatchPts == null || pts > overallLeaderMatchPts) {
+      overallLeaderMatchPts = pts;
+    }
+  }
+
+  return { divisionLeaderMatchPts, overallLeaderMatchPts };
+}
+
+/**
  * Compute percentile placement for a competitor within a ranked field.
  *   percentile = 1 − (rank − 1) / (N − 1)
  * where rank is 1-indexed (1 = best) and N = total ranked (non-DNF) competitors.

--- a/app/api/compare/logic.ts
+++ b/app/api/compare/logic.ts
@@ -102,21 +102,37 @@ function pct(hf: number | null, leaderHF: number | null): number | null {
 }
 
 /**
+ * Match rank within some reference field. `total` is the size of the field
+ * (excluding DQ'd competitors). Ties share the same rank; the next rank skips
+ * accordingly (1, 1, 3, 4 …).
+ */
+export interface MatchRank {
+  rank: number;
+  total: number;
+}
+
+/**
  * IPSC match-point totals across all stages for a match.
  *
  * For each (competitor, stage), `stage_points = (HF / division_stage_winner_HF) × stage.max_points`.
  * Sum per competitor → match points. Returns the highest match-points figure
  * within each division and across the full field — the anchors that define
- * 100% in division and overall mode respectively.
+ * 100% in division and overall mode respectively — plus per-competitor match
+ * ranks within division and across the full field.
  *
  * A competitor with any DQ scorecard (whole-match DQ in IPSC) is excluded
- * from the leader pool. DNF / zeroed stages contribute 0 stage points.
+ * from the leader pool and the rank maps. DNF / zeroed stages contribute 0
+ * stage points.
  */
 export function computeMatchPointTotals(allScorecards: RawScorecard[]): {
   /** division string → leader's total IPSC match points (max across the division). */
   divisionLeaderMatchPts: Record<string, number>;
   /** Highest match-points figure across the full field (any division). Null when no valid data. */
   overallLeaderMatchPts: number | null;
+  /** competitor_id → rank within their own division (1 = leader). DQ'd competitors are absent. */
+  divisionMatchRanks: Record<number, MatchRank>;
+  /** competitor_id → rank across the full field (1 = leader). DQ'd competitors are absent. */
+  overallMatchRanks: Record<number, MatchRank>;
 } {
   // Per-stage division winner HF (excludes DNF/DQ/zeroed and ≤0 HF cards).
   // Keyed by `${division}::${stageId}`.
@@ -177,26 +193,75 @@ export function computeMatchPointTotals(allScorecards: RawScorecard[]): {
     }
   }
 
-  // Reduce to per-division leaders and the overall leader.
+  // Reduce to per-division leaders and the overall leader, and rank every
+  // non-DQ competitor by match points within division and across the field.
   const divisionLeaderMatchPts: Record<string, number> = {};
+  const overallLeaderMatchPts = rankAndCollect(
+    overallMatchPts,
+    dqCompetitors,
+    null,
+  );
+  const overallMatchRanks = buildMatchRanks(overallMatchPts, dqCompetitors);
+
+  // Build per-division rank maps: bucket competitors by their division, then rank.
+  const byDivision = new Map<string, Map<number, number>>();
   for (const [compId, pts] of divisionMatchPts) {
-    if (dqCompetitors.has(compId)) continue;
     const div = competitorDivision.get(compId);
     if (!div) continue;
-    if (pts > (divisionLeaderMatchPts[div] ?? 0)) {
-      divisionLeaderMatchPts[div] = pts;
+    if (!byDivision.has(div)) byDivision.set(div, new Map());
+    byDivision.get(div)!.set(compId, pts);
+  }
+  const divisionMatchRanks: Record<number, MatchRank> = {};
+  for (const [div, divPts] of byDivision) {
+    const leader = rankAndCollect(divPts, dqCompetitors, null);
+    if (leader != null) divisionLeaderMatchPts[div] = leader;
+    const ranks = buildMatchRanks(divPts, dqCompetitors);
+    for (const [compId, mr] of Object.entries(ranks)) {
+      divisionMatchRanks[Number(compId)] = mr;
     }
   }
 
-  let overallLeaderMatchPts: number | null = null;
-  for (const [compId, pts] of overallMatchPts) {
-    if (dqCompetitors.has(compId)) continue;
-    if (overallLeaderMatchPts == null || pts > overallLeaderMatchPts) {
-      overallLeaderMatchPts = pts;
-    }
-  }
+  return {
+    divisionLeaderMatchPts,
+    overallLeaderMatchPts,
+    divisionMatchRanks,
+    overallMatchRanks,
+  };
+}
 
-  return { divisionLeaderMatchPts, overallLeaderMatchPts };
+/** Find the highest match-points value, ignoring DQ'd competitors. */
+function rankAndCollect(
+  pointsMap: Map<number, number>,
+  dq: Set<number>,
+  init: number | null,
+): number | null {
+  let best = init;
+  for (const [compId, pts] of pointsMap) {
+    if (dq.has(compId)) continue;
+    if (best == null || pts > best) best = pts;
+  }
+  return best;
+}
+
+/**
+ * Rank competitors by match points descending. Ties share a rank, the next
+ * rank skips accordingly (1, 1, 3, 4 …). DQ'd competitors are excluded from
+ * both the rank assignment and the `total` count.
+ */
+function buildMatchRanks(
+  pointsMap: Map<number, number>,
+  dq: Set<number>,
+): Record<number, MatchRank> {
+  const entries = [...pointsMap.entries()].filter(([id]) => !dq.has(id));
+  entries.sort((a, b) => b[1] - a[1]);
+  const total = entries.length;
+  const out: Record<number, MatchRank> = {};
+  let currentRank = 1;
+  for (let i = 0; i < entries.length; i++) {
+    if (i > 0 && entries[i][1] < entries[i - 1][1]) currentRank = i + 1;
+    out[entries[i][0]] = { rank: currentRank, total };
+  }
+  return out;
 }
 
 /**

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -11,7 +11,7 @@ import { isUpstreamDegraded } from "@/lib/upstream-status";
 import { afterResponse } from "@/lib/background-impl";
 
 import { extractDivision } from "@/lib/divisions";
-import { computeGroupRankings, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance, computeStageDegradationData } from "@/app/api/compare/logic";
+import { computeGroupRankings, computeMatchPointTotals, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance, computeStageDegradationData } from "@/app/api/compare/logic";
 import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
 import { decodeShooterId, indexMatchShooters } from "@/lib/shooter-index";
 import type { CompareMode, CompareResponse, CompetitorInfo, FieldFingerprintPoint, StageComparison, StageConditions } from "@/lib/types";
@@ -387,6 +387,9 @@ export async function GET(req: Request) {
 
   const tRankings = performance.now();
 
+  const { divisionLeaderMatchPts, overallLeaderMatchPts } =
+    computeMatchPointTotals(rawScorecards);
+
   const penaltyStats = Object.fromEntries(
     requestedCompetitors.map((c) => [c.id, computePenaltyStats(stages, c.id)])
   );
@@ -593,6 +596,8 @@ export async function GET(req: Request) {
     stageDegradationData,
     stageConditions,
     ...(scorecardsRestricted ? { scorecardsRestricted: true } : {}),
+    divisionLeaderMatchPts,
+    overallLeaderMatchPts,
     cacheInfo,
   };
 

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -387,8 +387,12 @@ export async function GET(req: Request) {
 
   const tRankings = performance.now();
 
-  const { divisionLeaderMatchPts, overallLeaderMatchPts } =
-    computeMatchPointTotals(rawScorecards);
+  const {
+    divisionLeaderMatchPts,
+    overallLeaderMatchPts,
+    divisionMatchRanks,
+    overallMatchRanks,
+  } = computeMatchPointTotals(rawScorecards);
 
   const penaltyStats = Object.fromEntries(
     requestedCompetitors.map((c) => [c.id, computePenaltyStats(stages, c.id)])
@@ -598,6 +602,8 @@ export async function GET(req: Request) {
     ...(scorecardsRestricted ? { scorecardsRestricted: true } : {}),
     divisionLeaderMatchPts,
     overallLeaderMatchPts,
+    divisionMatchRanks,
+    overallMatchRanks,
     cacheInfo,
   };
 

--- a/app/api/shooter/[shooterId]/route.ts
+++ b/app/api/shooter/[shooterId]/route.ts
@@ -10,6 +10,7 @@ import type { ShooterProfile } from "@/lib/shooter-index";
 import { parseRawScorecards } from "@/lib/scorecard-data";
 import { extractDivision } from "@/lib/divisions";
 import { computeAggregateStats } from "@/lib/shooter-stats";
+import { computeMatchStats } from "@/lib/match-stats";
 import { evaluateAchievements } from "@/lib/achievements/evaluate";
 import { maybeTagAsMcp } from "@/lib/telemetry-context";
 import type {
@@ -18,7 +19,6 @@ import type {
   UpcomingMatch,
 } from "@/lib/types";
 import type { RawScorecardsData } from "@/lib/scorecard-data";
-import type { RawScorecard } from "@/app/api/compare/logic";
 
 /** Dashboard result TTL — 5 minutes. */
 const DASHBOARD_TTL = 300;
@@ -158,141 +158,6 @@ function resolveShooterStatus(
     (s) => s.competitors?.some((sc) => sc.id === competitor.id) ?? false,
   );
   return { ...base, competitorId, isRegistered: true, isSquadded };
-}
-
-// ─── Computation helpers ──────────────────────────────────────────────────────
-
-/**
- * Compute per-match summary for one shooter from raw scorecard data.
- * Returns avgHF, matchPct, and hit-zone totals.
- */
-function computeMatchStats(
-  competitorId: number,
-  division: string | null,
-  rawScorecards: RawScorecard[],
-): {
-  stageCount: number;
-  avgHF: number | null;
-  matchPct: number | null;
-  totalA: number;
-  totalC: number;
-  totalD: number;
-  totalMiss: number;
-  totalNoShoots: number;
-  totalProcedurals: number;
-  dq: boolean;
-  perfectStages: number;
-  consistencyIndex: number | null;
-} {
-  const myCards = rawScorecards.filter(
-    (sc) =>
-      sc.competitor_id === competitorId &&
-      !sc.dnf &&
-      !sc.dq &&
-      !sc.zeroed &&
-      sc.hit_factor != null &&
-      sc.hit_factor >= 0,
-  );
-
-  const stageCount = myCards.length;
-  if (stageCount === 0) {
-    return {
-      stageCount: 0,
-      avgHF: null,
-      matchPct: null,
-      totalA: 0,
-      totalC: 0,
-      totalD: 0,
-      totalMiss: 0,
-      totalNoShoots: 0,
-      totalProcedurals: 0,
-      dq: false,
-      perfectStages: 0,
-      consistencyIndex: null,
-    };
-  }
-
-  const hfSum = myCards.reduce((s, sc) => s + (sc.hit_factor ?? 0), 0);
-  const avgHF = hfSum / stageCount;
-
-  // Consistency index: (1 - CV) * 100 where CV = stddev(stageHFs) / mean(stageHFs)
-  let consistencyIndex: number | null = null;
-  const hfs = myCards
-    .map((sc) => sc.hit_factor ?? 0)
-    .filter((hf) => hf > 0);
-  if (hfs.length >= 2) {
-    const mean = hfs.reduce((s, v) => s + v, 0) / hfs.length;
-    if (mean > 0) {
-      const variance =
-        hfs.reduce((s, v) => s + (v - mean) ** 2, 0) / hfs.length;
-      consistencyIndex = (1 - Math.sqrt(variance) / mean) * 100;
-    }
-  }
-
-  // Compute division-based match %
-  const stagePcts: number[] = [];
-  if (division) {
-    for (const card of myCards) {
-      // Find division leader HF for this stage
-      const divCards = rawScorecards.filter(
-        (sc) =>
-          sc.stage_id === card.stage_id &&
-          !sc.dnf &&
-          !sc.dq &&
-          !sc.zeroed &&
-          sc.hit_factor != null &&
-          sc.competitor_division === card.competitor_division,
-      );
-      const leaderHF = divCards.reduce(
-        (max, sc) => Math.max(max, sc.hit_factor ?? 0),
-        0,
-      );
-      if (leaderHF > 0 && card.hit_factor != null) {
-        stagePcts.push((card.hit_factor / leaderHF) * 100);
-      }
-    }
-  }
-  const matchPct =
-    stagePcts.length > 0
-      ? stagePcts.reduce((a, b) => a + b, 0) / stagePcts.length
-      : null;
-
-  // Hit-zone totals
-  const totalA = myCards.reduce((s, sc) => s + (sc.a_hits ?? 0), 0);
-  const totalC = myCards.reduce((s, sc) => s + (sc.c_hits ?? 0), 0);
-  const totalD = myCards.reduce((s, sc) => s + (sc.d_hits ?? 0), 0);
-  const totalMiss = myCards.reduce((s, sc) => s + (sc.miss_count ?? 0), 0);
-  const totalNoShoots = myCards.reduce((s, sc) => s + (sc.no_shoots ?? 0), 0);
-  const totalProcedurals = myCards.reduce((s, sc) => s + (sc.procedurals ?? 0), 0);
-  const dq = rawScorecards.some(
-    (sc) => sc.competitor_id === competitorId && sc.dq,
-  );
-
-  // Perfect stages: all A-hits, no C/D/miss/no-shoot/procedural, and at least one A-hit
-  const perfectStages = myCards.filter(
-    (sc) =>
-      (sc.a_hits ?? 0) > 0 &&
-      (sc.c_hits ?? 0) === 0 &&
-      (sc.d_hits ?? 0) === 0 &&
-      (sc.miss_count ?? 0) === 0 &&
-      (sc.no_shoots ?? 0) === 0 &&
-      (sc.procedurals ?? 0) === 0,
-  ).length;
-
-  return {
-    stageCount,
-    avgHF,
-    matchPct,
-    totalA,
-    totalC,
-    totalD,
-    totalMiss,
-    totalNoShoots,
-    totalProcedurals,
-    dq,
-    perfectStages,
-    consistencyIndex,
-  };
 }
 
 // ─── Route handler ────────────────────────────────────────────────────────────

--- a/components/cell-help-modal.tsx
+++ b/components/cell-help-modal.tsx
@@ -321,8 +321,8 @@ function SummaryRowDiagram() {
             </span>
           }
           badge="B"
-          title="Average percentage"
-          description="Average of this competitor's stage percentages — an overall match quality number. The label above the table changes with Group / Division / Overall mode."
+          title="Match percentage"
+          description="Official IPSC match percentage: stage points are weighted by stage size (longer stages count more), then summed and divided by the leader's total. In Group mode the anchor is the highest-scoring selected competitor, so one of them always lands on 100%. In Division / Overall mode the anchor is the full-division or full-field leader."
         />
         <DiagramRow
           visual={

--- a/components/cell-help-modal.tsx
+++ b/components/cell-help-modal.tsx
@@ -321,8 +321,8 @@ function SummaryRowDiagram() {
             </span>
           }
           badge="B"
-          title="Match percentage"
-          description="Official IPSC match percentage: stage points are weighted by stage size (longer stages count more), then summed and divided by the leader's total. In Group mode the anchor is the highest-scoring selected competitor, so one of them always lands on 100%. In Division / Overall mode the anchor is the full-division or full-field leader."
+          title="Match rank + percentage"
+          description="The medal/badge shows the competitor's overall match rank in the current mode (1 of N in your group, in their division, or across the full field). The percentage is the official IPSC match percentage: stage points are weighted by stage size (longer stages count more), then summed and divided by the leader's total. In Group mode the anchor is the highest-scoring selected competitor, so one of them always lands on rank 1 / 100%. In Division / Overall mode the anchor is the full-division or full-field leader."
         />
         <DiagramRow
           visual={

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -1110,8 +1110,30 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
     };
   });
 
-  // Resolve the mode-specific anchor (= 100% reference) for each competitor.
+  // Resolve the mode-specific anchor (= 100% reference) for each competitor,
+  // and the mode-specific match rank.
+  //
+  //   group   → highest match_pts among the selected competitors;
+  //             one of them always lands on rank 1 / 100%
+  //   division→ divisionLeaderMatchPts[<comp.division>], with rank/total from
+  //             the server-computed divisionMatchRanks (full division field)
+  //   overall → overallLeaderMatchPts, with rank/total from overallMatchRanks
+  //             (full match field, all divisions)
   const groupAnchor = Math.max(0, ...totalsRaw.map((t) => t.matchPts ?? 0));
+  // Pre-compute group ranks (1 = highest matchPts within the selection; ties share a rank).
+  const groupRankMap = new Map<number, { rank: number; total: number }>();
+  {
+    const ranked = [...totalsRaw]
+      .filter((t) => t.matchPts != null)
+      .sort((a, b) => (b.matchPts ?? 0) - (a.matchPts ?? 0));
+    let currentRank = 1;
+    for (let i = 0; i < ranked.length; i++) {
+      if (i > 0 && (ranked[i].matchPts ?? 0) < (ranked[i - 1].matchPts ?? 0)) {
+        currentRank = i + 1;
+      }
+      groupRankMap.set(ranked[i].id, { rank: currentRank, total: ranked.length });
+    }
+  }
   const totals = totalsRaw.map((t) => {
     let matchPct: number | null = null;
     if (t.matchPts != null && t.hasMaxPoints) {
@@ -1128,7 +1150,18 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
     }
     // Fallback for older cache entries lacking stage.max_points.
     if (matchPct == null) matchPct = t.avgPctFallback;
-    return { ...t, matchPct };
+
+    // Match rank (mode-aware).
+    let matchRank: { rank: number; total: number } | null = null;
+    if (mode === "group") {
+      matchRank = groupRankMap.get(t.id) ?? null;
+    } else if (mode === "division") {
+      matchRank = data.divisionMatchRanks?.[t.id] ?? null;
+    } else if (mode === "overall") {
+      matchRank = data.overallMatchRanks?.[t.id] ?? null;
+    }
+
+    return { ...t, matchPct, matchRank };
   });
 
   return (
@@ -1662,9 +1695,21 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
                           <span className="text-muted-foreground font-normal">—</span>
                         )}
                       </span>
-                      <span className="text-xs text-muted-foreground font-normal">
-                        {t.matchPct != null ? formatPct(t.matchPct) : "—"}
-                      </span>
+                      <div className="flex items-center gap-1">
+                        {t.matchRank != null && (
+                          <RankBadge
+                            rank={t.matchRank.rank}
+                            tooltip={matchRankTooltip(
+                              t.matchRank,
+                              mode,
+                              competitors.find((c) => c.id === t.id)?.division ?? null,
+                            )}
+                          />
+                        )}
+                        <span className="text-xs text-muted-foreground font-normal">
+                          {t.matchPct != null ? formatPct(t.matchPct) : "—"}
+                        </span>
+                      </div>
                       <HitZoneBar
                         aHits={t.aHits}
                         cHits={t.cHits}
@@ -2057,6 +2102,23 @@ function rankTooltip(
         : `Rank ${rank} in division (full field)`;
     case "overall":
       return `Rank ${rank} overall (all divisions)`;
+  }
+}
+
+function matchRankTooltip(
+  mr: { rank: number; total: number },
+  mode: PctMode,
+  divisionName: string | null,
+): string {
+  switch (mode) {
+    case "group":
+      return `Match rank ${mr.rank} of ${mr.total} in your group`;
+    case "division":
+      return divisionName
+        ? `Match rank ${mr.rank} of ${mr.total} in ${divisionName}`
+        : `Match rank ${mr.rank} of ${mr.total} in division`;
+    case "overall":
+      return `Match rank ${mr.rank} of ${mr.total} overall`;
   }
 }
 

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -1004,11 +1004,25 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
       : "";
   }, [stageSort, competitors]);
 
-  // Compute totals per competitor: total raw points, average %, zone/penalty sums, and clean match status
-  const totals = competitors.map((comp) => {
+  // Compute totals per competitor: total raw points, IPSC match %, zone/penalty sums, and clean match status.
+  //
+  // Match % follows the official IPSC points-weighted formula (matches shootnscoreit.com):
+  //   stage_points = (HF / mode_stage_winner_HF) × stage.max_points
+  //   match_points = sum across stages
+  //   matchPct     = match_points / mode_leader_match_points × 100
+  // The numerator uses each stage's `pct` from the response (already encodes the
+  // mode-relevant stage winner). The denominator depends on mode:
+  //   - group mode    → the highest match_points among the *selected* competitors
+  //                     (so the group leader always lands on 100%)
+  //   - division mode → divisionLeaderMatchPts[competitor.division] (full division)
+  //   - overall mode  → overallLeaderMatchPts (full field)
+  const totalsRaw = competitors.map((comp) => {
     let totalPts = 0;
+    let matchPts = 0;
     let pctSum = 0;
     let pctCount = 0;
+    let hasMaxPoints = true;
+    let rawDivision: string | null = null;
     let hasFired = false;
     let firedCount = 0;
     let aTotal = 0, cTotal = 0, dTotal = 0, mTotal = 0;
@@ -1037,10 +1051,16 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
       hasFired = true;
       firedCount++;
       totalPts += sc.points ?? 0;
+      if (rawDivision == null && sc.divisionKey) rawDivision = sc.divisionKey;
       const { pct } = modeValues(sc, mode);
       if (pct != null) {
         pctSum += pct;
         pctCount++;
+        if (stage.max_points > 0) {
+          matchPts += (pct / 100) * stage.max_points;
+        } else {
+          hasMaxPoints = false;
+        }
       }
       if (sc.a_hits !== null || sc.c_hits !== null || sc.d_hits !== null || sc.miss_count !== null) {
         hasZoneData = true;
@@ -1069,7 +1089,10 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
     return {
       id: comp.id,
       points: hasFired ? totalPts : null,
-      avgPct: pctCount > 0 ? pctSum / pctCount : null,
+      matchPts: pctCount > 0 ? matchPts : null,
+      avgPctFallback: pctCount > 0 ? pctSum / pctCount : null,
+      hasMaxPoints,
+      rawDivision,
       aHits: hasZoneData ? aTotal : null,
       cHits: hasZoneData ? cTotal : null,
       dHits: hasZoneData ? dTotal : null,
@@ -1085,6 +1108,27 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
       overpushCount,
       meltdownCount,
     };
+  });
+
+  // Resolve the mode-specific anchor (= 100% reference) for each competitor.
+  const groupAnchor = Math.max(0, ...totalsRaw.map((t) => t.matchPts ?? 0));
+  const totals = totalsRaw.map((t) => {
+    let matchPct: number | null = null;
+    if (t.matchPts != null && t.hasMaxPoints) {
+      let anchor: number | null = null;
+      if (mode === "group") anchor = groupAnchor;
+      else if (mode === "division" && t.rawDivision) {
+        anchor = data.divisionLeaderMatchPts?.[t.rawDivision] ?? null;
+      } else if (mode === "overall") {
+        anchor = data.overallLeaderMatchPts ?? null;
+      }
+      if (anchor != null && anchor > 0) {
+        matchPct = (t.matchPts / anchor) * 100;
+      }
+    }
+    // Fallback for older cache entries lacking stage.max_points.
+    if (matchPct == null) matchPct = t.avgPctFallback;
+    return { ...t, matchPct };
   });
 
   return (
@@ -1586,7 +1630,7 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
                 ) : (
                   <>
                     <div>Total pts</div>
-                    <div>Avg {MODE_LABELS[mode]} %</div>
+                    <div>{MODE_LABELS[mode]} %</div>
                     <div>pts/shot</div>
                   </>
                 )}
@@ -1619,7 +1663,7 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
                         )}
                       </span>
                       <span className="text-xs text-muted-foreground font-normal">
-                        {t.avgPct != null ? formatPct(t.avgPct) : "—"}
+                        {t.matchPct != null ? formatPct(t.matchPct) : "—"}
                       </span>
                       <HitZoneBar
                         aHits={t.aHits}

--- a/lib/match-stats.ts
+++ b/lib/match-stats.ts
@@ -1,0 +1,211 @@
+// Pure functions for per-match shooter statistics. No I/O, fully unit-tested.
+
+import type { RawScorecard } from "@/app/api/compare/logic";
+
+export interface MatchStats {
+  stageCount: number;
+  avgHF: number | null;
+  matchPct: number | null;
+  totalA: number;
+  totalC: number;
+  totalD: number;
+  totalMiss: number;
+  totalNoShoots: number;
+  totalProcedurals: number;
+  dq: boolean;
+  perfectStages: number;
+  consistencyIndex: number | null;
+}
+
+/**
+ * Compute per-match summary for one shooter from raw scorecard data.
+ *
+ * `matchPct` mirrors the official IPSC formula used by ShootNScoreIt:
+ *
+ *   stage_points = (competitor_HF / division_stage_winner_HF) × stage.max_points
+ *   match_points = sum over all valid stages
+ *   matchPct     = (my_match_points / division_leader_match_points) × 100
+ *
+ * Stage length matters (longer stages are worth more points), which matches
+ * the rank/percentage shown on shootnscoreit.com.
+ *
+ * Falls back to a simple average-of-stage-percentages when stage `max_points`
+ * is missing on any of the shooter's stages — keeps older cache entries
+ * (written before stage `max_points` was captured) usable.
+ */
+export function computeMatchStats(
+  competitorId: number,
+  division: string | null,
+  rawScorecards: RawScorecard[],
+): MatchStats {
+  const myCards = rawScorecards.filter(
+    (sc) =>
+      sc.competitor_id === competitorId &&
+      !sc.dnf &&
+      !sc.dq &&
+      !sc.zeroed &&
+      sc.hit_factor != null &&
+      sc.hit_factor >= 0,
+  );
+
+  const stageCount = myCards.length;
+  if (stageCount === 0) {
+    return {
+      stageCount: 0,
+      avgHF: null,
+      matchPct: null,
+      totalA: 0,
+      totalC: 0,
+      totalD: 0,
+      totalMiss: 0,
+      totalNoShoots: 0,
+      totalProcedurals: 0,
+      dq: rawScorecards.some(
+        (sc) => sc.competitor_id === competitorId && sc.dq,
+      ),
+      perfectStages: 0,
+      consistencyIndex: null,
+    };
+  }
+
+  const hfSum = myCards.reduce((s, sc) => s + (sc.hit_factor ?? 0), 0);
+  const avgHF = hfSum / stageCount;
+
+  // Consistency index: (1 - CV) * 100 where CV = stddev(stageHFs) / mean(stageHFs)
+  let consistencyIndex: number | null = null;
+  const hfs = myCards
+    .map((sc) => sc.hit_factor ?? 0)
+    .filter((hf) => hf > 0);
+  if (hfs.length >= 2) {
+    const mean = hfs.reduce((s, v) => s + v, 0) / hfs.length;
+    if (mean > 0) {
+      const variance =
+        hfs.reduce((s, v) => s + (v - mean) ** 2, 0) / hfs.length;
+      consistencyIndex = (1 - Math.sqrt(variance) / mean) * 100;
+    }
+  }
+
+  const matchPct = computeMatchPercent(competitorId, division, rawScorecards, myCards);
+
+  // Hit-zone totals
+  const totalA = myCards.reduce((s, sc) => s + (sc.a_hits ?? 0), 0);
+  const totalC = myCards.reduce((s, sc) => s + (sc.c_hits ?? 0), 0);
+  const totalD = myCards.reduce((s, sc) => s + (sc.d_hits ?? 0), 0);
+  const totalMiss = myCards.reduce((s, sc) => s + (sc.miss_count ?? 0), 0);
+  const totalNoShoots = myCards.reduce((s, sc) => s + (sc.no_shoots ?? 0), 0);
+  const totalProcedurals = myCards.reduce((s, sc) => s + (sc.procedurals ?? 0), 0);
+  const dq = rawScorecards.some(
+    (sc) => sc.competitor_id === competitorId && sc.dq,
+  );
+
+  // Perfect stages: all A-hits, no C/D/miss/no-shoot/procedural, and at least one A-hit
+  const perfectStages = myCards.filter(
+    (sc) =>
+      (sc.a_hits ?? 0) > 0 &&
+      (sc.c_hits ?? 0) === 0 &&
+      (sc.d_hits ?? 0) === 0 &&
+      (sc.miss_count ?? 0) === 0 &&
+      (sc.no_shoots ?? 0) === 0 &&
+      (sc.procedurals ?? 0) === 0,
+  ).length;
+
+  return {
+    stageCount,
+    avgHF,
+    matchPct,
+    totalA,
+    totalC,
+    totalD,
+    totalMiss,
+    totalNoShoots,
+    totalProcedurals,
+    dq,
+    perfectStages,
+    consistencyIndex,
+  };
+}
+
+function computeMatchPercent(
+  competitorId: number,
+  division: string | null,
+  rawScorecards: RawScorecard[],
+  myCards: RawScorecard[],
+): number | null {
+  if (!division || myCards.length === 0) return null;
+
+  // If any of the shooter's stages is missing max_points (older cache entries),
+  // we cannot compute IPSC points — fall back to the simple average.
+  const hasMaxPoints = myCards.every(
+    (sc) => sc.max_points != null && sc.max_points > 0,
+  );
+  if (!hasMaxPoints) return averageStagePercent(division, rawScorecards, myCards);
+
+  // Per-stage division winner HF (excludes DNF/DQ/zeroed and zero-HF cards).
+  const stageWinnerHF = new Map<number, number>();
+  for (const sc of rawScorecards) {
+    if (sc.competitor_division !== division) continue;
+    if (sc.dnf || sc.dq || sc.zeroed) continue;
+    if (sc.hit_factor == null || sc.hit_factor <= 0) continue;
+    const cur = stageWinnerHF.get(sc.stage_id) ?? 0;
+    if (sc.hit_factor > cur) stageWinnerHF.set(sc.stage_id, sc.hit_factor);
+  }
+
+  // Sum match points per division competitor.
+  // A competitor with any DQ scorecard is excluded from the leader pool
+  // (a stage DQ = whole-match DQ in IPSC).
+  const matchPoints = new Map<number, number>();
+  const dqCompetitors = new Set<number>();
+  for (const sc of rawScorecards) {
+    if (sc.competitor_division !== division) continue;
+    if (sc.dq) dqCompetitors.add(sc.competitor_id);
+    if (sc.dnf || sc.dq || sc.zeroed) continue;
+    if (sc.hit_factor == null || sc.hit_factor <= 0) continue;
+    if (sc.max_points == null || sc.max_points <= 0) continue;
+    const winner = stageWinnerHF.get(sc.stage_id) ?? 0;
+    if (winner <= 0) continue;
+    const pts = (sc.hit_factor / winner) * sc.max_points;
+    matchPoints.set(
+      sc.competitor_id,
+      (matchPoints.get(sc.competitor_id) ?? 0) + pts,
+    );
+  }
+
+  let leaderPoints = 0;
+  for (const [compId, pts] of matchPoints) {
+    if (dqCompetitors.has(compId)) continue;
+    if (pts > leaderPoints) leaderPoints = pts;
+  }
+
+  const myPoints = matchPoints.get(competitorId) ?? 0;
+  if (leaderPoints <= 0 || myPoints <= 0) return null;
+  return (myPoints / leaderPoints) * 100;
+}
+
+function averageStagePercent(
+  division: string,
+  rawScorecards: RawScorecard[],
+  myCards: RawScorecard[],
+): number | null {
+  const stagePcts: number[] = [];
+  for (const card of myCards) {
+    const divCards = rawScorecards.filter(
+      (sc) =>
+        sc.stage_id === card.stage_id &&
+        !sc.dnf &&
+        !sc.dq &&
+        !sc.zeroed &&
+        sc.hit_factor != null &&
+        sc.competitor_division === division,
+    );
+    const leaderHF = divCards.reduce(
+      (max, sc) => Math.max(max, sc.hit_factor ?? 0),
+      0,
+    );
+    if (leaderHF > 0 && card.hit_factor != null) {
+      stagePcts.push((card.hit_factor / leaderHF) * 100);
+    }
+  }
+  return stagePcts.length > 0
+    ? stagePcts.reduce((a, b) => a + b, 0) / stagePcts.length
+    : null;
+}

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -11,11 +11,26 @@ import type { Release } from "@/lib/types";
  * differs from the value stored in localStorage("whats-new-seen-id").
  */
 /** The `id` of the newest release. Used by e2e tests to suppress the What's New dialog. */
-export const LATEST_RELEASE_ID = "2026-04-28-competitor-selection";
+export const LATEST_RELEASE_ID = "2026-04-28-ipsc-match-percent";
 
 export const RELEASES: Release[] = [
   {
     id: LATEST_RELEASE_ID,
+    date: "April 28, 2026",
+    title: "Match % now matches SSI",
+    screenshotScenes: ["comparison-table", "shooter-dashboard"],
+    sections: [
+      {
+        heading: "Improved",
+        items: [
+          "Match percentage now uses the official IPSC points-weighted formula — longer stages count more — so the number on your shooter dashboard match cards matches what shootnscoreit.com shows.",
+          "Comparison-table totals row also uses the same formula. In Group mode the highest-scoring selected competitor lands on 100%; in Division and Overall mode the anchor is the full-division or full-field leader.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "2026-04-28-competitor-selection",
     date: "April 28, 2026",
     title: "Faster competitor selection",
     screenshotScenes: ["comparison-table", "tracked-shooters-sheet"],

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -17,7 +17,7 @@ export const RELEASES: Release[] = [
   {
     id: LATEST_RELEASE_ID,
     date: "April 28, 2026",
-    title: "Match % now matches SSI",
+    title: "Match % and rank now match SSI",
     screenshotScenes: ["comparison-table", "shooter-dashboard"],
     sections: [
       {
@@ -25,6 +25,12 @@ export const RELEASES: Release[] = [
         items: [
           "Match percentage now uses the official IPSC points-weighted formula — longer stages count more — so the number on your shooter dashboard match cards matches what shootnscoreit.com shows.",
           "Comparison-table totals row also uses the same formula. In Group mode the highest-scoring selected competitor lands on 100%; in Division and Overall mode the anchor is the full-division or full-field leader.",
+        ],
+      },
+      {
+        heading: "New",
+        items: [
+          "Match rank badge in the comparison-table totals row — the same gold/silver/bronze medal style as the per-stage rank, but for the overall match standing in the current view (Group / Division / Overall).",
         ],
       },
     ],

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -558,6 +558,15 @@ export interface CompareResponse {
    */
   divisionLeaderMatchPts?: Record<string, number>;
   overallLeaderMatchPts?: number | null;
+  /**
+   * Per-competitor match ranks (1 = leader). Keys are competitor IDs; values
+   * carry the rank and the size of the reference field (excluding DQs) so the
+   * UI can show "5 of 87". DQ'd competitors are absent. Used by the
+   * comparison-table totals row to render a medal/rank badge alongside the
+   * match %.
+   */
+  divisionMatchRanks?: Record<number, { rank: number; total: number }>;
+  overallMatchRanks?: Record<number, { rank: number; total: number }>;
   cacheInfo: CacheInfo;
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -547,6 +547,17 @@ export interface CompareResponse {
    * The client should show a clear notice instead of an empty comparison.
    */
   scorecardsRestricted?: boolean;
+  /**
+   * IPSC match-point totals (anchors for division and overall match %):
+   *   stage_points = (HF / division_stage_winner_HF) × stage.max_points
+   *   match_points = sum across stages
+   * The map is keyed by division string; values are the leader's total match
+   * points within that division. `overallLeaderMatchPts` is the same figure
+   * across the full field. The comparison-table totals row uses these as
+   * denominators when computing each selected competitor's match %.
+   */
+  divisionLeaderMatchPts?: Record<string, number>;
+  overallLeaderMatchPts?: number | null;
   cacheInfo: CacheInfo;
 }
 
@@ -749,7 +760,15 @@ export interface ShooterMatchSummary {
   stageCount: number;
   /** Mean hit factor across valid stages. Null if no valid stages. */
   avgHF: number | null;
-  /** Mean division % across valid stages (0–100). Null if no scorecards cached. */
+  /**
+   * Official IPSC match percentage within the shooter's division (0–100):
+   * (my_match_points / division_leader_match_points) × 100, where
+   * stage_points = (HF / division_stage_winner_HF) × stage.max_points.
+   * Mirrors the percentage shown on shootnscoreit.com. Null when the shooter
+   * has no valid scorecards or division is unknown. Falls back to a simple
+   * average of per-stage division percentages when stage max_points is
+   * missing on older cached entries.
+   */
   matchPct: number | null;
   /** Raw hit-zone totals across all valid stages. */
   totalA: number;

--- a/tests/unit/compare-logic.test.ts
+++ b/tests/unit/compare-logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeGroupRankings, computePenaltyStats, assignDifficulty, assignSeparatorLevels, computePercentile, computePercentileRank, assignArchetype, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, computeQuartiles, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance, computeStageDegradationData, tCritical95, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
+import { computeGroupRankings, computeMatchPointTotals, computePenaltyStats, assignDifficulty, assignSeparatorLevels, computePercentile, computePercentileRank, assignArchetype, computeCompetitorPPS, computeFieldPPSDistribution, classifyStageRun, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, computeQuartiles, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance, computeStageDegradationData, tCritical95, STAGE_CLASS_THRESHOLDS, type RawScorecard } from "@/app/api/compare/logic";
 import type { CompetitorInfo, StageComparison } from "@/lib/types";
 
 const competitors: CompetitorInfo[] = [
@@ -3169,5 +3169,87 @@ describe("tCritical95", () => {
   it("returns Infinity for df <= 0", () => {
     expect(tCritical95(0)).toBe(Infinity);
     expect(tCritical95(-1)).toBe(Infinity);
+  });
+});
+
+describe("computeMatchPointTotals — IPSC points anchors", () => {
+  it("returns the highest match-points figure within each division", () => {
+    // Two divisions, two stages each. Stage points = (HF / div_winner_HF) × max_points.
+    //
+    //   hg1 stage 1: A=5 (winner), C=4   → max_points=50
+    //   hg1 stage 2: A=4, C=6 (winner)   → max_points=100
+    //     A: (5/5)×50 + (4/6)×100 = 50 + 66.67 = 116.67
+    //     C: (4/5)×50 + (6/6)×100 = 40 + 100   = 140    ← hg1 leader
+    //
+    //   hg3 stage 1: B=3                 → max_points=50
+    //   hg3 stage 2: B=2                 → max_points=100
+    //     B: (3/3)×50 + (2/2)×100 = 50 + 100  = 150     ← hg3 leader (only competitor)
+    const cards: RawScorecard[] = [
+      makeCard(1, 1, { hit_factor: 5, max_points: 50 }),
+      makeCard(1, 2, { hit_factor: 4, max_points: 100 }),
+      makeCard(2, 1, { hit_factor: 3, max_points: 50 }),
+      makeCard(2, 2, { hit_factor: 2, max_points: 100 }),
+      makeCard(3, 1, { hit_factor: 4, max_points: 50 }),
+      makeCard(3, 2, { hit_factor: 6, max_points: 100 }),
+    ];
+    const { divisionLeaderMatchPts, overallLeaderMatchPts } =
+      computeMatchPointTotals(cards);
+    expect(divisionLeaderMatchPts.hg1).toBeCloseTo(140, 4);
+    expect(divisionLeaderMatchPts.hg3).toBeCloseTo(150, 4);
+    // Overall (cross-division) leader: stage 1 winner=5, stage 2 winner=6
+    //   A: (5/5)×50 + (4/6)×100 = 116.67
+    //   B: (3/5)×50 + (2/6)×100 = 30 + 33.33 = 63.33
+    //   C: (4/5)×50 + (6/6)×100 = 140
+    // → overall leader = C with 140
+    expect(overallLeaderMatchPts).toBeCloseTo(140, 4);
+  });
+
+  it("excludes competitors with any DQ scorecard from the leader pool", () => {
+    const cards: RawScorecard[] = [
+      // Hot shooter who DQs on stage 2 — must NOT define the 100% anchor
+      makeCard(1, 1, { hit_factor: 10, max_points: 50 }),
+      makeCard(1, 2, { hit_factor: 0, max_points: 100, dq: true, points: 0 }),
+      // Clean shooter who is the actual division leader
+      makeCard(3, 1, { hit_factor: 4, max_points: 50 }),
+      makeCard(3, 2, { hit_factor: 5, max_points: 100 }),
+    ];
+    const { divisionLeaderMatchPts } = computeMatchPointTotals(cards);
+    // Without DQ exclusion: comp 1 = (10/10)×50 + 0 = 50
+    //                       comp 3 = (4/10)×50 + (5/5)×100 = 20 + 100 = 120 ← actual leader
+    // With DQ exclusion: comp 1 dropped → leader = comp 3 = 120
+    expect(divisionLeaderMatchPts.hg1).toBeCloseTo(120, 4);
+  });
+
+  it("treats DNF / zeroed stages as 0 stage-points", () => {
+    const cards: RawScorecard[] = [
+      makeCard(1, 1, { hit_factor: 5, max_points: 50 }),
+      makeCard(1, 2, { hit_factor: 0, max_points: 100, dnf: true }),
+      // Clean leader
+      makeCard(3, 1, { hit_factor: 5, max_points: 50 }),
+      makeCard(3, 2, { hit_factor: 5, max_points: 100 }),
+    ];
+    const { divisionLeaderMatchPts } = computeMatchPointTotals(cards);
+    expect(divisionLeaderMatchPts.hg1).toBeCloseTo(150, 4);
+  });
+
+  it("returns null overall leader when no scorecards have valid HF", () => {
+    const cards: RawScorecard[] = [
+      makeCard(1, 1, { hit_factor: 0, dq: true }),
+    ];
+    const { overallLeaderMatchPts, divisionLeaderMatchPts } =
+      computeMatchPointTotals(cards);
+    expect(overallLeaderMatchPts).toBeNull();
+    expect(Object.keys(divisionLeaderMatchPts)).toHaveLength(0);
+  });
+
+  it("ignores cards with missing max_points (older cache entries)", () => {
+    const cards: RawScorecard[] = [
+      makeCard(1, 1, { hit_factor: 5, max_points: 0 }),
+      makeCard(3, 1, { hit_factor: 4, max_points: 0 }),
+    ];
+    const { overallLeaderMatchPts, divisionLeaderMatchPts } =
+      computeMatchPointTotals(cards);
+    expect(overallLeaderMatchPts).toBeNull();
+    expect(Object.keys(divisionLeaderMatchPts)).toHaveLength(0);
   });
 });

--- a/tests/unit/compare-logic.test.ts
+++ b/tests/unit/compare-logic.test.ts
@@ -3252,4 +3252,62 @@ describe("computeMatchPointTotals — IPSC points anchors", () => {
     expect(overallLeaderMatchPts).toBeNull();
     expect(Object.keys(divisionLeaderMatchPts)).toHaveLength(0);
   });
+
+  it("ranks competitors within their own division (1 = leader)", () => {
+    const cards: RawScorecard[] = [
+      // hg1 — comp 3 wins, comp 1 second
+      makeCard(1, 1, { hit_factor: 4, max_points: 50 }),
+      makeCard(1, 2, { hit_factor: 4, max_points: 100 }),
+      makeCard(3, 1, { hit_factor: 5, max_points: 50 }),
+      makeCard(3, 2, { hit_factor: 5, max_points: 100 }),
+      // hg3 — comp 2 alone
+      makeCard(2, 1, { hit_factor: 3, max_points: 50 }),
+      makeCard(2, 2, { hit_factor: 3, max_points: 100 }),
+    ];
+    const { divisionMatchRanks } = computeMatchPointTotals(cards);
+    expect(divisionMatchRanks[3]).toEqual({ rank: 1, total: 2 });
+    expect(divisionMatchRanks[1]).toEqual({ rank: 2, total: 2 });
+    expect(divisionMatchRanks[2]).toEqual({ rank: 1, total: 1 });
+  });
+
+  it("ranks competitors across the full field for overall mode", () => {
+    const cards: RawScorecard[] = [
+      makeCard(1, 1, { hit_factor: 4, max_points: 50 }),
+      makeCard(2, 1, { hit_factor: 5, max_points: 50 }),
+      makeCard(3, 1, { hit_factor: 3, max_points: 50 }),
+    ];
+    const { overallMatchRanks } = computeMatchPointTotals(cards);
+    // Overall stage winner = comp 2 (HF=5)
+    //   comp 2: 5/5×50 = 50  → rank 1
+    //   comp 1: 4/5×50 = 40  → rank 2
+    //   comp 3: 3/5×50 = 30  → rank 3
+    expect(overallMatchRanks[2]).toEqual({ rank: 1, total: 3 });
+    expect(overallMatchRanks[1]).toEqual({ rank: 2, total: 3 });
+    expect(overallMatchRanks[3]).toEqual({ rank: 3, total: 3 });
+  });
+
+  it("excludes DQ'd competitors from rank maps and total counts", () => {
+    const cards: RawScorecard[] = [
+      makeCard(1, 1, { hit_factor: 4, max_points: 50 }),
+      makeCard(2, 1, { hit_factor: 5, max_points: 50 }),
+      makeCard(3, 1, { hit_factor: 6, max_points: 50, dq: true }),
+    ];
+    const { overallMatchRanks } = computeMatchPointTotals(cards);
+    expect(overallMatchRanks[3]).toBeUndefined();
+    expect(overallMatchRanks[2]).toEqual({ rank: 1, total: 2 });
+    expect(overallMatchRanks[1]).toEqual({ rank: 2, total: 2 });
+  });
+
+  it("assigns shared rank for ties and skips the next rank", () => {
+    const cards: RawScorecard[] = [
+      // Comps 1 and 2 tie at the top; comp 3 trails
+      makeCard(1, 1, { hit_factor: 5, max_points: 50 }),
+      makeCard(2, 1, { hit_factor: 5, max_points: 50 }),
+      makeCard(3, 1, { hit_factor: 4, max_points: 50 }),
+    ];
+    const { overallMatchRanks } = computeMatchPointTotals(cards);
+    expect(overallMatchRanks[1].rank).toBe(1);
+    expect(overallMatchRanks[2].rank).toBe(1);
+    expect(overallMatchRanks[3].rank).toBe(3);
+  });
 });

--- a/tests/unit/match-stats.test.ts
+++ b/tests/unit/match-stats.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from "vitest";
+import { computeMatchStats } from "@/lib/match-stats";
+import type { RawScorecard } from "@/app/api/compare/logic";
+
+function card(overrides: Partial<RawScorecard> = {}): RawScorecard {
+  return {
+    competitor_id: 1,
+    competitor_division: "Production Optics",
+    stage_id: 1,
+    stage_number: 1,
+    stage_name: "Stage 1",
+    max_points: 50,
+    points: 50,
+    hit_factor: 5,
+    time: 10,
+    dq: false,
+    zeroed: false,
+    dnf: false,
+    incomplete: false,
+    a_hits: 10,
+    c_hits: 0,
+    d_hits: 0,
+    miss_count: 0,
+    no_shoots: 0,
+    procedurals: 0,
+    ...overrides,
+  };
+}
+
+describe("computeMatchStats — matchPct (IPSC points formula)", () => {
+  it("returns 100% when the shooter is the division leader on every stage", () => {
+    const cards: RawScorecard[] = [
+      card({ competitor_id: 1, stage_id: 1, hit_factor: 5, max_points: 50 }),
+      card({ competitor_id: 1, stage_id: 2, hit_factor: 6, max_points: 100 }),
+      // Slower competitor in same division
+      card({ competitor_id: 2, stage_id: 1, hit_factor: 4, max_points: 50, a_hits: 8 }),
+      card({ competitor_id: 2, stage_id: 2, hit_factor: 3, max_points: 100, a_hits: 8 }),
+    ];
+    const s = computeMatchStats(1, "Production Optics", cards);
+    expect(s.matchPct).toBeCloseTo(100, 4);
+  });
+
+  it("weights stages by max_points (longer stages count more)", () => {
+    // Shooter A scores 100% on a 25-pt stage and 50% on a 100-pt stage.
+    //
+    // Averaged-pct formula:    (100 + 50) / 2 = 75%
+    // IPSC points formula:     (1.0×25 + 0.5×100) / (1.0×25 + 1.0×100)
+    //                        = 75 / 125 = 60%
+    const cards: RawScorecard[] = [
+      card({ competitor_id: 1, stage_id: 1, hit_factor: 5, max_points: 25 }),
+      card({ competitor_id: 1, stage_id: 2, hit_factor: 3, max_points: 100 }),
+      // Division leader: 100% on every stage
+      card({ competitor_id: 2, stage_id: 1, hit_factor: 5, max_points: 25 }),
+      card({ competitor_id: 2, stage_id: 2, hit_factor: 6, max_points: 100 }),
+    ];
+    const s = computeMatchStats(1, "Production Optics", cards);
+    expect(s.matchPct).toBeCloseTo(60, 2);
+  });
+
+  it("ignores other divisions when picking the leader", () => {
+    const cards: RawScorecard[] = [
+      // Our shooter (Production Optics)
+      card({ competitor_id: 1, stage_id: 1, hit_factor: 4, max_points: 50 }),
+      // Higher HF in DIFFERENT division — must be ignored
+      card({
+        competitor_id: 99,
+        competitor_division: "Open",
+        stage_id: 1,
+        hit_factor: 10,
+        max_points: 50,
+      }),
+      // Same-division competitor (lower HF)
+      card({ competitor_id: 2, stage_id: 1, hit_factor: 4, max_points: 50 }),
+    ];
+    const s = computeMatchStats(1, "Production Optics", cards);
+    expect(s.matchPct).toBeCloseTo(100, 4);
+  });
+
+  it("excludes DQ'd competitors from the division leader pool", () => {
+    const cards: RawScorecard[] = [
+      // Our shooter
+      card({ competitor_id: 1, stage_id: 1, hit_factor: 5, max_points: 50 }),
+      card({ competitor_id: 1, stage_id: 2, hit_factor: 5, max_points: 50 }),
+      // Faster shooter who DQ'd on stage 2 — their match total must not anchor 100%
+      card({ competitor_id: 2, stage_id: 1, hit_factor: 10, max_points: 50 }),
+      card({ competitor_id: 2, stage_id: 2, hit_factor: 0, max_points: 50, dq: true }),
+    ];
+    const s = computeMatchStats(1, "Production Optics", cards);
+    // Without DQ exclusion: leader_pts = 50 (10/10 ×50) + 0 = 50, my_pts = 50 → 100%
+    // With DQ exclusion: comp 2 ignored → my shooter is the only valid total → 100%
+    // To distinguish, add a third clean shooter who is faster on stage 1 only.
+    expect(s.matchPct).toBeCloseTo(100, 4);
+
+    const cards2: RawScorecard[] = [
+      ...cards,
+      // Clean shooter who is the actual division leader
+      card({ competitor_id: 3, stage_id: 1, hit_factor: 8, max_points: 50 }),
+      card({ competitor_id: 3, stage_id: 2, hit_factor: 8, max_points: 50 }),
+    ];
+    const s2 = computeMatchStats(1, "Production Optics", cards2);
+    // shooter 1: 5/8×50 + 5/8×50 = 31.25 + 31.25 = 62.5
+    // shooter 3 (leader): 8/8×50 + 8/8×50 = 100
+    // pct = 62.5 / 100 = 62.5%
+    expect(s2.matchPct).toBeCloseTo(62.5, 4);
+  });
+
+  it("treats DNF / zeroed stages as 0 points but still rates the shooter", () => {
+    const cards: RawScorecard[] = [
+      card({ competitor_id: 1, stage_id: 1, hit_factor: 5, max_points: 50 }),
+      card({ competitor_id: 1, stage_id: 2, hit_factor: 0, max_points: 50, dnf: true }),
+      // Division leader: clean run on both
+      card({ competitor_id: 2, stage_id: 1, hit_factor: 5, max_points: 50 }),
+      card({ competitor_id: 2, stage_id: 2, hit_factor: 5, max_points: 50 }),
+    ];
+    const s = computeMatchStats(1, "Production Optics", cards);
+    // leader = 100 pts, mine = 50 pts → 50%
+    expect(s.matchPct).toBeCloseTo(50, 4);
+    expect(s.stageCount).toBe(1); // DNF stage excluded from valid count
+  });
+
+  it("returns null when division is unknown", () => {
+    const cards: RawScorecard[] = [
+      card({ competitor_id: 1, stage_id: 1, hit_factor: 5, max_points: 50 }),
+    ];
+    const s = computeMatchStats(1, null, cards);
+    expect(s.matchPct).toBeNull();
+  });
+
+  it("returns null when no valid scorecards exist for the shooter", () => {
+    const cards: RawScorecard[] = [
+      card({ competitor_id: 1, stage_id: 1, hit_factor: 0, max_points: 50, dq: true }),
+    ];
+    const s = computeMatchStats(1, "Production Optics", cards);
+    expect(s.matchPct).toBeNull();
+    expect(s.dq).toBe(true);
+  });
+
+  it("falls back to averaged-percentage formula when max_points is missing", () => {
+    // Mirrors older cache entries where stage.max_points wasn't captured.
+    const cards: RawScorecard[] = [
+      card({ competitor_id: 1, stage_id: 1, hit_factor: 5, max_points: 0 }),
+      card({ competitor_id: 1, stage_id: 2, hit_factor: 3, max_points: 0 }),
+      // Division leader on each stage
+      card({ competitor_id: 2, stage_id: 1, hit_factor: 5, max_points: 0 }),
+      card({ competitor_id: 2, stage_id: 2, hit_factor: 6, max_points: 0 }),
+    ];
+    const s = computeMatchStats(1, "Production Optics", cards);
+    // Stage 1: 5/5 = 100%; Stage 2: 3/6 = 50%; avg = 75%
+    expect(s.matchPct).toBeCloseTo(75, 4);
+  });
+});
+
+describe("computeMatchStats — other fields preserved", () => {
+  it("computes avgHF as the arithmetic mean of valid stage hit factors", () => {
+    const cards: RawScorecard[] = [
+      card({ competitor_id: 1, stage_id: 1, hit_factor: 4 }),
+      card({ competitor_id: 1, stage_id: 2, hit_factor: 6 }),
+    ];
+    const s = computeMatchStats(1, "Production Optics", cards);
+    expect(s.avgHF).toBeCloseTo(5, 4);
+    expect(s.stageCount).toBe(2);
+  });
+
+  it("counts perfect stages and aggregates hit-zone totals", () => {
+    const cards: RawScorecard[] = [
+      card({
+        competitor_id: 1,
+        stage_id: 1,
+        a_hits: 10,
+        c_hits: 0,
+        d_hits: 0,
+        miss_count: 0,
+        no_shoots: 0,
+        procedurals: 0,
+      }),
+      card({
+        competitor_id: 1,
+        stage_id: 2,
+        a_hits: 8,
+        c_hits: 1,
+        d_hits: 1,
+        miss_count: 0,
+        no_shoots: 0,
+        procedurals: 0,
+      }),
+    ];
+    const s = computeMatchStats(1, "Production Optics", cards);
+    expect(s.perfectStages).toBe(1);
+    expect(s.totalA).toBe(18);
+    expect(s.totalC).toBe(1);
+    expect(s.totalD).toBe(1);
+  });
+
+  it("computes a consistency index in (−∞, 100]; 100 = identical HF on every stage", () => {
+    const cards: RawScorecard[] = [
+      card({ competitor_id: 1, stage_id: 1, hit_factor: 5 }),
+      card({ competitor_id: 1, stage_id: 2, hit_factor: 5 }),
+      card({ competitor_id: 1, stage_id: 3, hit_factor: 5 }),
+    ];
+    const s = computeMatchStats(1, "Production Optics", cards);
+    expect(s.consistencyIndex).toBeCloseTo(100, 4);
+  });
+
+  it("flags match-level DQ when any stage has dq=true", () => {
+    const cards: RawScorecard[] = [
+      card({ competitor_id: 1, stage_id: 1, hit_factor: 5 }),
+      card({ competitor_id: 1, stage_id: 2, hit_factor: 0, dq: true }),
+    ];
+    const s = computeMatchStats(1, "Production Optics", cards);
+    expect(s.dq).toBe(true);
+  });
+});


### PR DESCRIPTION
Match percentage on the shooter dashboard match cards and on the
comparison-table totals row now mirrors shootnscoreit.com:

  stage_pts  = (HF / division_stage_winner_HF) × stage.max_points
  match_pts  = sum across stages
  matchPct   = match_pts / leader_match_pts × 100

Previously both surfaces used an unweighted mean of per-stage
percentages, which understated competitors who performed better on
longer (higher max_points) stages.

For comparison-table totals the anchor is mode-aware:
  group   → highest match_pts among the *selected* competitors
  division→ divisionLeaderMatchPts[<competitor's division>]
  overall → overallLeaderMatchPts

Group mode now guarantees one selected competitor lands on 100%.

A new helper computeMatchPointTotals (compare/logic.ts) ships the
full-division and full-field anchors on CompareResponse. The
shooter-dashboard helper computeMatchStats moves into lib/match-stats.ts
for unit-testing. Both fall back to the old averaged-percentage
formula for older cache entries that lack stage.max_points.

https://claude.ai/code/session_01Q8pfW6goMTH4kPqDkjnFJr