### PR TITLE
feat(api-v1): add per-competitor stage results endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,7 @@ routes the browser app uses are unauthenticated and have no contract. Only
 Endpoints (thin wrappers around the internal routes, see `app/api/v1/`):
 - `GET /api/v1/events` -- match search
 - `GET /api/v1/match/{ct}/{id}` -- match overview
+- `GET /api/v1/match/{ct}/{id}/competitor/{competitorId}/stages` -- per-competitor stage results
 - `GET /api/v1/shooter/search` -- name search
 - `GET /api/v1/shooter/{shooterId}` -- shooter dashboard
 

--- a/app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts
+++ b/app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts
@@ -1,0 +1,223 @@
+// /api/match/{ct}/{id}/competitor/{competitorId}/stages
+//
+// Per-competitor stage results for a single match: time, hit factor, points,
+// stage_pct, hit zones, penalties, and DQ flag for every stage. The v1 wrapper
+// at app/api/v1/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts is
+// the public, bearer-token-gated surface for this data.
+
+import { NextResponse } from "next/server";
+import { afterResponse } from "@/lib/background-impl";
+import cache from "@/lib/cache-impl";
+import { reportError } from "@/lib/error-telemetry";
+import { cachedExecuteQuery, gqlCacheKey, refreshCachedMatchQuery, SCORECARDS_QUERY } from "@/lib/graphql";
+import { fetchMatchData } from "@/lib/match-data";
+import { persistToMatchStore } from "@/lib/match-data-store";
+import { computeMatchFreshness, computeMatchSwrTtl } from "@/lib/match-ttl";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
+import { maybeTagAsMcp } from "@/lib/telemetry-context";
+import { isUpstreamDegraded } from "@/lib/upstream-status";
+import { computeGroupRankings } from "@/app/api/compare/logic";
+import type {
+  CompetitorStageResult,
+  CompetitorStageResults,
+  CompetitorSummary,
+} from "@/lib/types";
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ ct: string; id: string; competitorId: string }> },
+) {
+  maybeTagAsMcp(req);
+  const rl = await checkRateLimit(req, { prefix: "competitor-stages", limit: 60, windowSeconds: 60 });
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": String(rl.retryAfter) } },
+    );
+  }
+
+  const { ct, id, competitorId: competitorIdStr } = await params;
+  const ctNum = parseInt(ct, 10);
+  const matchIdNum = parseInt(id, 10);
+  const competitorIdNum = parseInt(competitorIdStr, 10);
+  if (isNaN(ctNum) || isNaN(matchIdNum) || isNaN(competitorIdNum)) {
+    return NextResponse.json(
+      { error: "Invalid ct, id, or competitorId" },
+      { status: 400 },
+    );
+  }
+
+  const matchResult = await fetchMatchData(ct, id);
+  if (!matchResult) {
+    return NextResponse.json({ error: "Match not found" }, { status: 404 });
+  }
+  const match = matchResult.data;
+  const competitor = match.competitors.find((c) => c.id === competitorIdNum);
+  if (!competitor) {
+    return NextResponse.json(
+      { error: "Competitor not found in this match" },
+      { status: 404 },
+    );
+  }
+
+  // Mirror the compare route's TTL machinery for the scorecards key. The match
+  // key was already TTL-corrected and SWR-refreshed by `fetchMatchData` above.
+  const daysSince = match.date
+    ? (Date.now() - new Date(match.date).getTime()) / 86_400_000
+    : 0;
+  const signals = {
+    status: match.match_status,
+    resultsPublished: match.results_status === "all",
+  };
+  const dataTtl = computeMatchSwrTtl(
+    match.scoring_completed,
+    daysSince,
+    match.date,
+    signals,
+  );
+
+  const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
+  let scorecardsData: RawScorecardsData;
+  let scorecardsCachedAt: string | null;
+  try {
+    ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
+      await cachedExecuteQuery<RawScorecardsData>(
+        scorecardsKey,
+        SCORECARDS_QUERY,
+        { ct: ctNum, id },
+        dataTtl,
+      ));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Upstream error";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+
+  // Promote the scorecards cache TTL to match the resolved match state.
+  try {
+    if (dataTtl === null) {
+      const raw = await cache.get(scorecardsKey);
+      if (raw) {
+        await cache.persist(scorecardsKey);
+        afterResponse(persistToMatchStore(scorecardsKey, raw));
+      }
+    } else if (!scorecardsCachedAt) {
+      await cache.expire(scorecardsKey, dataTtl);
+    }
+  } catch (err) {
+    reportError("competitor-stages.scorecards-ttl-apply", err, {
+      matchKey: scorecardsKey,
+    });
+  }
+
+  // SWR for scorecards — single-flighted inside refreshCachedMatchQuery.
+  const matchFreshness = computeMatchFreshness(
+    match.scoring_completed,
+    daysSince,
+    match.date,
+    signals,
+  );
+  if (scorecardsCachedAt && dataTtl != null && matchFreshness != null) {
+    const age =
+      (Date.now() - new Date(scorecardsCachedAt).getTime()) / 1000;
+    if (age > matchFreshness) {
+      afterResponse(
+        refreshCachedMatchQuery<RawScorecardsData>(
+          scorecardsKey,
+          SCORECARDS_QUERY,
+          { ct: ctNum, id },
+          dataTtl,
+          { ct: ctNum, id },
+        ),
+      );
+    }
+  }
+
+  const rawScorecards = parseRawScorecards(scorecardsData);
+  const stageComparisons = computeGroupRankings(rawScorecards, [competitor]);
+
+  // Build a stage_id → CompetitorSummary lookup. Stages with no scorecards in
+  // the field are absent from `stageComparisons`; we still emit them with null
+  // fields so callers see one entry per match stage.
+  const summaryByStageId = new Map<number, CompetitorSummary>();
+  for (const stage of stageComparisons) {
+    const summary = stage.competitors[competitor.id];
+    if (summary) summaryByStageId.set(stage.stage_id, summary);
+  }
+
+  const sortedMatchStages = [...match.stages].sort(
+    (a, b) => a.stage_number - b.stage_number,
+  );
+
+  const stages: CompetitorStageResult[] = sortedMatchStages.map((s) => {
+    const summary = summaryByStageId.get(s.id);
+    if (!summary) {
+      return {
+        stage_number: s.stage_number,
+        stage_id: s.id,
+        time_seconds: null,
+        scorecard_updated_at: null,
+        hit_factor: null,
+        stage_points: null,
+        stage_pct: null,
+        alphas: null,
+        charlies: null,
+        deltas: null,
+        misses: null,
+        no_shoots: null,
+        procedurals: null,
+        dq: false,
+      };
+    }
+    return {
+      stage_number: s.stage_number,
+      stage_id: s.id,
+      time_seconds: summary.time,
+      scorecard_updated_at: summary.scorecard_created ?? null,
+      hit_factor: summary.hit_factor,
+      stage_points: summary.points,
+      stage_pct: summary.overall_percent,
+      alphas: summary.a_hits,
+      charlies: summary.c_hits,
+      deltas: summary.d_hits,
+      misses: summary.miss_count,
+      no_shoots: summary.no_shoots,
+      procedurals: summary.procedurals,
+      dq: summary.dq,
+    };
+  });
+
+  // Surface both the match-overview cachedAt and the scorecards cachedAt — the
+  // match-overview value alone is misleading during scoring (event.updated does
+  // not tick on scorecard saves). Mirrors the contract documented on
+  // CacheInfo.scorecardsCachedAt.
+  const cacheInfo: CompetitorStageResults["cacheInfo"] = {
+    cachedAt: matchResult.cachedAt,
+    scorecardsCachedAt,
+  };
+  if (cacheInfo.cachedAt && (await isUpstreamDegraded())) {
+    cacheInfo.upstreamDegraded = true;
+  }
+  let lastScorecardTs: string | null = null;
+  for (const sc of rawScorecards) {
+    if (
+      sc.scorecard_created &&
+      (!lastScorecardTs || sc.scorecard_created > lastScorecardTs)
+    ) {
+      lastScorecardTs = sc.scorecard_created;
+    }
+  }
+  if (lastScorecardTs) cacheInfo.lastScorecardAt = lastScorecardTs;
+
+  const response: CompetitorStageResults = {
+    ct: ctNum,
+    matchId: matchIdNum,
+    competitorId: competitor.id,
+    shooterId: competitor.shooterId,
+    division: competitor.division,
+    stages,
+    cacheInfo,
+  };
+
+  return NextResponse.json(response);
+}

