### PR TITLE
fix(compare): expose scorecardsCachedAt separately so the badge stops drifting to 5min

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -234,9 +234,22 @@ export async function GET(req: Request) {
 
   let fingerprintCacheHit: boolean | null = null;
 
-  // Report the older of the two cache timestamps (most stale data wins)
+  // Ship both the match-overview cachedAt and the scorecards cachedAt so the
+  // client can choose the right signal per phase. The legacy `cachedAt` field
+  // is the older of the two (preserves the original "most stale wins"
+  // intent for older clients / non-live phases). The dedicated
+  // `scorecardsCachedAt` is what the live-phase badge reads — see the
+  // CacheInfo doc for why the match-overview age is misleading during
+  // scoring.
+  const olderCachedAt =
+    matchCachedAt && scorecardsCachedAt
+      ? new Date(matchCachedAt) < new Date(scorecardsCachedAt)
+        ? matchCachedAt
+        : scorecardsCachedAt
+      : matchCachedAt ?? scorecardsCachedAt;
   const cacheInfo: CompareResponse["cacheInfo"] = {
-    cachedAt: matchCachedAt ?? scorecardsCachedAt,
+    cachedAt: olderCachedAt,
+    scorecardsCachedAt: scorecardsCachedAt,
   };
   if (cacheInfo.cachedAt && (await isUpstreamDegraded())) {
     cacheInfo.upstreamDegraded = true;

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -506,30 +506,29 @@ export default function MatchPageClient() {
   // (e.g. early squads have finished but their afternoon/day-2 squad hasn't).
   const isPreMatch = effectiveMode === "prematch";
 
-  // Pick the cachedAt to show in the "Updated X ago" badge. null means
-  // "just fetched live" — prefer non-null if one is cached.
+  // Pick the cachedAt to show in the "Updated X ago" badge.
   //
-  // During the **live** phase, prefer `compareCachedAt` (scorecards cache)
-  // over the staler-of-two. Reason: the match-overview cache uses the
-  // if-modified-since probe (lib/graphql.ts), and probe-skip — which is the
-  // common outcome during scoring since `event.updated` doesn't tick on
-  // scorecard saves — bumps TTL without writing a new `cachedAt`. So
-  // `matchCachedAt` legitimately drifts toward the 5-min probe ceiling
-  // even while scorecards are < 30s fresh. Surfacing the older value made
-  // the badge read "Updated 4 minutes ago" on a match whose scorecards
-  // data was actually 20 seconds old (reported during SPSK Open 2026,
-  // match 22/27190).
+  // During the **live** phase, prefer the dedicated `scorecardsCachedAt`
+  // shipped by the compare route — that's the timestamp of the last
+  // scorecards-key refetch, which after PR #392 is full-refetched on every
+  // SWR cycle. The legacy `cacheInfo.cachedAt` reflects the match-overview
+  // key, which uses the if-modified-since probe and drifts toward the 5-min
+  // probe ceiling during scoring (event.updated doesn't tick on scorecard
+  // saves). Surfacing the match-overview age made the badge read
+  // "Updated 4 minutes ago" on a match whose scorecards data was actually
+  // 20 seconds old (reported during SPSK Open 2026, match 22/27190).
   //
-  // For prematch / finished phases the staler-of-two is still correct:
-  // match metadata changes (squadding, registration, results-published
-  // flag) matter to the user, and there's no scoring loop driving
-  // scorecards freshness.
+  // For prematch / finished phases the staler-of-two is still right:
+  // match metadata changes (squadding, registration, results-published)
+  // matter, and there's no scoring loop driving scorecards freshness.
   const matchCachedAt = match.cacheInfo.cachedAt;
   const compareCachedAt = compareQuery.data?.cacheInfo.cachedAt ?? null;
+  const scorecardsCachedAt =
+    compareQuery.data?.cacheInfo.scorecardsCachedAt ?? null;
   const isLivePhase =
     effectiveMode !== "prematch" && effectiveMode !== "coaching";
   const stalestCachedAt = isLivePhase
-    ? compareCachedAt ?? matchCachedAt
+    ? scorecardsCachedAt ?? compareCachedAt ?? matchCachedAt
     : matchCachedAt && compareCachedAt
       ? new Date(matchCachedAt) < new Date(compareCachedAt)
         ? matchCachedAt

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -71,6 +71,15 @@ export interface CacheInfo {
    *  a "data is N minutes old" indicator on ongoing matches even when the
    *  cache itself looks fresh. Absent when no scorecards have been recorded. */
   lastScorecardAt?: string | null;
+  /** ISO timestamp of when the **scorecards** cache entry was last refetched.
+   *  Set only by the compare route, where we read both the match-overview
+   *  and scorecards keys. Distinct from `cachedAt`, which mirrors the
+   *  match-overview key — that one drifts toward the probe safety ceiling
+   *  during scoring (event.updated doesn't tick on scorecard saves), so
+   *  it's a misleading signal for "is my scoring data fresh?". The client
+   *  prefers this field during the live phase. Absent on responses where
+   *  no scorecards key was read. */
+  scorecardsCachedAt?: string | null;
 }
 
 export interface MatchResponse {


### PR DESCRIPTION
## The actual root cause of the drift

Direct probe of staging \`/api/compare\` over 75 seconds:

\`\`\`
request 1 09:57:40Z  cachedAt = 09:55:56  lastScorecardAt = 09:57:03
request 2 09:58:16Z  cachedAt = 09:55:56  lastScorecardAt = 09:57:03
request 3 09:58:51Z  cachedAt = 09:55:56  lastScorecardAt = 09:57:54
\`\`\`

\`cachedAt\` froze across 35-second polls while \`lastScorecardAt\` advanced — proof that scorecards data was refreshing but the field we shipped wasn't tracking it.

\`app/api/compare/route.ts:239\` was sending the match-overview cachedAt:

\`\`\`ts
cachedAt: matchCachedAt ?? scorecardsCachedAt
\`\`\`

The match-overview key uses the if-modified-since probe; probe-skip keeps the entry alive but does not write a new \`cachedAt\`. With \`MATCH_PROBE_MAX_SKIP_AGE_SECONDS=300s\`, that field drifts up to 5 minutes during scoring (\`event.updated\` does not tick on scorecard saves). \`matchCachedAt\` was almost never null, so the fallback to \`scorecardsCachedAt\` never kicked in. The earlier \"prefer compareCachedAt during live\" match-page fix was a no-op for the same reason — \`compareCachedAt\` was already match-derived.

## Fix

- New \`CacheInfo.scorecardsCachedAt\` field exposing the scorecards-key refresh timestamp directly.
- \`compare/route.ts\` ships both. Legacy \`cachedAt\` becomes the older-of-two (now actually doing what the original comment said).
- \`match-page-client.tsx\` reads \`scorecardsCachedAt\` during the live phase; falls back to \`compareCachedAt\` then \`matchCachedAt\` for older responses or non-live phases.

After this lands, the badge during scoring reads the actual scorecards-key age (< 30s during normal SWR cycles).

## Test plan

- [x] \`pnpm -w run typecheck\` clean
- [x] \`pnpm -w run lint\` clean
- [x] \`pnpm -w test\` 1642 passed
- [ ] Deploy to staging, re-probe \`/api/compare\` 3x at 35s gaps — \`scorecardsCachedAt\` should advance on each call
- [ ] Confirm badge during a live match reads \"Synced <30s ago · last data Xm ago\" consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)