### PR TITLE
feat(compare): per-competitor fetch during live; gate whole-field stats (PR-B-2 for #410)

### DIFF
--- a/app/api/compare/logic.ts
+++ b/app/api/compare/logic.ts
@@ -646,10 +646,25 @@ export function computeFullFieldRankings(
  *   - DNF (stage not fired) → null rank/percent
  *   - Ties share the same rank; next rank skips
  */
+export interface ComputeGroupRankingsOptions {
+  /**
+   * Set to `false` when `allScorecards` only contains the selected competitors'
+   * data (per-competitor live fetch path -- see #410). Causes overall/division
+   * field statistics to be omitted (null) since they cannot be computed without
+   * the rest of the field. Group rankings within `selectedCompetitors` remain
+   * fully populated.
+   *
+   * Default: true (back-compat with the whole-match path).
+   */
+  fullFieldAvailable?: boolean;
+}
+
 export function computeGroupRankings(
   allScorecards: RawScorecard[],
-  selectedCompetitors: CompetitorInfo[]
+  selectedCompetitors: CompetitorInfo[],
+  opts: ComputeGroupRankingsOptions = {}
 ): StageComparison[] {
+  const fullFieldAvailable = opts.fullFieldAvailable ?? true;
   const selectedIds = new Set(selectedCompetitors.map((c) => c.id));
 
   // Pre-compute per-competitor shooting order for selected competitors.
@@ -699,59 +714,83 @@ export function computeGroupRankings(
     const { rankMap: groupRankMap, leaderHF: groupLeaderHF } =
       rankByHF(groupScorecards);
 
-    // Overall rankings — all competitors across all divisions
-    const { rankMap: overallRankMap, leaderHF: overallLeaderHF } =
-      rankByHF(allStage);
-    // N for percentile: number of non-DNF competitors in the full field on this stage
-    const overallN = overallRankMap.size;
+    // Overall / division / field stats only make sense when we actually have
+    // the full field. During the per-competitor live path (#410), `allStage`
+    // contains *only* the selected competitors, so computing field statistics
+    // from it would lie about cohort size and leader benchmarks. Surface them
+    // as null instead — the UI gate (PR-C / #406) handles the messaging.
+    let overallRankMap: Map<number, number>;
+    let overallLeaderHF: number | null;
+    let overallN: number;
+    let fieldMedianHF: number | null;
+    let fieldCompetitorCount: number;
+    let fieldMedianAccuracy: number | null;
+    let fieldCV: number | null;
+    let divResults: Map<string, { rankMap: Map<number, number>; leaderHF: number | null }>;
+    let divisionDistributions: Record<string, DivisionHFDistribution>;
 
-    // Full-field median HF (excluding DNF/DQ/zeroed)
-    const { median: fieldMedianHF, count: fieldCompetitorCount } =
-      medianHF(allStage);
-    const fieldMedianAccuracy = medianAccuracy(allStage); // FEATURE: accuracy-metric
-    const fieldCV = stageCV(allStage);                    // FEATURE: separator-metric
+    if (fullFieldAvailable) {
+      // Overall rankings — all competitors across all divisions
+      ({ rankMap: overallRankMap, leaderHF: overallLeaderHF } =
+        rankByHF(allStage));
+      // N for percentile: number of non-DNF competitors in the full field on this stage
+      overallN = overallRankMap.size;
 
-    // Division rankings — group by division string, rank within each
-    const byDivision = new Map<string, RawScorecard[]>();
-    for (const sc of allStage) {
-      const key = sc.competitor_division ?? "__none__";
-      const existing = byDivision.get(key) ?? [];
-      existing.push(sc);
-      byDivision.set(key, existing);
-    }
-    const divResults = new Map<
-      string,
-      { rankMap: Map<number, number>; leaderHF: number | null }
-    >();
-    for (const [div, divCards] of byDivision) {
-      divResults.set(div, rankByHF(divCards));
-    }
+      // Full-field median HF (excluding DNF/DQ/zeroed)
+      ({ median: fieldMedianHF, count: fieldCompetitorCount } =
+        medianHF(allStage));
+      fieldMedianAccuracy = medianAccuracy(allStage); // FEATURE: accuracy-metric
+      fieldCV = stageCV(allStage);                    // FEATURE: separator-metric
 
-    // Per-division HF distributions (quartiles as % of division leader HF)
-    const divisionDistributions: Record<string, DivisionHFDistribution> = {};
-    for (const [div, divCards] of byDivision) {
-      if (div === "__none__") continue;
-      const divInfo = divResults.get(div);
-      const leaderHF = divInfo?.leaderHF;
-      if (!leaderHF || leaderHF <= 0) continue;
-      const validPcts = divCards
-        .filter(
-          (sc) =>
-            !sc.dnf && !sc.dq && !sc.zeroed &&
-            sc.hit_factor != null && sc.hit_factor > 0
-        )
-        .map((sc) => (sc.hit_factor! / leaderHF) * 100)
-        .sort((a, b) => a - b);
-      if (validPcts.length < 2) continue;
-      const q = computeQuartiles(validPcts);
-      if (!q) continue;
-      divisionDistributions[div] = {
-        minPct: validPcts[0],
-        q1Pct: q.q1,
-        medianPct: q.median,
-        q3Pct: q.q3,
-        count: validPcts.length,
-      };
+      // Division rankings — group by division string, rank within each
+      const byDivision = new Map<string, RawScorecard[]>();
+      for (const sc of allStage) {
+        const key = sc.competitor_division ?? "__none__";
+        const existing = byDivision.get(key) ?? [];
+        existing.push(sc);
+        byDivision.set(key, existing);
+      }
+      divResults = new Map();
+      for (const [div, divCards] of byDivision) {
+        divResults.set(div, rankByHF(divCards));
+      }
+
+      // Per-division HF distributions (quartiles as % of division leader HF)
+      divisionDistributions = {};
+      for (const [div, divCards] of byDivision) {
+        if (div === "__none__") continue;
+        const divInfo = divResults.get(div);
+        const leaderHF = divInfo?.leaderHF;
+        if (!leaderHF || leaderHF <= 0) continue;
+        const validPcts = divCards
+          .filter(
+            (sc) =>
+              !sc.dnf && !sc.dq && !sc.zeroed &&
+              sc.hit_factor != null && sc.hit_factor > 0
+          )
+          .map((sc) => (sc.hit_factor! / leaderHF) * 100)
+          .sort((a, b) => a - b);
+        if (validPcts.length < 2) continue;
+        const q = computeQuartiles(validPcts);
+        if (!q) continue;
+        divisionDistributions[div] = {
+          minPct: validPcts[0],
+          q1Pct: q.q1,
+          medianPct: q.median,
+          q3Pct: q.q3,
+          count: validPcts.length,
+        };
+      }
+    } else {
+      overallRankMap = new Map();
+      overallLeaderHF = null;
+      overallN = 0;
+      fieldMedianHF = null;
+      fieldCompetitorCount = 0;
+      fieldMedianAccuracy = null;
+      fieldCV = null;
+      divResults = new Map();
+      divisionDistributions = {};
     }
 
     // group_leader_points kept for the benchmark overlay hook (issue #1)

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -12,8 +12,9 @@ import { isUpstreamDegraded } from "@/lib/upstream-status";
 import { afterResponse } from "@/lib/background-impl";
 
 import { extractDivision } from "@/lib/divisions";
-import { computeGroupRankings, computeMatchPointTotals, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance, computeStageDegradationData } from "@/app/api/compare/logic";
+import { computeGroupRankings, computeMatchPointTotals, computePenaltyStats, computeCompetitorPPS, computeFieldPPSDistribution, computeConsistencyStats, computeLossBreakdown, simulateWithoutWorstStage, computeStyleFingerprint, computeAllFingerprintPoints, computePercentileRank, assignArchetype, computeStylePercentiles, classifyStageArchetype, computeArchetypePerformance, parseStageConstraints, computeCourseLengthPerformance, computeConstraintPerformance, computeStageDegradationData, type RawScorecard } from "@/app/api/compare/logic";
 import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
+import { fetchSelectedCompetitorsScorecards } from "@/lib/scorecards-per-competitor";
 import { decodeShooterId, indexMatchShooters } from "@/lib/shooter-index";
 import type { CompareMode, CompareResponse, CompetitorInfo, FieldFingerprintPoint, StageComparison, StageConditions } from "@/lib/types";
 import { fetchMatchWeatherRaw, getHourlySnapshot } from "@/lib/weather";
@@ -176,53 +177,132 @@ export async function GET(req: Request) {
     }
   }
 
-  // Step 2 — fetch scorecards with TTL determined by match state
+  // Step 2 — fetch scorecards with a path that depends on match state.
+  //
+  // Per #410: live matches must NOT pull whole-match scorecards. We fan out
+  // `competitor_scorecards()` for the requested competitor IDs only. Whole-
+  // field statistics (group-of-everyone leader, division medians, overall
+  // ranks, etc.) are unavailable during live and surface as null. PR-C
+  // (#406) handles UI gating around those nulls.
+  //
+  // For completed matches we keep the existing whole-match path; PR-D (#404
+  // redesigned) replaces it with a per-stage archive fan-out.
   const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
-  let scorecardsData: RawScorecardsData;
-  let scorecardsCachedAt: string | null;
-  try {
-    ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
-      await cachedExecuteQuery<RawScorecardsData>(
-        scorecardsKey,
-        SCORECARDS_QUERY,
-        { ct: ctNum, id },
-        dataTtl,
-      ));
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Upstream error";
-    return NextResponse.json({ error: message }, { status: 502 });
-  }
+  let scorecardsCachedAt: string | null = null;
+  let rawScorecards: RawScorecard[];
+  let scorecardsRestricted = false;
 
-  // Upgrade scorecards cache entry TTL based on match state
-  try {
-    if (dataTtl === null) {
-      const raw = await cache.get(scorecardsKey);
-      if (raw) {
-        await cache.persist(scorecardsKey);
-        // Persist completed scorecard data to D1/SQLite for durable storage
-        afterResponse(persistToMatchStore(scorecardsKey, raw));
-      }
-    } else if (!scorecardsCachedAt) {
-      await cache.expire(scorecardsKey, dataTtl);
-    }
-  } catch (err) {
-    reportError("compare.scorecards-ttl-apply", err, { matchKey: scorecardsKey });
-  }
-
-  // SWR for scorecards (the slowest upstream call) — same single-flight pattern.
-  if (scorecardsCachedAt && dataTtl != null && matchFreshness != null) {
-    const age = (Date.now() - new Date(scorecardsCachedAt).getTime()) / 1000;
-    if (age > matchFreshness) {
-      afterResponse(
-        refreshCachedMatchQuery<RawScorecardsData>(
+  if (isComplete) {
+    let scorecardsData: RawScorecardsData;
+    try {
+      ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
+        await cachedExecuteQuery<RawScorecardsData>(
           scorecardsKey,
           SCORECARDS_QUERY,
           { ct: ctNum, id },
           dataTtl,
-          { ct: ctNum, id },
-        ),
+        ));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Upstream error";
+      return NextResponse.json({ error: message }, { status: 502 });
+    }
+
+    // Upgrade scorecards cache entry TTL based on match state
+    try {
+      if (dataTtl === null) {
+        const raw = await cache.get(scorecardsKey);
+        if (raw) {
+          await cache.persist(scorecardsKey);
+          // Persist completed scorecard data to D1/SQLite for durable storage
+          afterResponse(persistToMatchStore(scorecardsKey, raw));
+        }
+      } else if (!scorecardsCachedAt) {
+        await cache.expire(scorecardsKey, dataTtl);
+      }
+    } catch (err) {
+      reportError("compare.scorecards-ttl-apply", err, { matchKey: scorecardsKey });
+    }
+
+    // SWR for scorecards (the slowest upstream call) — same single-flight pattern.
+    if (scorecardsCachedAt && dataTtl != null && matchFreshness != null) {
+      const age = (Date.now() - new Date(scorecardsCachedAt).getTime()) / 1000;
+      if (age > matchFreshness) {
+        afterResponse(
+          refreshCachedMatchQuery<RawScorecardsData>(
+            scorecardsKey,
+            SCORECARDS_QUERY,
+            { ct: ctNum, id },
+            dataTtl,
+            { ct: ctNum, id },
+          ),
+        );
+      }
+    }
+
+    if (!scorecardsData.event || !matchData.event) {
+      return NextResponse.json({ error: "Match not found" }, { status: 404 });
+    }
+    rawScorecards = parseRawScorecards(scorecardsData);
+
+    // SSI hides per-shot scorecard detail on Level I (club) matches: it returns
+    // a non-zero `scoring_completed` but an empty `scorecards` array. Surface
+    // that as an explicit flag so the client can render a clear notice instead
+    // of a blank comparison table.
+    scorecardsRestricted =
+      scoringPct > 0 &&
+      rawScorecards.length === 0 &&
+      (matchData.event.stages?.length ?? 0) > 0;
+  } else {
+    // Live: per-competitor fan-out. Resolve each requested competitor's
+    // content_type from the match data first; bail out cleanly if any are
+    // missing (would indicate stale match-cache without the new field).
+    const allCompetitorsRaw = matchData.event?.competitors_approved_w_wo_results_not_dnf ?? [];
+    const ctByCompetitorId = new Map<number, number>();
+    for (const c of allCompetitorsRaw) {
+      ctByCompetitorId.set(parseInt(c.id, 10), c.get_content_type_key);
+    }
+    const refs = competitorIds
+      .map((cid) => {
+        const ct = ctByCompetitorId.get(cid);
+        if (ct == null) return null;
+        return { ct, id: String(cid), numericId: cid };
+      })
+      .filter((r): r is { ct: number; id: string; numericId: number } => r !== null);
+
+    if (refs.length === 0) {
+      return NextResponse.json(
+        { error: "Selected competitors not found in this match" },
+        { status: 404 },
       );
     }
+
+    const matchStageIds = new Set(
+      (matchData.event?.stages ?? []).map((s) => parseInt(s.id, 10)),
+    );
+
+    try {
+      const result = await fetchSelectedCompetitorsScorecards(refs, matchStageIds, dataTtl);
+      rawScorecards = result.scorecards;
+      // Use the most-recent cachedAt across the per-competitor entries — the
+      // freshness signal the live UI cares about.
+      const newest = result.cachedAts.reduce<string | null>((acc, t) => {
+        if (!t) return acc;
+        if (!acc) return t;
+        return new Date(t) > new Date(acc) ? t : acc;
+      }, null);
+      scorecardsCachedAt = newest;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Upstream error";
+      return NextResponse.json({ error: message }, { status: 502 });
+    }
+
+    if (!matchData.event) {
+      return NextResponse.json({ error: "Match not found" }, { status: 404 });
+    }
+
+    // The Level-I "restricted" detection requires whole-match data; during
+    // live we cannot tell whether scorecards are hidden or merely sparse.
+    scorecardsRestricted = false;
   }
 
   // Start match-global cache read early so the Redis round-trip can resolve
@@ -257,7 +337,7 @@ export async function GET(req: Request) {
 
   const tFetch = performance.now();
 
-  if (!scorecardsData.event || !matchData.event) {
+  if (!matchData.event) {
     return NextResponse.json({ error: "Match not found" }, { status: 404 });
   }
 
@@ -307,18 +387,8 @@ export async function GET(req: Request) {
     );
   });
 
-  // Flatten ALL stage scorecards — not filtered to requested competitors.
-  // computeGroupRankings needs the full field to compute division and overall rankings.
-  const rawScorecards = parseRawScorecards(scorecardsData);
-
-  // SSI hides per-shot scorecard detail on Level I (club) matches: it returns
-  // a non-zero `scoring_completed` but an empty `scorecards` array. Surface
-  // that as an explicit flag so the client can render a clear notice instead
-  // of a blank comparison table.
-  const scorecardsRestricted =
-    scoringPct > 0 &&
-    rawScorecards.length === 0 &&
-    (matchData.event.stages?.length ?? 0) > 0;
+  // `rawScorecards` and `scorecardsRestricted` were populated above by the
+  // isComplete branch.
 
   // Surface max(scorecard_created) so the client can show how stale the
   // upstream itself is, independent of our cache age. On an active match
@@ -352,7 +422,11 @@ export async function GET(req: Request) {
     ])
   );
 
-  let stages: StageComparison[] = computeGroupRankings(rawScorecards, requestedCompetitors).map(
+  let stages: StageComparison[] = computeGroupRankings(
+    rawScorecards,
+    requestedCompetitors,
+    { fullFieldAvailable: isComplete },
+  ).map(
     (s) => {
       const meta = stageMetaMap.get(s.stage_id);
       return {
@@ -401,18 +475,30 @@ export async function GET(req: Request) {
 
   const tRankings = performance.now();
 
+  // Match-point totals and field-PPS distribution both require the full
+  // field. During live (per-competitor fetch) we only have data for the
+  // selected shooters, so these become empty / null. PR-C gates the UI.
   const {
     divisionLeaderMatchPts,
     overallLeaderMatchPts,
     divisionMatchRanks,
     overallMatchRanks,
-  } = computeMatchPointTotals(rawScorecards);
+  } = isComplete
+    ? computeMatchPointTotals(rawScorecards)
+    : {
+        divisionLeaderMatchPts: {},
+        overallLeaderMatchPts: null,
+        divisionMatchRanks: {},
+        overallMatchRanks: {},
+      };
 
   const penaltyStats = Object.fromEntries(
     requestedCompetitors.map((c) => [c.id, computePenaltyStats(stages, c.id)])
   );
 
-  const fieldPPS = computeFieldPPSDistribution(rawScorecards);
+  const fieldPPS = isComplete
+    ? computeFieldPPSDistribution(rawScorecards)
+    : { fieldMin: null, fieldMedian: null, fieldMax: null, fieldCount: 0 };
   const efficiencyStats = Object.fromEntries(
     requestedCompetitors.map((c) => [
       c.id,
@@ -431,7 +517,9 @@ export async function GET(req: Request) {
     requestedCompetitors.map((c) => [c.id, computeLossBreakdown(stages, c.id)])
   );
 
-  // Coaching-only computations — skipped in live mode for faster responses
+  // Coaching-only computations — skipped in live mode for faster responses,
+  // and additionally gated on `isComplete` per #410 since several depend on
+  // whole-field data that the per-competitor live path does not have.
   let archetypePerformance: CompareResponse["archetypePerformance"] = null;
   let courseLengthPerformance: CompareResponse["courseLengthPerformance"] = null;
   let constraintPerformance: CompareResponse["constraintPerformance"] = null;
@@ -441,7 +529,7 @@ export async function GET(req: Request) {
   let stageDegradationData: CompareResponse["stageDegradationData"] = null;
   let stageConditions: CompareResponse["stageConditions"] = null;
 
-  if (mode === "coaching") {
+  if (mode === "coaching" && isComplete) {
     archetypePerformance = Object.fromEntries(
       requestedCompetitors.map((c) => [c.id, computeArchetypePerformance(stages, c.id)])
     );
@@ -509,7 +597,7 @@ export async function GET(req: Request) {
 
   const tPerCompetitor = performance.now();
 
-  if (mode === "coaching") {
+  if (mode === "coaching" && isComplete) {
     const rawGlobal = await matchGlobalCachePromise;
     let cachedPoints: FieldFingerprintPoint[] | undefined;
     if (rawGlobal) {

--- a/tests/unit/compare-logic.test.ts
+++ b/tests/unit/compare-logic.test.ts
@@ -157,6 +157,82 @@ describe("computeGroupRankings — group rankings", () => {
   });
 });
 
+describe("computeGroupRankings — fullFieldAvailable=false (live per-competitor)", () => {
+  // Per #410 the live path passes only the selected competitors' scorecards
+  // and sets fullFieldAvailable: false. Whole-field-derived stats must come
+  // back null so callers (and the UI gate in PR-C / #406) can render an
+  // "unavailable during live" notice instead of stats computed against a
+  // non-representative cohort.
+
+  it("nullifies overall, division, and field stats when fullFieldAvailable is false", () => {
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 5.0, points: 100 }),
+      makeCard(2, 1, { hit_factor: 4.0, points: 80 }),
+    ];
+    const result = computeGroupRankings(
+      scorecards,
+      [competitors[0], competitors[1]],
+      { fullFieldAvailable: false },
+    );
+    expect(result).toHaveLength(1);
+    const stage = result[0];
+    expect(stage.overall_leader_hf).toBeNull();
+    expect(stage.field_median_hf).toBeNull();
+    expect(stage.field_median_accuracy).toBeNull();
+    expect(stage.field_cv).toBeNull();
+    expect(stage.field_competitor_count).toBe(0);
+    expect(stage.divisionDistributions).toEqual({});
+  });
+
+  it("preserves group-rank / group-leader / group-percent within selected", () => {
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 5.0, points: 100 }),
+      makeCard(2, 1, { hit_factor: 4.0, points: 80 }),
+    ];
+    const stage = computeGroupRankings(
+      scorecards,
+      [competitors[0], competitors[1]],
+      { fullFieldAvailable: false },
+    )[0];
+    expect(stage.group_leader_hf).toBe(5.0);
+    expect(stage.group_leader_points).toBe(100);
+    expect(stage.competitors[1].group_rank).toBe(1);
+    expect(stage.competitors[2].group_rank).toBe(2);
+    expect(stage.competitors[1].group_percent).toBeCloseTo(100, 5);
+    expect(stage.competitors[2].group_percent).toBeCloseTo(80, 5);
+  });
+
+  it("nullifies per-competitor overall and division ranks/percents", () => {
+    const scorecards = [makeCard(1, 1, { hit_factor: 5.0 })];
+    const stage = computeGroupRankings(
+      scorecards,
+      [competitors[0]],
+      { fullFieldAvailable: false },
+    )[0];
+    expect(stage.competitors[1].overall_rank).toBeNull();
+    expect(stage.competitors[1].overall_percent).toBeNull();
+    expect(stage.competitors[1].overall_percentile).toBeNull();
+    expect(stage.competitors[1].div_rank).toBeNull();
+    expect(stage.competitors[1].div_percent).toBeNull();
+  });
+
+  it("default fullFieldAvailable=true preserves whole-field behaviour", () => {
+    const scorecards = [
+      makeCard(1, 1, { hit_factor: 5.0, points: 100 }),
+      makeCard(2, 1, { hit_factor: 4.0, points: 80 }),
+    ];
+    const stage = computeGroupRankings(
+      scorecards,
+      [competitors[0]], // only Alice selected; Bob is part of "field"
+    )[0];
+    // Without the flag, field stats should be present.
+    expect(stage.overall_leader_hf).toBe(5.0);
+    expect(stage.field_competitor_count).toBeGreaterThan(0);
+    // Alice is overall #1 (5.0 HF beats Bob's 4.0)
+    expect(stage.competitors[1].overall_rank).toBe(1);
+  });
+});
+
 describe("computeGroupRankings — division rankings", () => {
   it("ranks each competitor within their own division", () => {
     // Alice (hg1) and Charlie (hg1) compete within hg1


### PR DESCRIPTION
## Summary
Migrates the compare route to use the per-competitor fetcher (landed in #412) when the match is live. Whole-match scorecard fetches now happen only when \`isMatchCompleteFromEvent()\` is true. Per #410's architecture, this is the second behaviour change on the path to live-views-only.

The API surfaces null for whole-field-derived statistics during live -- intentionally truthful, since computing them from a selected-only cohort would lie about cohort size and benchmarks. PR-C (#406) puts the UI gate around those nulls.

## What changed in computeGroupRankings
New optional \`{ fullFieldAvailable: boolean }\`. When false:
- \`overall_leader_hf\`, \`field_median_hf\`, \`field_median_accuracy\`, \`field_cv\`, \`field_competitor_count\`, \`divisionDistributions\` -> null/empty
- per-competitor \`overall_rank\`, \`overall_percent\`, \`overall_percentile\`, \`div_rank\`, \`div_percent\` -> null
- group-rank, group-leader-hf, group-percent, group-leader-points still computed within the selected cohort
- shooting_order, hitLossPoints, penaltyLossPoints still computed (per-competitor)

Default is \`true\` so all existing whole-match callers keep working unchanged.

## What changed in /compare
- During live, fans out \`competitor_scorecards()\` for the requested IDs (parallel) instead of pulling \`event { stages { scorecards } }\`.
- Post-match keeps the existing whole-match path. PR-D (#404) replaces it with the per-stage archive.
- \`computeMatchPointTotals\` and \`computeFieldPPSDistribution\` are gated on isComplete; live mode emits empty / null defaults that match the existing return-type signatures.
- Coaching-mode-only computations (fingerprint cloud, archetype, course-length, constraint, what-if, stage-degradation, weather conditions) are gated on \`mode === "coaching" && isComplete\`. Live coaching mode returns nulls -- PR-C surfaces an "available after match completion" notice.
- The Level-I "scorecards restricted" detection is gated on the whole-match path (it requires field counts to detect).

## Round-trip math
For a typical 4-competitor compare on a live 200-competitor / 16-stage match:
- **Before:** 1 huge \`event { stages { scorecards } }\` query (~16 stages * ~200 cards = 3200 scorecards).
- **After:** 4 small \`competitor_scorecards(ct, id)\` queries in parallel, ~16 cards each.
- Roughly 50x reduction in upstream payload per compare load on live matches.

## Test plan
- [x] \`pnpm -w run typecheck\` clean
- [x] \`pnpm -w run lint\` clean
- [x] \`pnpm -w test\` -- 57 files / 1687 tests pass (4 new for the fullFieldAvailable=false path)
- [x] \`pnpm validate:ssi-queries\` -- clean

## Closes
Resolves the second half of #405 (compare route migration). Issue #410 stays open as the umbrella tracking the rest of the redesign (PR-C through PR-F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)