### PR TITLE
fix(home): fall back to 'live' indicator when scoring_completed is 0

### DIFF
--- a/components/live-matches.tsx
+++ b/components/live-matches.tsx
@@ -59,17 +59,30 @@ function LiveDot() {
   );
 }
 
-function LiveMatchCard({ match }: { match: EventSummary }) {
+export function LiveMatchCard({ match }: { match: EventSummary }) {
   const router = useRouter();
   const startedAgo = formatStartedAgo(match.date);
   const pct = Math.round(match.scoring_completed);
+
+  // SSI's match-level `scoring_completed` aggregate has been observed
+  // returning 0 for live matches whose stages are 20-30% scored
+  // (SPSK Open 2026, match 22/27190). PR #391 derives the right value
+  // for the match page from per-stage scoring_completed, but EVENTS_QUERY
+  // doesn't fetch stages (50x slowdown — see PR #373). On the homepage
+  // we therefore can't reliably show a percentage when SSI reports 0.
+  // Render an honest "live" indicator instead of a misleading "0%".
+  const hasReliableProgress = pct > 0;
 
   return (
     <button
       type="button"
       className="text-left rounded-lg border bg-card p-4 hover:bg-muted/30 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
       onClick={() => router.push(`/match/${match.content_type}/${match.id}`)}
-      aria-label={`Open ${match.name}, scoring ${pct}% complete, started ${startedAgo}`}
+      aria-label={
+        hasReliableProgress
+          ? `Open ${match.name}, scoring ${pct}% complete, started ${startedAgo}`
+          : `Open ${match.name}, live, started ${startedAgo}`
+      }
     >
       <div className="flex items-start justify-between gap-2">
         <span className="font-semibold leading-snug">{match.name}</span>
@@ -77,7 +90,7 @@ function LiveMatchCard({ match }: { match: EventSummary }) {
           className="text-sm font-medium text-muted-foreground shrink-0 tabular-nums"
           aria-hidden="true"
         >
-          {pct}%
+          {hasReliableProgress ? `${pct}%` : "live"}
         </span>
       </div>
 
@@ -85,11 +98,20 @@ function LiveMatchCard({ match }: { match: EventSummary }) {
         {[match.venue, startedAgo].filter(Boolean).join(" · ")}
       </p>
 
-      <Progress
-        value={match.scoring_completed}
-        className="mt-3 h-1.5"
-        aria-hidden="true"
-      />
+      {hasReliableProgress ? (
+        <Progress
+          value={match.scoring_completed}
+          className="mt-3 h-1.5"
+          aria-hidden="true"
+        />
+      ) : (
+        <div
+          className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted"
+          aria-hidden="true"
+        >
+          <div className="h-full w-1/3 animate-pulse rounded-full bg-green-500/50" />
+        </div>
+      )}
     </button>
   );
 }

--- a/tests/components/live-matches.test.tsx
+++ b/tests/components/live-matches.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { EventSummary } from "@/lib/types";
+
+// next/navigation's useRouter has to be mocked at the module level for the
+// component to mount under JSDOM.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import { LiveMatchCard } from "@/components/live-matches";
+
+function event(overrides: Partial<EventSummary>): EventSummary {
+  return {
+    id: 27190,
+    content_type: 22,
+    name: "Test Match",
+    venue: "Range A",
+    date: "2026-05-02T07:00:00Z",
+    ends: "2026-05-02T16:00:00Z",
+    status: "on",
+    region: "SWE",
+    discipline: "IPSC Handgun",
+    level: "Level II",
+    registration_status: "cl",
+    registration_starts: null,
+    registration_closes: null,
+    is_registration_possible: false,
+    squadding_starts: null,
+    squadding_closes: null,
+    is_squadding_possible: false,
+    max_competitors: null,
+    scoring_completed: 0,
+    ...overrides,
+  };
+}
+
+describe("LiveMatches card progress display", () => {
+  it("shows the percentage and a real progress bar when scoring_completed > 0", () => {
+    render(<LiveMatchCard match={event({ id: 1, scoring_completed: 42 })} />);
+    expect(screen.getByText("42%")).toBeTruthy();
+    // The shadcn Progress component renders an indicator with role=progressbar
+    // and aria-valuenow on the parent. We assert the shown number is 42.
+  });
+
+  it("falls back to a 'live' indicator when scoring_completed is 0 (SSI aggregate broken)", () => {
+    // SPSK Open 2026 scenario: match is live, stages are 25% scored, but
+    // SSI's match-level scoring_completed aggregate returns 0. We should
+    // not render "0%" — that's misleading. Show a live signal instead.
+    render(<LiveMatchCard match={event({ id: 2, scoring_completed: 0 })} />);
+    expect(screen.getByText(/live/i)).toBeTruthy();
+    expect(screen.queryByText("0%")).toBeNull();
+  });
+
+  it("rounds the displayed percentage", () => {
+    render(<LiveMatchCard match={event({ id: 3, scoring_completed: 33.71 })} />);
+    expect(screen.getByText("34%")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Issue

Reported on prod after the #394 deploy: every card in the homepage \"Live now\" section showed 0%. Same upstream bug as the original SPSK Open incident — SSI's match-level \`scoring_completed\` aggregate returns 0 even while individual stages are 20-30% scored.

PR #391 worked around it on \`/api/match\` by deriving from per-stage values, but \`EVENTS_QUERY\` (the live-list source) deliberately doesn't fetch stages — PR #373 documented the 50x slowdown that adding them costs. So on the homepage we genuinely cannot derive a percentage when SSI returns 0.

## Fix

Render an honest \"live\" indicator instead of misleading 0%:

- \`scoring_completed > 0\` — unchanged: \`42%\` + real progress bar.
- \`scoring_completed === 0\` — \"live\" + a pulsing animated bar. The temporal-liveness fallback from PR #392 already established the match is genuinely happening, so we just refuse to fabricate a percentage we don't have.

Aria-labels updated to drop the percentage in the fallback case.

## Test plan

- [x] \`pnpm -w run typecheck\` clean
- [x] \`pnpm -w run lint\` clean
- [x] \`pnpm -w test\` 1645 passed (3 new component tests pin the contract)
- [ ] Deploy to staging — homepage should show \"live\" cards with the pulsing bar where SSI's aggregate is 0

## Aside on the 25-min 'Synced 25 minutes ago' from prod

That was traffic-driven, not the cache stuck. Telemetry showed 4 ttl-decisions at 09:42, 25 min of silence, then 4 more at 10:07. With nobody on the page during the window, SWR has nothing to trigger — the cache just ages until the next visitor. Normal SWR behaviour, not a regression. (Worth flagging only if it recurs with active traffic.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)