--- a/app/api/v1/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts
+++ b/app/api/v1/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts
@@ -1,0 +1,21 @@
+// /api/v1/match/{ct}/{id}/competitor/{competitorId}/stages -- public,
+// bearer-token-gated per-competitor stage results.
+//
+// Thin wrapper around the internal /api/match/[ct]/[id]/competitor/[competitorId]/stages
+// route. See docs/api-v1.md.
+
+import { GET as innerGET } from "@/app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route";
+import { forwardToInternal, gateV1Request, mapInnerToV1 } from "@/lib/api-v1";
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ ct: string; id: string; competitorId: string }> },
+) {
+  const gate = await gateV1Request(req);
+  if (gate instanceof Response) return gate;
+
+  const inner = await forwardToInternal(() => innerGET(req, { params }));
+  return mapInnerToV1(inner, {
+    notFoundMessage: "Match or competitor not found",
+  });
+}

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -22,10 +22,11 @@ All examples below use `$TOKEN` as a placeholder for a valid bearer token (see
 |---|---|---|
 | GET | `/api/v1/events` | Match search / browse |
 | GET | `/api/v1/match/{ct}/{id}` | Full match overview |
+| GET | `/api/v1/match/{ct}/{id}/competitor/{competitorId}/stages` | Per-competitor stage results for one match |
 | GET | `/api/v1/shooter/search` | Name search over indexed shooter profiles |
 | GET | `/api/v1/shooter/{shooterId}` | Shooter dashboard (stats, achievements, recent matches) |
 
-All four endpoints accept only `GET`. Other methods return `405 Method Not Allowed`.
+All endpoints accept only `GET`. Other methods return `405 Method Not Allowed`.
 
 ---
 
@@ -157,6 +158,70 @@ refetch -- absent on this endpoint, present in the compare endpoint).
 curl -s -H "Authorization: Bearer $TOKEN" \
   "https://scoreboard.urdr.dev/api/v1/match/22/27190" \
   | jq '{name, scoring_completed, stages: (.stages | length), competitors: (.competitors | length)}'
