### PR TITLE
fix(match): refetch live match data on tab focus

### DIFF
--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -17,6 +17,13 @@ export function useMatchQuery(ct: string, id: string) {
     // and tab-return show data instantly while a background refetch resolves,
     // instead of triggering a fresh skeleton load.
     gcTime: 1_800_000,
+    // Refetch immediately when the tab regains focus. The global default
+    // (Providers.tsx) is `false` to avoid sitewide refetch storms, but for
+    // a live courtside scoreboard the user-visible regression of "I picked
+    // up my phone and the score is 3 minutes old" is exactly what we have
+    // to avoid. The server side's stale-while-revalidate makes a focus
+    // refetch cheap — usually resolves from Redis.
+    refetchOnWindowFocus: true,
     // Poll while the match is active (scoring in progress and results not yet
     // published). The server's stale-while-revalidate path makes these polls
     // cheap — they almost always resolve from Redis without blocking on the
@@ -101,6 +108,11 @@ export function useCompareQuery(
     queryFn: () => fetchCompare(ct, id, competitorIds, mode),
     staleTime: mode === "live" ? 30_000 : 300_000,
     refetchInterval: mode === "live" ? 30_000 : false,
+    // Refetch immediately on tab focus during the live phase. See the same
+    // override on `useMatchQuery` for rationale — the global default in
+    // Providers.tsx is `false` site-wide, but courtside users tap back into
+    // the page expecting the latest scorecards.
+    refetchOnWindowFocus: mode === "live",
     enabled: Boolean(ct && id && competitorIds.length > 0),
   });
 }


### PR DESCRIPTION
## Summary

Reported on staging post-merge of #392: badge oscillates between \"Synced 2s ago\" (good) and \"Updated 3 minutes ago\" with a warning (bad), depending on whether the user has just opened the tab or it's been backgrounded.

Root cause: \`components/providers.tsx:23\` sets \`refetchOnWindowFocus: false\` globally (reasonable site-wide to avoid refetch storms), and React Query's \`refetchInterval\` defaults to pausing while the tab is hidden. So when a phone screen locks / app is backgrounded, polling stops, and on return the first refetch waits up to one full interval before firing — during which the badge correctly reads the actual cache age, which by then is several minutes old.

## Fix

Per-query override:
- \`useMatchQuery\` — \`refetchOnWindowFocus: true\` always (the page is only loaded for an active match anyway).
- \`useCompareQuery\` — \`refetchOnWindowFocus: mode === \"live\"\` (don't refetch on focus in coaching mode where data is static).

Other queries keep the global default.

## Test plan

- [x] \`pnpm -w run typecheck\` clean
- [x] \`pnpm -w run lint\` clean
- [x] \`pnpm -w test\` 1642 passed
- [ ] Deploy to staging, lock phone, wait 2 min, unlock — badge should refetch within a second and show \"Synced <5s ago\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)