### PR TITLE
fix(graphql): send x-api-key header to comply with SSI requirement

### DIFF
--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -120,6 +120,7 @@ async function executeQueryOnce<T>(
       headers: {
         "Content-Type": "application/json",
         Authorization: `Api-Key ${apiKey}`,
+        "x-api-key": apiKey,
       },
       body: JSON.stringify({ query, variables }),
       cache: revalidate === false ? "no-store" : undefined,

--- a/scripts/check-ssi-schema.ts
+++ b/scripts/check-ssi-schema.ts
@@ -74,7 +74,7 @@ async function introspectType(typeName: string, endpoint: string, token: string)
   const query = `{ __type(name: "${typeName}") { fields { name type { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind } } } } } args { name type { name kind ofType { name kind ofType { name kind ofType { name kind } } } } } } } }`;
   const r = await fetch(endpoint, {
     method: "POST",
-    headers: { "Content-Type": "application/json", Authorization: `Token ${token}` },
+    headers: { "Content-Type": "application/json", Authorization: `Token ${token}`, "x-api-key": token },
     body: JSON.stringify({ query }),
   });
   if (!r.ok) throw new Error(`SSI HTTP ${r.status}`);


### PR DESCRIPTION
## Summary
- SSI's 2026-05-04 admin announcement makes the `x-api-key` header mandatory on every GraphQL request. Non-compliant keys risk being disabled.
- Add `x-api-key: \${apiKey}` alongside the existing `Authorization: Api-Key \${apiKey}` in `executeQuery` (`lib/graphql.ts`).
- Add the same header to the schema-check script (`scripts/check-ssi-schema.ts`) so introspection keeps working.

This is the smallest possible compliance fix and ships ahead of the larger inefficiency-reduction work tracked in #404 / #405 / #406 / #407 / #408.

Closes #403.

## Test plan
- [x] `pnpm -w run typecheck` -- clean
- [x] `pnpm -w run lint` -- clean
- [x] `pnpm -w test` -- 56 files / 1669 tests pass
- [x] `pnpm tsx scripts/check-ssi-schema.ts` -- live introspection authenticates with the new header
- [ ] Post-deploy: spot-check `upstream-graphql-request` telemetry to confirm requests are still succeeding upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)