+```
+
+---
+
+## `GET /api/v1/match/{ct}/{id}/competitor/{competitorId}/stages`
+
+Per-competitor, per-stage results for a single match: time, hit factor, points,
+hit-zone counts, penalties, and DQ flag. Mirrors the data the MCP
+`compare_competitors` and `get_stage_times` tools return, but published on the
+v1 contract.
+
+### Path parameters
+
+| Param | Type | Notes |
+|---|---|---|
+| `ct` | number | SSI Django content type. `22` for IPSC matches. |
+| `id` | number | SSI numeric match ID. |
+| `competitorId` | number | Per-match competitor ID (`competitors[].id` from the match endpoint). **Not** the global `shooterId`. |
+
+### Response
+
+`200 OK` with a `CompetitorStageResults` object:
+
+| Field | Type | Notes |
+|---|---|---|
+| `ct` | number | Echoed. |
+| `matchId` | number | Echoed. |
+| `competitorId` | number | Echoed. |
+| `shooterId` | number \| null | Globally stable shooter ID. `null` when SSI did not surface one. |
+| `division` | string \| null | Division this competitor was registered in for this match (may differ from the shooter's profile division). |
+| `stages` | `CompetitorStageResult[]` | One entry per match stage, ordered by `stage_number` ascending. Stages without a scorecard are emitted with all numeric fields `null` and `dq=false` so callers see a stable per-stage entry. |
+| `cacheInfo` | `CacheInfo` | `cachedAt` is the match-overview cache age; `scorecardsCachedAt` is the scorecards cache age and is the right signal during scoring. |
+
+`CompetitorStageResult` per-stage fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `stage_number` | number | |
+| `stage_id` | number | SSI stage ID (matches `MatchResponse.stages[].id`). |
+| `time_seconds` | number \| null | Raw stage time. `null` for unscored / DNF / missing timer reading. |
+| `scorecard_updated_at` | string \| null | ISO timestamp of the scorecard. Drives splitsmith's video-match window. |
+| `hit_factor` | number \| null | |
+| `stage_points` | number \| null | Includes penalty deductions. |
+| `stage_pct` | number \| null | HF as percent of the overall stage leader's HF (0-100). |
+| `alphas` | number \| null | A-zone hit count. |
+| `charlies` | number \| null | C-zone hit count. SSI combines B-zone into C; this field reflects that. |
+| `deltas` | number \| null | D-zone hit count. |
+| `misses` | number \| null | |
+| `no_shoots` | number \| null | |
+| `procedurals` | number \| null | |
+| `dq` | boolean | `true` for the stage on which the competitor was disqualified. |
+
+### Errors
+
+- `404 not_found` -- match does not exist, or the competitor is not registered in this match.
+- `400 bad_request` -- `ct`, `id`, or `competitorId` is not a number.
+- `502 upstream_failed` -- SSI unreachable.
+
+### Example
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://scoreboard.urdr.dev/api/v1/match/22/27190/competitor/12345/stages" \
+  | jq '{division, stages: (.stages | map({stage_number, time_seconds, hit_factor}))}'
 ```
 
 ---

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -876,6 +876,47 @@ export interface ShooterSearchResult {
   lastSeen: string;
 }
 
