### PR TITLE
feat(scorecards): per-competitor live fetcher + /stages migration (PR-B for #410)

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -268,6 +268,7 @@ export async function GET(req: Request) {
       parseInt(c.id, 10),
       {
         id: parseInt(c.id, 10),
+        content_type: c.get_content_type_key,
         shooterId: decodeShooterId(c.shooter?.id),
         name: [c.first_name, c.last_name].filter(Boolean).join(" ") || "Unknown",
         competitor_number: c.number ?? "",

--- a/app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts
+++ b/app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts
@@ -12,9 +12,15 @@ import { reportError } from "@/lib/error-telemetry";
 import { cachedExecuteQuery, gqlCacheKey, refreshCachedMatchQuery, SCORECARDS_QUERY } from "@/lib/graphql";
 import { fetchMatchData } from "@/lib/match-data";
 import { persistToMatchStore } from "@/lib/match-data-store";
-import { computeMatchFreshness, computeMatchSwrTtl } from "@/lib/match-ttl";
+import {
+  computeMatchFreshness,
+  computeMatchSwrTtl,
+  isMatchCompleteFromEvent,
+} from "@/lib/match-ttl";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
+import { fetchSelectedCompetitorsScorecards } from "@/lib/scorecards-per-competitor";
+import type { RawScorecard } from "@/app/api/compare/logic";
 import { maybeTagAsMcp } from "@/lib/telemetry-context";
 import { isUpstreamDegraded } from "@/lib/upstream-status";
 import { computeGroupRankings } from "@/app/api/compare/logic";
@@ -77,72 +83,162 @@ export async function GET(
     signals,
   );
 
-  const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
-  let scorecardsData: RawScorecardsData;
+  // Pick the fetch path based on whether the match is complete:
+  //  - complete  -> whole-match scorecards (will move to per-stage archive in PR-D)
+  //  - live      -> per-competitor scorecards via SSI's `competitor_scorecards()`,
+  //                 the SSI-blessed pattern after their 2026-05-04 announcement.
+  // During live, whole-field-derived fields like `stage_pct` are not available
+  // and surface as null; the UI surfaces this via the gate added in PR-C.
+  const isComplete = isMatchCompleteFromEvent({
+    scoringPct: match.scoring_completed,
+    startDate: match.date,
+    status: match.match_status,
+    resultsStatus: match.results_status,
+  });
+
+  let rawScorecards: RawScorecard[];
   let scorecardsCachedAt: string | null;
-  try {
-    ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
-      await cachedExecuteQuery<RawScorecardsData>(
-        scorecardsKey,
-        SCORECARDS_QUERY,
-        { ct: ctNum, id },
-        dataTtl,
-      ));
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Upstream error";
-    return NextResponse.json({ error: message }, { status: 502 });
-  }
+  // Map of stage_id → CompetitorSummary (full or partial) for the requested
+  // competitor. Whole-field-derived members are null when running the live
+  // (per-competitor) path.
+  const summaryByStageId = new Map<number, CompetitorSummary>();
 
-  // Promote the scorecards cache TTL to match the resolved match state.
-  try {
-    if (dataTtl === null) {
-      const raw = await cache.get(scorecardsKey);
-      if (raw) {
-        await cache.persist(scorecardsKey);
-        afterResponse(persistToMatchStore(scorecardsKey, raw));
-      }
-    } else if (!scorecardsCachedAt) {
-      await cache.expire(scorecardsKey, dataTtl);
-    }
-  } catch (err) {
-    reportError("competitor-stages.scorecards-ttl-apply", err, {
-      matchKey: scorecardsKey,
-    });
-  }
-
-  // SWR for scorecards — single-flighted inside refreshCachedMatchQuery.
-  const matchFreshness = computeMatchFreshness(
-    match.scoring_completed,
-    daysSince,
-    match.date,
-    signals,
-  );
-  if (scorecardsCachedAt && dataTtl != null && matchFreshness != null) {
-    const age =
-      (Date.now() - new Date(scorecardsCachedAt).getTime()) / 1000;
-    if (age > matchFreshness) {
-      afterResponse(
-        refreshCachedMatchQuery<RawScorecardsData>(
+  if (isComplete) {
+    // Post-match: existing whole-match path.
+    const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
+    let scorecardsData: RawScorecardsData;
+    try {
+      ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
+        await cachedExecuteQuery<RawScorecardsData>(
           scorecardsKey,
           SCORECARDS_QUERY,
           { ct: ctNum, id },
           dataTtl,
-          { ct: ctNum, id },
-        ),
+        ));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Upstream error";
+      return NextResponse.json({ error: message }, { status: 502 });
+    }
+
+    // Promote the scorecards cache TTL to match the resolved match state.
+    try {
+      if (dataTtl === null) {
+        const raw = await cache.get(scorecardsKey);
+        if (raw) {
+          await cache.persist(scorecardsKey);
+          afterResponse(persistToMatchStore(scorecardsKey, raw));
+        }
+      } else if (!scorecardsCachedAt) {
+        await cache.expire(scorecardsKey, dataTtl);
+      }
+    } catch (err) {
+      reportError("competitor-stages.scorecards-ttl-apply", err, {
+        matchKey: scorecardsKey,
+      });
+    }
+
+    // SWR for scorecards — single-flighted inside refreshCachedMatchQuery.
+    const matchFreshness = computeMatchFreshness(
+      match.scoring_completed,
+      daysSince,
+      match.date,
+      signals,
+    );
+    if (scorecardsCachedAt && dataTtl != null && matchFreshness != null) {
+      const age =
+        (Date.now() - new Date(scorecardsCachedAt).getTime()) / 1000;
+      if (age > matchFreshness) {
+        afterResponse(
+          refreshCachedMatchQuery<RawScorecardsData>(
+            scorecardsKey,
+            SCORECARDS_QUERY,
+            { ct: ctNum, id },
+            dataTtl,
+            { ct: ctNum, id },
+          ),
+        );
+      }
+    }
+
+    rawScorecards = parseRawScorecards(scorecardsData);
+    const stageComparisons = computeGroupRankings(rawScorecards, [competitor]);
+    for (const stage of stageComparisons) {
+      const summary = stage.competitors[competitor.id];
+      if (summary) summaryByStageId.set(stage.stage_id, summary);
+    }
+  } else {
+    // Live: per-competitor scorecards only. We never pull other shooters'
+    // data, so whole-field stats are unavailable and surface as null.
+    if (competitor.content_type == null) {
+      return NextResponse.json(
+        { error: "Competitor metadata missing content_type — refresh the match" },
+        { status: 502 },
       );
     }
-  }
+    const matchStageIds = new Set(match.stages.map((s) => s.id));
+    try {
+      const result = await fetchSelectedCompetitorsScorecards(
+        [
+          {
+            ct: competitor.content_type,
+            id: String(competitor.id),
+            numericId: competitor.id,
+          },
+        ],
+        matchStageIds,
+        dataTtl,
+      );
+      rawScorecards = result.scorecards;
+      scorecardsCachedAt = result.cachedAts[0] ?? null;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Upstream error";
+      return NextResponse.json({ error: message }, { status: 502 });
+    }
 
-  const rawScorecards = parseRawScorecards(scorecardsData);
-  const stageComparisons = computeGroupRankings(rawScorecards, [competitor]);
+    // Build per-stage summaries from per-competitor data only. Whole-field
+    // fields (group/division/overall ranks and percents, classification) stay
+    // null until the match is complete.
+    const withTimestamps = rawScorecards
+      .filter((sc) => sc.scorecard_created)
+      .sort((a, b) => a.scorecard_created!.localeCompare(b.scorecard_created!));
+    const shootingOrderByStageId = new Map<number, number>();
+    withTimestamps.forEach((sc, i) =>
+      shootingOrderByStageId.set(sc.stage_id, i + 1),
+    );
 
-  // Build a stage_id → CompetitorSummary lookup. Stages with no scorecards in
-  // the field are absent from `stageComparisons`; we still emit them with null
-  // fields so callers see one entry per match stage.
-  const summaryByStageId = new Map<number, CompetitorSummary>();
-  for (const stage of stageComparisons) {
-    const summary = stage.competitors[competitor.id];
-    if (summary) summaryByStageId.set(stage.stage_id, summary);
+    for (const sc of rawScorecards) {
+      const penaltyLossPoints =
+        ((sc.miss_count ?? 0) + (sc.no_shoots ?? 0) + (sc.procedurals ?? 0)) * 10;
+      summaryByStageId.set(sc.stage_id, {
+        competitor_id: sc.competitor_id,
+        points: sc.points,
+        hit_factor: sc.hit_factor,
+        time: sc.time,
+        group_rank: null,
+        group_percent: null,
+        div_rank: null,
+        div_percent: null,
+        overall_rank: null,
+        overall_percent: null,
+        overall_percentile: null,
+        dq: sc.dq,
+        zeroed: sc.zeroed,
+        dnf: sc.dnf,
+        incomplete: sc.incomplete,
+        a_hits: sc.a_hits,
+        c_hits: sc.c_hits,
+        d_hits: sc.d_hits,
+        miss_count: sc.miss_count,
+        no_shoots: sc.no_shoots,
+        procedurals: sc.procedurals,
+        shooting_order: shootingOrderByStageId.get(sc.stage_id) ?? null,
+        divisionKey: sc.competitor_division ?? null,
+        stageClassification: null,
+        hitLossPoints: null,
+        penaltyLossPoints,
+        scorecard_created: sc.scorecard_created,
+      });
+    }
   }
 
   const sortedMatchStages = [...match.stages].sort(

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -890,12 +890,16 @@ export async function cachedExecuteQuery<T>(
 }
 
 // ─── Shared scorecard field set ──────────────────────────────────────────────
-// CRITICAL: SCORECARDS_QUERY and SCORECARDS_DELTA_QUERY MUST request the same
-// scorecard fields. The delta merge (#362, lib/scorecard-merge.ts) writes
-// delta entries into the cached full snapshot — if the delta is missing fields
-// the full query has, the merge silently corrupts the cached entry.
+// CRITICAL: SCORECARDS_QUERY, SCORECARDS_DELTA_QUERY, and
+// COMPETITOR_SCORECARDS_QUERY MUST request the same scorecard fields. The delta
+// merge (#362, lib/scorecard-merge.ts) writes delta entries into the cached
+// full snapshot — if the delta is missing fields the full query has, the merge
+// silently corrupts the cached entry. The per-competitor query in
+// lib/scorecards-per-competitor.ts feeds the same RawScorecard parser, so it
+// must project the same field set too.
 //
-// This shared constant is interpolated into both queries so they CANNOT drift.
+// This shared constant is interpolated into all three queries so they CANNOT
+// drift. Exported so the per-competitor module can reuse it without copying.
 //
 // When adding a scorecard field, see CLAUDE.md → "Delta-merge contract" for
 // the full list of files that must be updated together. In short:
@@ -905,7 +909,7 @@ export async function cachedExecuteQuery<T>(
 //   4. Copy in deltaToCacheCard() (lib/scorecard-merge.ts)
 //   5. Bump CACHE_SCHEMA_VERSION (lib/constants.ts)
 //   6. Run `pnpm check:ssi-schema --update` and commit the snapshot diff
-const SCORECARD_NODE_FIELDS = `
+export const SCORECARD_NODE_FIELDS = `
   ... on IpscScoreCardNode {
     created
     points

--- a/lib/match-data.ts
+++ b/lib/match-data.ts
@@ -271,6 +271,7 @@ export async function fetchMatchData(
     ev.competitors_approved_w_wo_results_not_dnf ?? []
   ).map((c) => ({
     id: parseInt(c.id, 10),
+    content_type: c.get_content_type_key,
     shooterId: decodeShooterId(c.shooter?.id),
     name: [c.first_name, c.last_name].filter(Boolean).join(" ") || "Unknown",
     competitor_number: c.number ?? "",

--- a/lib/scorecards-per-competitor.ts
+++ b/lib/scorecards-per-competitor.ts
@@ -1,0 +1,258 @@
+// Server-only — fetches per-competitor scorecard data via SSI's
+// `competitor_scorecards()` and `competitor_scorecards_count()` root queries
+// (added 2026-05-04 alongside SSI's deprecation of the whole-match
+// `event { stages { scorecards } }` path).
+//
+// This module exists so live views can fetch ONLY the competitors a user
+// has selected, instead of pulling every scorecard for every competitor in
+// a match. See #410 for the redesign rationale.
+//
+// Cache strategy: Redis-only, keyed per (competitor_ct, competitor_id). No
+// D1 mirror — entries are small enough that re-fetching from upstream after
+// a Redis eviction is acceptable. If we ever need durability for these
+// (e.g. for shooter-dashboard offline reads), add a sibling table.
+
+import {
+  cachedExecuteQuery,
+  executeQuery,
+  gqlCacheKey,
+  SCORECARD_NODE_FIELDS,
+} from "@/lib/graphql";
+import type { RawScorecard } from "@/app/api/compare/logic";
+
+// ─── Queries ─────────────────────────────────────────────────────────────────
+
+// Fetches every scorecard for a single competitor across every stage of every
+// match they have appeared in. Returns a flat list (not nested by stage).
+//
+// Each scorecard carries its own `stage` reference so the caller can rebucket
+// per stage if needed. The `competitor` block is redundant for per-competitor
+// queries (we already know whose data this is) but is preserved so the same
+// `parseRawScorecards`-shaped output can be produced without forking the
+// downstream parser.
+export const COMPETITOR_SCORECARDS_QUERY = `
+  query GetCompetitorScorecards($ct: Int!, $id: String!) {
+    competitor_scorecards(content_type: $ct, id: $id) {
+      ... on IpscScoreCardNode {
+        stage {
+          id
+          number
+          name
+          ... on IpscStageNode {
+            max_points
+          }
+        }
+      }
+      ${SCORECARD_NODE_FIELDS}
+    }
+  }
+`;
+
+// Tiny probe query — returns just the scalar count. Used to detect changes
+// before triggering a full per-competitor refetch (planned in PR-E).
+export const COMPETITOR_SCORECARDS_COUNT_QUERY = `
+  query GetCompetitorScorecardsCount($ct: Int!, $id: String!) {
+    competitor_scorecards_count(content_type: $ct, id: $id)
+  }
+`;
+
+// ─── Raw response shapes ─────────────────────────────────────────────────────
+
+interface RawCompetitorScCard {
+  stage?: {
+    id: string;
+    number: number;
+    name: string;
+    max_points?: number | null;
+  } | null;
+  created?: string | null;
+  points?: number | string | null;
+  hitfactor?: number | string | null;
+  time?: number | string | null;
+  disqualified?: boolean | null;
+  zeroed?: boolean | null;
+  stage_not_fired?: boolean | null;
+  incomplete?: boolean | null;
+  ascore?: number | string | null;
+  bscore?: number | string | null;
+  cscore?: number | string | null;
+  dscore?: number | string | null;
+  miss?: number | string | null;
+  penalty?: number | string | null;
+  procedural?: number | string | null;
+  competitor?: {
+    id: string;
+    get_division_display?: string | null;
+    handgun_div?: string | null;
+    get_handgun_div_display?: string | null;
+  } | null;
+}
+
+export interface CompetitorScorecardsData {
+  competitor_scorecards: RawCompetitorScCard[];
+}
+
+export interface CompetitorScorecardsCountData {
+  competitor_scorecards_count: number;
+}
+
+// ─── Parser ──────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a per-competitor GraphQL response into RawScorecard[] (the same flat
+ * shape `parseRawScorecards()` produces from the whole-match query). Filters
+ * to the requested competitor id so multi-match noise from the upstream
+ * response (a single shooter usually competes in many matches) is dropped
+ * before we try to use it for a single-match comparison.
+ *
+ * `matchStageIds` is the set of stage ids that belong to the match currently
+ * being rendered. Scorecards from other matches (e.g. earlier events the
+ * shooter competed in) will not have stage ids in this set and are filtered
+ * out.
+ */
+export function parseCompetitorScorecards(
+  data: CompetitorScorecardsData,
+  competitorId: number,
+  matchStageIds: Set<number>,
+): RawScorecard[] {
+  const out: RawScorecard[] = [];
+  const parseNum = (v: number | string | null | undefined): number | null =>
+    v != null ? parseFloat(String(v)) : null;
+
+  for (const sc of data.competitor_scorecards ?? []) {
+    if (!sc.stage || !sc.competitor) continue;
+
+    const stageId = parseInt(sc.stage.id, 10);
+    if (!matchStageIds.has(stageId)) continue;
+
+    const compId = parseInt(sc.competitor.id, 10);
+    if (compId !== competitorId) continue;
+
+    const b = parseNum(sc.bscore);
+    const c = parseNum(sc.cscore);
+    out.push({
+      competitor_id: compId,
+      competitor_division:
+        sc.competitor.get_division_display ||
+        sc.competitor.get_handgun_div_display ||
+        sc.competitor.handgun_div ||
+        null,
+      stage_id: stageId,
+      stage_number: sc.stage.number,
+      stage_name: sc.stage.name,
+      max_points: sc.stage.max_points ?? 0,
+      points: parseNum(sc.points),
+      hit_factor: parseNum(sc.hitfactor),
+      time: parseNum(sc.time),
+      dq: sc.disqualified ?? false,
+      zeroed: sc.zeroed ?? false,
+      dnf: sc.stage_not_fired ?? false,
+      incomplete: sc.incomplete ?? false,
+      a_hits: parseNum(sc.ascore),
+      c_hits: b !== null || c !== null ? (b ?? 0) + (c ?? 0) : null,
+      d_hits: parseNum(sc.dscore),
+      miss_count: parseNum(sc.miss),
+      no_shoots: parseNum(sc.penalty),
+      procedurals: parseNum(sc.procedural),
+      scorecard_created: sc.created ?? null,
+    });
+  }
+
+  return out;
+}
+
+// ─── Cache wrappers ──────────────────────────────────────────────────────────
+
+/**
+ * Cached fetch of one competitor's scorecards. Same TTL semantics as
+ * `cachedExecuteQuery` for the match-overview key — caller decides how long
+ * the entry stays in Redis.
+ *
+ * Cache key is keyed on the **competitor's** (ct, id), not the match's. A
+ * single shooter's scorecards are global-ish (cover all matches they have
+ * shot) so a per-competitor cache is shared across all matches that need
+ * data for that shooter. The match-stage-id filter applied during parsing
+ * scopes the response to one match at the consumer side.
+ */
+export async function cachedCompetitorScorecards(
+  competitorCt: number,
+  competitorId: string,
+  ttlSeconds: number | null,
+): Promise<{ data: CompetitorScorecardsData; cachedAt: string | null }> {
+  const cacheKey = gqlCacheKey("GetCompetitorScorecards", {
+    ct: competitorCt,
+    id: competitorId,
+  });
+  return cachedExecuteQuery<CompetitorScorecardsData>(
+    cacheKey,
+    COMPETITOR_SCORECARDS_QUERY,
+    { ct: competitorCt, id: competitorId },
+    ttlSeconds,
+  );
+}
+
+/**
+ * Uncached fan-out probe for a single competitor's scorecards count.
+ *
+ * Not currently called from any runtime path — added now so PR-E (cadence
+ * tiering / SWR per-competitor) has a ready hook. Each call is one tiny
+ * round-trip; SWR-style usage will batch these per match-tab.
+ */
+export async function fetchCompetitorScorecardsCount(
+  competitorCt: number,
+  competitorId: string,
+): Promise<number> {
+  const data = await executeQuery<CompetitorScorecardsCountData>(
+    COMPETITOR_SCORECARDS_COUNT_QUERY,
+    { ct: competitorCt, id: competitorId },
+  );
+  return data.competitor_scorecards_count ?? 0;
+}
+
+/**
+ * Fan-out helper: fetch scorecards for several competitors in parallel and
+ * concatenate into a single flat `RawScorecard[]`. Each input ref is the
+ * **competitor's** (ct, id) — different from the match's (ct, id) — together
+ * with the numeric competitor id used for filtering during parsing.
+ *
+ * `matchStageIds` is the set of stage ids belonging to the match currently
+ * being rendered, used to drop cross-match noise from each per-competitor
+ * response (shooters typically have scorecards across many matches).
+ *
+ * Failures on a single competitor cause the whole helper to reject — caller
+ * decides how to surface that. We don't return partial results because the
+ * downstream rendering paths assume each requested competitor either has
+ * data or is an explicit miss; silently dropping one looks like the
+ * shooter has no scorecards.
+ */
+export interface SelectedCompetitorRef {
+  /** Competitor's content_type (e.g. IpscCompetitorNode key). NOT the match's ct. */
+  ct: number;
+  /** Competitor id as a string (SSI's id type). */
+  id: string;
+  /** Same id as a number — used to filter the per-competitor response. */
+  numericId: number;
+}
+
+export async function fetchSelectedCompetitorsScorecards(
+  refs: SelectedCompetitorRef[],
+  matchStageIds: Set<number>,
+  ttlSeconds: number | null,
+): Promise<{ scorecards: RawScorecard[]; cachedAts: (string | null)[] }> {
+  const responses = await Promise.all(
+    refs.map((ref) => cachedCompetitorScorecards(ref.ct, ref.id, ttlSeconds)),
+  );
+  const scorecards: RawScorecard[] = [];
+  const cachedAts: (string | null)[] = [];
+  for (let i = 0; i < refs.length; i++) {
+    cachedAts.push(responses[i].cachedAt);
+    scorecards.push(
+      ...parseCompetitorScorecards(
+        responses[i].data,
+        refs[i].numericId,
+        matchStageIds,
+      ),
+    );
+  }
+  return { scorecards, cachedAts };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -36,6 +36,13 @@ export interface StageInfo {
 
 export interface CompetitorInfo {
   id: number;
+  /**
+   * SSI content_type integer for this competitor's underlying node type
+   * (e.g. IpscCompetitorNode). Required for `competitor_scorecards(ct, id)`
+   * lookups. Optional only because pre-redesign cached responses don't carry
+   * it; freshly-served responses always include it.
+   */
+  content_type?: number;
   /** Globally stable ShooterNode primary key — same person across all matches. Null if unavailable. */
   shooterId: number | null;
   name: string;

--- a/scripts/ssi-schema-snapshot.json
+++ b/scripts/ssi-schema-snapshot.json
@@ -39,6 +39,38 @@
       ]
     },
     {
+      "name": "competitor_scorecards",
+      "type": "[ScoreCardInterface!]!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
+        },
+        {
+          "name": "updated_after",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "competitor_scorecards_count",
+      "type": "Int!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
       "name": "event",
       "type": "EventInterface!",
       "args": [

--- a/scripts/validate-ssi-queries.ts
+++ b/scripts/validate-ssi-queries.ts
@@ -50,6 +50,10 @@ import {
   SCORECARDS_QUERY,
   SCORECARDS_DELTA_QUERY,
 } from "../lib/graphql";
+import {
+  COMPETITOR_SCORECARDS_QUERY,
+  COMPETITOR_SCORECARDS_COUNT_QUERY,
+} from "../lib/scorecards-per-competitor";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_PATH = resolve(__dirname, "ssi-schema-snapshot.json");
@@ -80,6 +84,8 @@ const QUERIES: { name: string; src: string }[] = [
   { name: "UPCOMING_STATUS_QUERY", src: UPCOMING_STATUS_QUERY },
   { name: "SCORECARDS_QUERY", src: SCORECARDS_QUERY },
   { name: "SCORECARDS_DELTA_QUERY", src: SCORECARDS_DELTA_QUERY },
+  { name: "COMPETITOR_SCORECARDS_QUERY", src: COMPETITOR_SCORECARDS_QUERY },
+  { name: "COMPETITOR_SCORECARDS_COUNT_QUERY", src: COMPETITOR_SCORECARDS_COUNT_QUERY },
 ];
 
 export function loadSnapshot(): Snapshot {

--- a/tests/unit/scorecards-per-competitor.test.ts
+++ b/tests/unit/scorecards-per-competitor.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseCompetitorScorecards,
+  type CompetitorScorecardsData,
+} from "@/lib/scorecards-per-competitor";
+
+function makeScorecard(overrides: Partial<{
+  stageId: string;
+  stageNumber: number;
+  stageName: string;
+  maxPoints: number;
+  competitorId: string;
+  division: string | null;
+  points: number | string | null;
+  hitfactor: number | string | null;
+  time: number | string | null;
+  ascore: number | string | null;
+  bscore: number | string | null;
+  cscore: number | string | null;
+  dscore: number | string | null;
+  miss: number | string | null;
+  penalty: number | string | null;
+  procedural: number | string | null;
+  disqualified: boolean | null;
+  zeroed: boolean | null;
+  stage_not_fired: boolean | null;
+  incomplete: boolean | null;
+  created: string | null;
+}>): CompetitorScorecardsData["competitor_scorecards"][number] {
+  return {
+    stage: {
+      id: overrides.stageId ?? "100",
+      number: overrides.stageNumber ?? 1,
+      name: overrides.stageName ?? "Stage 1",
+      max_points: overrides.maxPoints ?? 60,
+    },
+    created: overrides.created ?? "2026-05-01T10:00:00Z",
+    points: overrides.points ?? 50,
+    hitfactor: overrides.hitfactor ?? 5.5,
+    time: overrides.time ?? 9.1,
+    disqualified: overrides.disqualified ?? false,
+    zeroed: overrides.zeroed ?? false,
+    stage_not_fired: overrides.stage_not_fired ?? false,
+    incomplete: overrides.incomplete ?? false,
+    ascore: overrides.ascore ?? 8,
+    bscore: overrides.bscore ?? 0,
+    cscore: overrides.cscore ?? 2,
+    dscore: overrides.dscore ?? 0,
+    miss: overrides.miss ?? 0,
+    penalty: overrides.penalty ?? 0,
+    procedural: overrides.procedural ?? 0,
+    competitor: {
+      id: overrides.competitorId ?? "777",
+      get_division_display: overrides.division ?? "Production",
+    },
+  };
+}
+
+describe("parseCompetitorScorecards", () => {
+  it("emits one RawScorecard per matching scorecard", () => {
+    const data: CompetitorScorecardsData = {
+      competitor_scorecards: [
+        makeScorecard({ stageId: "100", competitorId: "777" }),
+        makeScorecard({ stageId: "101", competitorId: "777", stageNumber: 2 }),
+      ],
+    };
+    const out = parseCompetitorScorecards(data, 777, new Set([100, 101]));
+    expect(out).toHaveLength(2);
+    expect(out[0].competitor_id).toBe(777);
+    expect(out[0].stage_id).toBe(100);
+    expect(out[1].stage_id).toBe(101);
+  });
+
+  it("filters out scorecards from stages outside the requested match", () => {
+    const data: CompetitorScorecardsData = {
+      competitor_scorecards: [
+        makeScorecard({ stageId: "100", competitorId: "777" }),
+        // Stage 999 belongs to a different match the shooter also competed in
+        makeScorecard({ stageId: "999", competitorId: "777", stageNumber: 5 }),
+      ],
+    };
+    const out = parseCompetitorScorecards(data, 777, new Set([100]));
+    expect(out).toHaveLength(1);
+    expect(out[0].stage_id).toBe(100);
+  });
+
+  it("filters out scorecards belonging to a different competitor", () => {
+    // SSI's response should be scoped to the queried competitor, but the
+    // parser defends against malformed responses (e.g. someone passing the
+    // wrong competitor id).
+    const data: CompetitorScorecardsData = {
+      competitor_scorecards: [
+        makeScorecard({ competitorId: "888" }),
+        makeScorecard({ competitorId: "777" }),
+      ],
+    };
+    const out = parseCompetitorScorecards(data, 777, new Set([100]));
+    expect(out).toHaveLength(1);
+    expect(out[0].competitor_id).toBe(777);
+  });
+
+  it("drops scorecards with no stage or no competitor reference", () => {
+    const data = {
+      competitor_scorecards: [
+        { ...makeScorecard({}), stage: null },
+        { ...makeScorecard({}), competitor: null },
+      ],
+    } as CompetitorScorecardsData;
+    const out = parseCompetitorScorecards(data, 777, new Set([100]));
+    expect(out).toHaveLength(0);
+  });
+
+  it("combines b-zone hits into c_hits", () => {
+    const data: CompetitorScorecardsData = {
+      competitor_scorecards: [
+        makeScorecard({ ascore: 8, bscore: 2, cscore: 4, dscore: 1 }),
+      ],
+    };
+    const out = parseCompetitorScorecards(data, 777, new Set([100]));
+    expect(out[0].a_hits).toBe(8);
+    expect(out[0].c_hits).toBe(6); // b + c
+    expect(out[0].d_hits).toBe(1);
+  });
+
+  it("preserves null hit zones when both b and c are null", () => {
+    const data = {
+      competitor_scorecards: [
+        { ...makeScorecard({}), bscore: null, cscore: null },
+      ],
+    } as CompetitorScorecardsData;
+    const out = parseCompetitorScorecards(data, 777, new Set([100]));
+    expect(out[0].c_hits).toBeNull();
+  });
+
+  it("forwards DQ and DNF flags as-is", () => {
+    const data: CompetitorScorecardsData = {
+      competitor_scorecards: [
+        makeScorecard({ stageId: "100", disqualified: true }),
+        makeScorecard({ stageId: "101", stageNumber: 2, stage_not_fired: true }),
+      ],
+    };
+    const out = parseCompetitorScorecards(data, 777, new Set([100, 101]));
+    expect(out[0].dq).toBe(true);
+    expect(out[1].dnf).toBe(true);
+  });
+
+  it("returns an empty array for an empty response", () => {
+    const out = parseCompetitorScorecards(
+      { competitor_scorecards: [] },
+      777,
+      new Set([100]),
+    );
+    expect(out).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
First behaviour change in the live-views-only redesign (#410). Adds the per-competitor scorecards module backed by SSI's new root queries (\`competitor_scorecards()\` / \`competitor_scorecards_count()\`, deployed 2026-05-04) and migrates the per-competitor \`/stages\` route to use it during live matches.

The compare route still uses the whole-match path. Migrating it requires a \`computeGroupRankings\` refactor (handle missing field data, nullify whole-field-derived stats) and is the immediate next PR under the same issue (#405).

## Why /stages first
- The route fetches one competitor's data anyway. Per-competitor is a strict win: response size drops from O(competitors * stages * fields) to O(stages * fields) for that shooter.
- Smallest blast radius for the first migration -- the response shape change is just whole-field-derived fields (\`stage_pct\` etc.) becoming null during live.
- Validates the new module's plumbing end-to-end.

## What's in the box
- \`lib/scorecards-per-competitor.ts\` (new): queries, parser, cache wrapper, parallel fan-out helper.
- \`COMPETITOR_SCORECARDS_QUERY\` and \`COMPETITOR_SCORECARDS_COUNT_QUERY\` exported via the new module; both registered with \`validate:ssi-queries\`.
- \`CompetitorInfo.content_type\` (optional) -- exposes the existing \`get_content_type_key\` GraphQL field so callers can pass it to \`competitor_scorecards(ct, id)\` without a second hop.
- \`SCORECARD_NODE_FIELDS\` exported from \`lib/graphql.ts\` so the new module reuses the same scorecard projection (no drift between queries).
- Schema snapshot refreshed.
- /stages route branches on \`isMatchCompleteFromEvent()\` -- whole-match path post-match, per-competitor path during live.

## Whole-field-derived fields during live
\`stage_pct\` (and group/division/overall ranks/percents on \`CompetitorSummary\` -- not used by /stages but used by /compare) are null when running the per-competitor path. Per #410's decision, gating these in the UI is PR-C's (#406) work.

## What's NOT in this PR
- Compare route migration -- the next PR.
- OG image / add-match / shooter-dashboard migrations -- follow-ups.
- D1 mirror for per-competitor cache entries -- entries are small enough that re-fetch on Redis eviction is acceptable for now.

## Test plan
- [x] \`pnpm -w run typecheck\` clean
- [x] \`pnpm -w run lint\` clean
- [x] \`pnpm -w test\` -- 57 files / 1683 tests pass (8 new for the parser)
- [x] \`pnpm validate:ssi-queries\` -- 8 queries valid (incl. both new ones)
- [x] \`pnpm tsx scripts/check-ssi-schema.ts\` -- snapshot matches live

🤖 Generated with [Claude Code](https://claude.com/claude-code)