### PR TITLE
feat(match-ttl): add isMatchCompleteFromEvent() wrapper (PR-A for #410)

### DIFF
--- a/lib/match-ttl.ts
+++ b/lib/match-ttl.ts
@@ -109,6 +109,41 @@ export function isMatchComplete(
 }
 
 /**
+ * High-level form of `isMatchComplete()` that takes the raw fields callers
+ * already have on hand (an effective scoring percentage, a start-date string
+ * or Date, the SSI status, and the SSI results status). Computes `daysSince`
+ * and the signals object internally so each call site doesn't repeat that
+ * arithmetic.
+ *
+ * Use this whenever you have a match-event-shaped object; reach for the
+ * primitive `isMatchComplete()` only when the inputs come from somewhere
+ * non-event-shaped (e.g. a synthetic test fixture).
+ */
+export interface MatchCompletionInputs {
+  /** Effective scoring percentage (0-100). Use `effectiveMatchScoringPct(ev)` to derive. */
+  scoringPct: number;
+  /** Match start date — accepts ISO string, Date, or null/undefined for unknown. */
+  startDate: string | Date | null | undefined;
+  /** SSI `event.status` field — pass through unchanged. */
+  status: string | null | undefined;
+  /** SSI `event.results` field — pass through unchanged. The helper handles the `=== "all"` check. */
+  resultsStatus: string | null | undefined;
+}
+
+export function isMatchCompleteFromEvent(input: MatchCompletionInputs): boolean {
+  const matchDate = input.startDate
+    ? input.startDate instanceof Date
+      ? input.startDate
+      : new Date(input.startDate)
+    : null;
+  const daysSince = matchDate ? (Date.now() - matchDate.getTime()) / 86_400_000 : 0;
+  return isMatchComplete(input.scoringPct, daysSince, {
+    status: input.status ?? null,
+    resultsPublished: input.resultsStatus === "all",
+  });
+}
+
+/**
  * Is the match scoring "settled enough" for downstream consumers that need
  * authoritative data — e.g. coaching tips, achievement evaluation? Distinct
  * from `isMatchComplete()`, which gates *permanent cache pinning* and so

--- a/tests/unit/match-ttl.test.ts
+++ b/tests/unit/match-ttl.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { computeMatchTtl, computeMatchFreshness, isMatchComplete } from "@/lib/match-ttl";
+import {
+  computeMatchTtl,
+  computeMatchFreshness,
+  isMatchComplete,
+  isMatchCompleteFromEvent,
+} from "@/lib/match-ttl";
 
 const NOW = new Date("2025-06-15T12:00:00Z").getTime();
 
@@ -91,6 +96,91 @@ describe("isMatchComplete", () => {
   it("false for future matches", () => {
     expect(isMatchComplete(0, -1)).toBe(false);
     expect(isMatchComplete(0, -10)).toBe(false);
+  });
+});
+
+describe("isMatchCompleteFromEvent", () => {
+  it("computes daysSince from an ISO start-date string", () => {
+    expect(
+      isMatchCompleteFromEvent({
+        scoringPct: 99,
+        startDate: isoHoursFromNow(-100),
+        status: null,
+        resultsStatus: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a Date object as well as a string", () => {
+    expect(
+      isMatchCompleteFromEvent({
+        scoringPct: 99,
+        startDate: new Date(NOW - 100 * 3_600_000),
+        status: null,
+        resultsStatus: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats null/undefined startDate as daysSince=0 (inside the time gate)", () => {
+    expect(
+      isMatchCompleteFromEvent({
+        scoringPct: 100,
+        startDate: null,
+        status: "cp",
+        resultsStatus: "all",
+      }),
+    ).toBe(false);
+    expect(
+      isMatchCompleteFromEvent({
+        scoringPct: 100,
+        startDate: undefined,
+        status: "cp",
+        resultsStatus: "all",
+      }),
+    ).toBe(false);
+  });
+
+  it("maps resultsStatus === 'all' to resultsPublished signal", () => {
+    expect(
+      isMatchCompleteFromEvent({
+        scoringPct: 0,
+        startDate: isoHoursFromNow(-100),
+        status: null,
+        resultsStatus: "all",
+      }),
+    ).toBe(true);
+    expect(
+      isMatchCompleteFromEvent({
+        scoringPct: 0,
+        startDate: isoHoursFromNow(-100),
+        status: null,
+        resultsStatus: "org", // not "all" -> not published
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves the cancelled-status terminal short-circuit", () => {
+    expect(
+      isMatchCompleteFromEvent({
+        scoringPct: 0,
+        startDate: isoHoursFromNow(-1),
+        status: "cs",
+        resultsStatus: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves the time-gate protection against premature flag flips", () => {
+    // Skepplanda regression: mid-match SSI flips results=all but daysSince <= 3
+    expect(
+      isMatchCompleteFromEvent({
+        scoringPct: 99,
+        startDate: isoHoursFromNow(-48),
+        status: "cp",
+        resultsStatus: "all",
+      }),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds a thin high-level wrapper \`isMatchCompleteFromEvent()\` around the existing \`isMatchComplete()\` predicate in \`lib/match-ttl.ts\`.
- The wrapper accepts the raw event fields callers already have on hand (\`scoringPct\`, \`startDate\`, \`status\`, \`resultsStatus\`) and computes \`daysSince\` + the signals object internally.
- 6 new tests covering: ISO-string and Date inputs, null/undefined startDate handling, resultsStatus mapping, the cancelled-status terminal short-circuit, and the time-gate protection against premature SSI flag flips.

## Why now
PR-B (#405), PR-C (#406), and PR-D (#404) in the live-views-only redesign (#410) each need a single high-level gate to ask "is this match complete enough to fetch / display whole-match data?". This wrapper avoids each new call site re-deriving \`daysSince\` and the signals object.

## Why not migrate the existing 4 call sites
The 4 existing manual call sites (\`lib/match-data.ts\`, \`app/api/compare/route.ts\`, \`app/api/coaching/[ct]/[id]/[competitorId]/route.ts\`, \`app/api/og/match/[ct]/[id]/route.tsx\`) all already compute \`daysSince\` and \`signals\` because they reuse those values for TTL machinery (\`computeMatchSwrTtl\`, \`computeMatchFreshness\`). Migrating them would be churn without a DRY win.

## Test plan
- [x] \`pnpm -w run typecheck\` -- clean
- [x] \`pnpm -w run lint\` -- clean
- [x] \`pnpm -w test\` -- 56 files / 1675 tests pass (up from 1669)

🤖 Generated with [Claude Code](https://claude.com/claude-code)