+// Per-stage result for one competitor at one match.
+// Returned by GET /api/v1/match/{ct}/{id}/competitor/{competitorId}/stages.
+// Stages with no scorecard for the competitor have all numeric fields set to
+// null (and dq=false), so callers see a stable entry per match stage.
+export interface CompetitorStageResult {
+  stage_number: number;
+  stage_id: number;
+  /** Raw stage time in seconds; null when the competitor has no scorecard for the stage. */
+  time_seconds: number | null;
+  /** ISO timestamp of when the scorecard was recorded; null when unknown. */
+  scorecard_updated_at: string | null;
+  hit_factor: number | null;
+  /** Stage points after penalties; null when unscored. */
+  stage_points: number | null;
+  /** HF as percent of the overall stage leader's HF (0-100); null when unscored. */
+  stage_pct: number | null;
+  alphas: number | null;
+  /** B-zone is combined into C in the SSI scoring model. */
+  charlies: number | null;
+  deltas: number | null;
+  misses: number | null;
+  no_shoots: number | null;
+  procedurals: number | null;
+  /** True for the stage on which the competitor was disqualified. */
+  dq: boolean;
+}
+
+// Response from GET /api/v1/match/{ct}/{id}/competitor/{competitorId}/stages.
+export interface CompetitorStageResults {
+  ct: number;
+  matchId: number;
+  competitorId: number;
+  /** Globally stable ShooterNode ID; null when SSI did not surface one. */
+  shooterId: number | null;
+  /** Division this competitor was registered in for this match. */
+  division: string | null;
+  /** One entry per match stage, ordered by stage_number ascending. */
+  stages: CompetitorStageResult[];
+  cacheInfo: CacheInfo;
+}
+
 // Re-export achievement types for convenience.
 export type {
   AchievementProgress,

--- a/tests/unit/__snapshots__/api-v1-routes.test.ts.snap
+++ b/tests/unit/__snapshots__/api-v1-routes.test.ts.snap
@@ -125,6 +125,72 @@ exports[`/api/v1/match/[ct]/[id] > returns the match payload through the v1 enve
 }
 `;
 
+exports[`/api/v1/match/[ct]/[id]/competitor/[competitorId]/stages > maps a 400 from the inner route to bad_request 1`] = `
+{
+  "error": {
+    "code": "bad_request",
+    "message": "Invalid ct, id, or competitorId",
+  },
+}
+`;
+
+exports[`/api/v1/match/[ct]/[id]/competitor/[competitorId]/stages > maps a 404 from the inner route to not_found 1`] = `
+{
+  "error": {
+    "code": "not_found",
+    "message": "Match or competitor not found",
+  },
+}
+`;
+
+exports[`/api/v1/match/[ct]/[id]/competitor/[competitorId]/stages > returns the per-competitor stage results through the v1 envelope 1`] = `
+{
+  "cacheInfo": {
+    "cachedAt": "2026-04-27T10:00:00Z",
+    "scorecardsCachedAt": "2026-04-27T10:00:05Z",
+  },
+  "competitorId": 101,
+  "ct": 22,
+  "division": "Production Optics",
+  "matchId": 27190,
+  "shooterId": 12345,
+  "stages": [
+    {
+      "alphas": 12,
+      "charlies": 0,
+      "deltas": 0,
+      "dq": false,
+      "hit_factor": 8.142,
+      "misses": 0,
+      "no_shoots": 0,
+      "procedurals": 0,
+      "scorecard_updated_at": "2026-04-26T09:14:32Z",
+      "stage_id": 5001,
+      "stage_number": 1,
+      "stage_pct": 100,
+      "stage_points": 150,
+      "time_seconds": 18.42,
+    },
+    {
+      "alphas": null,
+      "charlies": null,
+      "deltas": null,
+      "dq": false,
+      "hit_factor": null,
+      "misses": null,
+      "no_shoots": null,
+      "procedurals": null,
+      "scorecard_updated_at": null,
+      "stage_id": 5002,
+      "stage_number": 2,
+      "stage_pct": null,
+      "stage_points": null,
+      "time_seconds": null,
+    },
+  ],
+}
+`;
+
 exports[`/api/v1/shooter/[shooterId] > maps GDPR 410 to not_found preserving the 410 status code 1`] = `
 {
   "error": {

--- a/tests/unit/api-v1-routes.test.ts
+++ b/tests/unit/api-v1-routes.test.ts
@@ -12,6 +12,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
+  CompetitorStageResults,
   EventSummary,
   MatchResponse,
   ShooterDashboardResponse,
@@ -34,11 +35,20 @@ const innerShooterSearch = vi.hoisted(() => vi.fn<(req: Request) => Promise<Resp
 const innerShooterDashboard = vi.hoisted(() =>
   vi.fn<(req: Request, ctx: { params: Promise<{ shooterId: string }> }) => Promise<Response>>(),
 );
+const innerCompetitorStages = vi.hoisted(() =>
+  vi.fn<(
+    req: Request,
+    ctx: { params: Promise<{ ct: string; id: string; competitorId: string }> },
+  ) => Promise<Response>>(),
+);
 
 vi.mock("@/app/api/events/route", () => ({ GET: innerEvents }));
 vi.mock("@/app/api/match/[ct]/[id]/route", () => ({ GET: innerMatch }));
 vi.mock("@/app/api/shooter/search/route", () => ({ GET: innerShooterSearch }));
 vi.mock("@/app/api/shooter/[shooterId]/route", () => ({ GET: innerShooterDashboard }));
+vi.mock("@/app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route", () => ({
+  GET: innerCompetitorStages,
+}));
 
 const ORIGINAL_TOKENS = process.env.EXTERNAL_API_TOKENS;
 
@@ -50,6 +60,7 @@ beforeEach(() => {
   innerMatch.mockReset();
   innerShooterSearch.mockReset();
   innerShooterDashboard.mockReset();
+  innerCompetitorStages.mockReset();
 });
 
 afterEach(() => {
@@ -336,6 +347,115 @@ describe("/api/v1/shooter/[shooterId]", () => {
       { params: Promise.resolve({ shooterId: "12345" }) },
     );
     expect(res.status).toBe(410);
+    expect(await res.json()).toMatchSnapshot();
+  });
+});
+
+describe("/api/v1/match/[ct]/[id]/competitor/[competitorId]/stages", () => {
+  it("returns the per-competitor stage results through the v1 envelope", async () => {
+    const payload = {
+      ct: 22,
+      matchId: 27190,
+      competitorId: 101,
+      shooterId: 12345,
+      division: "Production Optics",
+      stages: [
+        {
+          stage_number: 1,
+          stage_id: 5001,
+          time_seconds: 18.42,
+          scorecard_updated_at: "2026-04-26T09:14:32Z",
+          hit_factor: 8.142,
+          stage_points: 150,
+          stage_pct: 100,
+          alphas: 12,
+          charlies: 0,
+          deltas: 0,
+          misses: 0,
+          no_shoots: 0,
+          procedurals: 0,
+          dq: false,
+        },
+        {
+          stage_number: 2,
+          stage_id: 5002,
+          time_seconds: null,
+          scorecard_updated_at: null,
+          hit_factor: null,
+          stage_points: null,
+          stage_pct: null,
+          alphas: null,
+          charlies: null,
+          deltas: null,
+          misses: null,
+          no_shoots: null,
+          procedurals: null,
+          dq: false,
+        },
+      ],
+      cacheInfo: {
+        cachedAt: "2026-04-27T10:00:00Z",
+        scorecardsCachedAt: "2026-04-27T10:00:05Z",
+      },
+    } satisfies CompetitorStageResults;
+    innerCompetitorStages.mockResolvedValue(
+      new Response(JSON.stringify(payload), { status: 200 }),
+    );
+
+    const { GET } = await import(
+      "@/app/api/v1/match/[ct]/[id]/competitor/[competitorId]/stages/route"
+    );
+    const res = await GET(
+      new Request("http://x/api/v1/match/22/27190/competitor/101/stages", {
+        headers: auth,
+      }),
+      {
+        params: Promise.resolve({ ct: "22", id: "27190", competitorId: "101" }),
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchSnapshot();
+  });
+
+  it("maps a 404 from the inner route to not_found", async () => {
+    innerCompetitorStages.mockResolvedValue(
+      new Response(JSON.stringify({ error: "Competitor not found in this match" }), {
+        status: 404,
+      }),
+    );
+    const { GET } = await import(
+      "@/app/api/v1/match/[ct]/[id]/competitor/[competitorId]/stages/route"
+    );
+    const res = await GET(
+      new Request("http://x/api/v1/match/22/27190/competitor/999/stages", {
+        headers: auth,
+      }),
+      {
+        params: Promise.resolve({ ct: "22", id: "27190", competitorId: "999" }),
+      },
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchSnapshot();
+  });
+
+  it("maps a 400 from the inner route to bad_request", async () => {
+    innerCompetitorStages.mockResolvedValue(
+      new Response(JSON.stringify({ error: "Invalid ct, id, or competitorId" }), {
+        status: 400,
+      }),
+    );
+    const { GET } = await import(
+      "@/app/api/v1/match/[ct]/[id]/competitor/[competitorId]/stages/route"
+    );
+    const res = await GET(
+      new Request("http://x/api/v1/match/abc/27190/competitor/101/stages", {
+        headers: auth,
+      }),
+      {
+        params: Promise.resolve({ ct: "abc", id: "27190", competitorId: "101" }),
+      },
+    );
+    expect(res.status).toBe(400);
     expect(await res.json()).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Closes #400.

## Summary
- New `GET /api/v1/match/{ct}/{id}/competitor/{competitorId}/stages` endpoint -- per-stage time, hit factor, points, stage_pct, hit-zone counts, penalties, and DQ flag for a single competitor in a match.
- Follows the existing v1 pattern: thin wrapper (same bearer auth, per-token rate limit, error envelope) over a focused internal route under `app/api/match/.../competitor/[competitorId]/stages`.
- Internal route reuses `fetchMatchData` for match-side TTL/SWR/shooter-index hygiene and mirrors `app/api/compare/route.ts`'s scorecards TTL+SWR machinery; it then runs `computeGroupRankings([competitor])` and emits one entry per match stage (numeric fields null + `dq=false` for stages with no scorecard so the per-stage list is stable).
- New `CompetitorStageResult` / `CompetitorStageResults` types in `lib/types.ts`. Snapshot test added next to the existing v1 ones, fixture typed via `satisfies` for drift detection.
- Docs: new section in `docs/api-v1.md` (path params, response fields, errors, curl example) and the endpoint list in `CLAUDE.md`.

`charlies` reflects SSI's B-into-C combination -- documented in both the type and the v1 doc.

## Test plan
- [x] `pnpm -w run typecheck` clean
- [x] `pnpm -w run lint` clean
- [x] `pnpm -w test` (1669 tests pass, including 3 new snapshots for the new endpoint)
- [ ] Manual smoke test with a real bearer token against an active match once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)