### PR TITLE
fix(cache): derive match scoring % from stages when SSI aggregate is broken

### DIFF
--- a/app/api/coaching/[ct]/[id]/[competitorId]/route.ts
+++ b/app/api/coaching/[ct]/[id]/[competitorId]/route.ts
@@ -23,6 +23,7 @@ import {
   type RawScorecard,
 } from "@/app/api/compare/logic";
 import { computeMatchTtl, isMatchComplete } from "@/lib/match-ttl";
+import { effectiveMatchScoringPct } from "@/lib/match-data";
 import { extractDivision } from "@/lib/divisions";
 import { decodeShooterId } from "@/lib/shooter-index";
 import cache from "@/lib/cache-impl";
@@ -137,6 +138,7 @@ interface RawMatchData {
       number: number;
       name: string;
       max_points: number;
+      scoring_completed?: string | number | null;
     }[];
     competitors_approved_w_wo_results_not_dnf?: RawCompetitor[];
   } | null;
@@ -199,9 +201,7 @@ export async function GET(
   }
 
   // Determine match state
-  const scoringPct = Math.round(
-    parseFloat(String(matchData.event.scoring_completed ?? 0)),
-  );
+  const scoringPct = Math.round(effectiveMatchScoringPct(matchData.event));
   const matchDate = matchData.event.starts
     ? new Date(matchData.event.starts)
     : null;

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -7,6 +7,7 @@ import { cachedExecuteQuery, gqlCacheKey, SCORECARDS_QUERY, MATCH_QUERY, refresh
 import cache from "@/lib/cache-impl";
 import { computeMatchFreshness, computeMatchSwrTtl, isMatchComplete } from "@/lib/match-ttl";
 import { persistToMatchStore } from "@/lib/match-data-store";
+import { effectiveMatchScoringPct } from "@/lib/match-data";
 import { isUpstreamDegraded } from "@/lib/upstream-status";
 import { afterResponse } from "@/lib/background-impl";
 
@@ -62,6 +63,7 @@ interface RawMatchData {
       get_course_display?: string | null;
       procedure?: string | null;
       firearm_condition?: string | null;
+      scoring_completed?: string | number | null;
     }[];
     competitors_approved_w_wo_results_not_dnf?: RawCompetitor[];
   } | null;
@@ -126,9 +128,7 @@ export async function GET(req: Request) {
   }
 
   // Determine match state and compute TTL
-  const scoringPct = parseFloat(
-    String(matchData.event?.scoring_completed ?? 0)
-  );
+  const scoringPct = effectiveMatchScoringPct(matchData.event);
   const matchDate = matchData.event?.starts ? new Date(matchData.event.starts) : null;
   const daysSince = matchDate ? (Date.now() - matchDate.getTime()) / 86_400_000 : 0;
   const signals = {

--- a/app/api/data/match/[ct]/[id]/results/route.ts
+++ b/app/api/data/match/[ct]/[id]/results/route.ts
@@ -8,6 +8,7 @@ import { cachedExecuteQuery, gqlCacheKey, MATCH_QUERY, SCORECARDS_QUERY } from "
 import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
 import { computeFullFieldRankings } from "@/app/api/compare/logic";
 import { decodeShooterId } from "@/lib/shooter-index";
+import { effectiveMatchScoringPct } from "@/lib/match-data";
 
 interface RawMatchData {
   event: {
@@ -22,6 +23,7 @@ interface RawMatchData {
       number: number;
       name: string;
       max_points?: number | null;
+      scoring_completed?: string | number | null;
     }>;
     competitors_approved_w_wo_results_not_dnf?: Array<{
       id: string;
@@ -141,7 +143,7 @@ export async function GET(
       level: ev.level ?? null,
       region: ev.region ?? null,
       discipline: ev.get_full_rule_display ?? null,
-      scoringCompleted: Math.round(parseFloat(String(ev.scoring_completed ?? 0))),
+      scoringCompleted: Math.round(effectiveMatchScoringPct(ev)),
     },
     stages,
     competitors,

--- a/app/api/shooter/[shooterId]/add-match/route.ts
+++ b/app/api/shooter/[shooterId]/add-match/route.ts
@@ -18,7 +18,7 @@ import { parseMatchUrl } from "@/lib/utils";
 import { extractDivision } from "@/lib/divisions";
 import db from "@/lib/db-impl";
 import cache from "@/lib/cache-impl";
-import type { RawMatchData } from "@/lib/match-data";
+import { effectiveMatchScoringPct, type RawMatchData } from "@/lib/match-data";
 
 interface RawScorecardsResponse {
   event: unknown;
@@ -80,7 +80,7 @@ export async function POST(
 
     // Compute proper TTL for this entry
     if (matchData.event) {
-      const scoringPct = Math.round(parseFloat(String(matchData.event.scoring_completed ?? 0)));
+      const scoringPct = Math.round(effectiveMatchScoringPct(matchData.event));
       const matchDate = matchData.event.starts ? new Date(matchData.event.starts) : null;
       const daysSince = matchDate ? (Date.now() - matchDate.getTime()) / 86_400_000 : 99;
       const ttl = computeMatchTtl(scoringPct, daysSince, matchData.event.starts ?? null, undefined, {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -34,5 +34,11 @@ export const MAX_COMPETITORS = 12;
  *  14 → added scorecard_created to CompetitorSummary on CompareResponse
  *       (powers the stage-times export feature so video editors can align
  *       per-stage runs to a recording timeline).
+ *  15 → added scoring_completed to IpscStageNode in MATCH_QUERY. Lets us
+ *       derive a match-level scoring percentage from the stages when SSI's
+ *       own match-level `scoring_completed` is broken — observed during
+ *       SPSK Open 2026 (match 22/27190): every stage reported 21-29% but
+ *       the match-level field returned "0", which froze the cache TTL on
+ *       the 5-min "started, no scoring yet" tier.
  */
-export const CACHE_SCHEMA_VERSION = 14;
+export const CACHE_SCHEMA_VERSION = 15;

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -189,12 +189,22 @@ async function executeQueryOnce<T>(
 }
 
 // ─── Query: match overview ───────────────────────────────────────────────────
-// `venue` and `scoring_completed` are on EventInterface (top level).
-// `sub_rule`, `level`, `region`, `stages_count`, `competitors_count`, and
-// the nested lists require `... on IpscMatchNode`.
+// `venue` is on EventInterface (top level). `sub_rule`, `level`, `region`,
+// `stages_count`, `competitors_count`, and the nested lists require
+// `... on IpscMatchNode`.
 //
-// `scoring_completed` is returned as a decimal string (e.g. "56.31067961165048"),
-// not a number. Parse with parseFloat() in the route handler.
+// `scoring_completed` is requested inside the IpscMatchNode fragment for
+// consistency with EVENTS_QUERY (PR #368). It is returned as a decimal string
+// (e.g. "56.31067961165048"), not a number — parse with parseFloat().
+//
+// IMPORTANT: the match-level `scoring_completed` aggregate is unreliable
+// upstream. Observed during SPSK Open 2026 (match 22/27190): every stage
+// reported 21-29% scored but the match-level field returned "0". A 0 here
+// froze the cache TTL on the 5-min "started, no scoring yet" tier and made
+// live matches feel stuck. We therefore also request `scoring_completed` on
+// each IpscStageNode and derive an effective match-level percentage from the
+// per-stage values whenever the match-level value looks broken (see
+// `effectiveMatchScoringPct` in lib/match-data.ts).
 //
 // `competitor(content_type, id)` at the top level returns 404 in practice.
 // All competitor/scorecard data is fetched via the event node.
@@ -216,8 +226,8 @@ export const MATCH_QUERY = `
       starts
       status
       results
-      scoring_completed
       ... on IpscMatchNode {
+        scoring_completed
         region
         sub_rule
         get_full_rule_display
@@ -256,6 +266,7 @@ export const MATCH_QUERY = `
             get_course_display
             procedure
             firearm_condition
+            scoring_completed
           }
         }
         competitors_approved_w_wo_results_not_dnf {

--- a/lib/match-data.ts
+++ b/lib/match-data.ts
@@ -15,6 +15,39 @@ import { cacheTelemetry } from "@/lib/cache-telemetry";
 import { reportError } from "@/lib/error-telemetry";
 import type { MatchResponse, StageInfo, CompetitorInfo, SquadInfo } from "@/lib/types";
 
+// ── Effective match-level scoring percentage ────────────────────────────────
+//
+// SSI's match-level `event.scoring_completed` aggregate is unreliable: it can
+// return "0" while every stage independently reports 20-30% scored (observed
+// during SPSK Open 2026, match 22/27190). A 0 here cascades into the
+// "match started, no scoring yet" TTL tier (5 min freshness) and freezes the
+// scoreboard for users courtside.
+//
+// `effectiveMatchScoringPct` trusts the match-level value when it is plausible
+// and falls back to the unweighted mean of per-stage `scoring_completed`
+// values whenever it is materially lower than the stage average. This catches
+// the bug without changing behaviour for healthy matches.
+
+interface MatchEventForScoring {
+  scoring_completed?: string | number | null;
+  stages?: Array<{ scoring_completed?: string | number | null }> | null;
+}
+
+export function effectiveMatchScoringPct(event: MatchEventForScoring | null | undefined): number {
+  if (!event) return 0;
+  const matchPct = event.scoring_completed != null
+    ? parseFloat(String(event.scoring_completed))
+    : 0;
+  const stagePcts = (event.stages ?? [])
+    .map((s) => (s?.scoring_completed != null ? parseFloat(String(s.scoring_completed)) : NaN))
+    .filter((n) => Number.isFinite(n)) as number[];
+  if (stagePcts.length === 0) return matchPct;
+  const stageMean = stagePcts.reduce((a, b) => a + b, 0) / stagePcts.length;
+  // 1 percentage point of slack absorbs rounding while still catching the
+  // "match=0, stages=29%" failure mode.
+  return stageMean > matchPct + 1 ? stageMean : matchPct;
+}
+
 // ── Raw GraphQL response shapes ─────────────────────────────────────────────
 
 interface RawStage {
@@ -31,6 +64,10 @@ interface RawStage {
   get_course_display?: string | null;
   procedure?: string | null;
   firearm_condition?: string | null;
+  /** Per-stage scoring percentage as a decimal string (e.g. "29.487179487179485").
+   *  Added in cache schema v15 — used to derive a match-level percentage when
+   *  SSI's own `event.scoring_completed` aggregate is broken. */
+  scoring_completed?: string | number | null;
 }
 
 interface RawCompetitor {
@@ -147,7 +184,7 @@ export async function fetchMatchData(
 
   const ev = raw.event;
 
-  const scoringPct = parseFloat(String(ev.scoring_completed ?? 0));
+  const scoringPct = effectiveMatchScoringPct(ev);
   const matchDate = ev.starts ? new Date(ev.starts) : null;
   const daysSince = matchDate ? (Date.now() - matchDate.getTime()) / 86_400_000 : 0;
   const resultsPublished = ev.results === "all";
@@ -323,10 +360,7 @@ export async function fetchMatchData(
     stages_count: ev.stages_count ?? stages.length,
     competitors_count: ev.competitors_count ?? competitors.length,
     max_competitors: ev.max_competitors ?? null,
-    scoring_completed:
-      ev.scoring_completed != null
-        ? parseFloat(String(ev.scoring_completed))
-        : 0,
+    scoring_completed: effectiveMatchScoringPct(ev),
     match_status: ev.status ?? "on",
     results_status: ev.results ?? "org",
     registration_status: ev.registration ?? "cl",

--- a/lib/og-data.ts
+++ b/lib/og-data.ts
@@ -1,7 +1,7 @@
 // Server-only — fetches match/shooter metadata for OG images and page metadata.
 // Uses cached data (GraphQL cache for matches, Redis index for shooters).
 
-import { fetchRawMatchData } from "@/lib/match-data";
+import { effectiveMatchScoringPct, fetchRawMatchData } from "@/lib/match-data";
 import { extractDivision } from "@/lib/divisions";
 import { decodeShooterId } from "@/lib/shooter-index";
 import cache from "@/lib/cache-impl";
@@ -114,10 +114,7 @@ async function fetchOgMatchDataImpl(
       imageUrl,
       imageWidth,
       imageHeight,
-      scoringCompleted:
-        ev.scoring_completed != null
-          ? Math.round(parseFloat(String(ev.scoring_completed)))
-          : 0,
+      scoringCompleted: Math.round(effectiveMatchScoringPct(ev)),
       matchStatus: ev.status ?? null,
       resultsStatus: ev.results ?? null,
       competitors,

--- a/tests/unit/effective-match-scoring-pct.test.ts
+++ b/tests/unit/effective-match-scoring-pct.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { effectiveMatchScoringPct } from "@/lib/match-data";
+
+describe("effectiveMatchScoringPct", () => {
+  it("returns 0 for null/undefined event", () => {
+    expect(effectiveMatchScoringPct(null)).toBe(0);
+    expect(effectiveMatchScoringPct(undefined)).toBe(0);
+  });
+
+  it("trusts the match-level value when stages agree", () => {
+    expect(
+      effectiveMatchScoringPct({
+        scoring_completed: "57.0",
+        stages: [
+          { scoring_completed: "55" },
+          { scoring_completed: "60" },
+          { scoring_completed: "56" },
+        ],
+      }),
+    ).toBeCloseTo(57);
+  });
+
+  it("falls back to stage mean when match-level reports 0 but stages have scoring", () => {
+    // SPSK Open 2026 (match 22/27190) shape: SSI returned scoring_completed="0"
+    // for the match while every stage independently reported 21-29%.
+    expect(
+      effectiveMatchScoringPct({
+        scoring_completed: "0",
+        stages: [
+          { scoring_completed: "29.487179487179485" },
+          { scoring_completed: "28.846153846153847" },
+          { scoring_completed: "21.153846153846153" },
+        ],
+      }),
+    ).toBeCloseTo((29.4872 + 28.8462 + 21.1538) / 3, 2);
+  });
+
+  it("absorbs <=1pp slack between match and stage mean (no flap)", () => {
+    expect(
+      effectiveMatchScoringPct({
+        scoring_completed: "55",
+        stages: [
+          { scoring_completed: "55.5" },
+          { scoring_completed: "55.5" },
+        ],
+      }),
+    ).toBe(55);
+  });
+
+  it("ignores stages without scoring_completed", () => {
+    expect(
+      effectiveMatchScoringPct({
+        scoring_completed: "0",
+        stages: [
+          { scoring_completed: null },
+          { scoring_completed: undefined },
+        ],
+      }),
+    ).toBe(0);
+  });
+
+  it("returns the match value when stages array is empty", () => {
+    expect(
+      effectiveMatchScoringPct({
+        scoring_completed: "42.5",
+        stages: [],
+      }),
+    ).toBeCloseTo(42.5);
+  });
+
+  it("handles numeric scoring_completed without parseFloat surprises", () => {
+    expect(
+      effectiveMatchScoringPct({
+        scoring_completed: 0,
+        stages: [{ scoring_completed: 30 }, { scoring_completed: 40 }],
+      }),
+    ).toBe(35);
+  });
+});


### PR DESCRIPTION
## Summary

- SSI's match-level \`event.scoring_completed\` aggregate is returning \`\"0\"\` while every \`IpscStageNode\` independently reports 21-29% scored. Reproduced live this morning against match 22/27190 (SPSK Open 2026): users reported 7-14 minutes since update with no progress.
- Root cause: a 0 here pegs \`computeMatchTtl()\` on the 5-min \"started, no scoring yet\" tier (\`lib/match-ttl.ts:147-166\`). Combined with the match-level probe seeing \`event.updated\` unchanged, the cache only self-heals once \`MATCH_PROBE_MAX_SKIP_AGE_SECONDS\` (300s) elapses.
- New \`effectiveMatchScoringPct(event)\` helper trusts the match-level value but falls back to the unweighted mean of per-stage \`scoring_completed\` whenever match-level is materially lower (>1pp slack so healthy matches don't flap).
- \`MATCH_QUERY\` now also requests \`scoring_completed\` on each \`IpscStageNode\`. Cache schema bumped 14 → 15 so stale entries (no per-stage field) evict on next read.

Wired through: \`/api/compare\`, \`/api/match\` (via \`lib/match-data\`), \`/api/coaching\`, \`/api/shooter/.../add-match\`, \`/api/data/match/.../results\`, OG image data.

## Test plan

- [x] \`pnpm -w run typecheck\` clean
- [x] \`pnpm -w run lint\` clean
- [x] \`pnpm -w test\` 1623 passed (added 7 new tests for \`effectiveMatchScoringPct\`, including the SPSK 22/27190 shape)
- [x] \`pnpm validate:ssi-queries\` OK against schema snapshot
- [ ] Deploy and confirm \`match-ttl-decision\` events for 27190 transition from \`scoringPct=0, ttl=300\` to \`scoringPct≈25, ttl=90\` via R2 telemetry
- [ ] Confirm courtside users see fresh data within 30s after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)