### PR TITLE
feat(ui): minimal-during-live empty states + LIVE pill on OG (PR-C-3 for #410)

### DIFF
--- a/app/api/og/match/[ct]/[id]/route.tsx
+++ b/app/api/og/match/[ct]/[id]/route.tsx
@@ -137,7 +137,7 @@ export async function GET(
       ? singleCompetitorImage(match, selectedCompetitors[0], statsMap)
       : variant === "multi"
         ? multiCompetitorImage(match, selectedCompetitors, statsMap)
-        : matchOverviewImage(match);
+        : matchOverviewImage(match, isComplete);
 
   usageTelemetry({
     op: "og-render",
@@ -368,15 +368,15 @@ function matchContext(match: OgMatchData): string {
 // ── Image variants ──────────────────────────────────────────────────────
 
 /** Match overview — no competitors selected. Shows match metadata + stats. */
-function matchOverviewImage(match: OgMatchData) {
+function matchOverviewImage(match: OgMatchData, isComplete: boolean) {
   const subtitle = matchSubtitle(match);
   const scored = match.scoringCompleted;
-  const statusText =
-    scored >= 95
-      ? "Results complete"
-      : scored > 0
-        ? `Scoring in progress (${String(scored)}%)`
-        : "Upcoming match";
+  const liveStatus = !isComplete && scored > 0;
+  const statusText = isComplete
+    ? "Results complete"
+    : liveStatus
+      ? `Scoring in progress (${String(scored)}%)`
+      : "Upcoming match";
 
   return (
     <div
@@ -415,7 +415,10 @@ function matchOverviewImage(match: OgMatchData) {
             justifyContent: "space-between",
           }}
         >
-          {brandHeader()}
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", width: "100%" }}>
+            {brandHeader()}
+            {liveStatus ? pill("LIVE", "#ef4444") : null}
+          </div>
 
           {/* Main content — match name and subtitle */}
           <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>

--- a/components/coaching-tip.tsx
+++ b/components/coaching-tip.tsx
@@ -72,7 +72,15 @@ function TipPanel({ ct, id, competitorId, competitorName, mode, autoFetch }: Tip
     );
   }
 
-  if (data) {
+  if (data?.available === false) {
+    return (
+      <p className="text-sm text-muted-foreground italic">
+        Available after match completes
+      </p>
+    );
+  }
+
+  if (data?.tip) {
     return <p className="text-sm leading-relaxed">{data.tip}</p>;
   }
 

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -1171,6 +1171,14 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
     return { ...t, matchPct, matchRank };
   });
 
+  // During live the compare route only fetches the selected competitors'
+  // scorecards (per #410), so every stage's whole-field median is null and
+  // any "vs the field" benchmark cannot be computed. Detect that purely
+  // from the data shape and surface a single-line notice — rather than
+  // letting the absent values silently look like a stale or broken table.
+  const fieldStatsUnavailable =
+    stages.length > 0 && stages.every((s) => s.field_median_hf == null);
+
   return (
     <div className="space-y-3">
       {/* Match-level DQ banners */}
@@ -1184,6 +1192,15 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
           <span>— Disqualified from match</span>
         </div>
       ))}
+
+      {fieldStatsUnavailable && (
+        <p
+          role="status"
+          className="text-xs text-muted-foreground italic"
+        >
+          Stage-winner benchmarks and field rankings: available after match completes
+        </p>
+      )}
 
       {/* View mode toggle (Absolute / Delta) + percentage context + help */}
       {/* Toolbar wraps on narrow screens — at 390px the three view-mode

--- a/components/stage-simulator.tsx
+++ b/components/stage-simulator.tsx
@@ -769,8 +769,14 @@ export function StageSimulator({ ct, id, data, competitors, scoringCompleted }: 
                       deltaPositive={simMatch ? (simMatch.matchPctDelta ?? 0) > 0 : null}
                     />
                   )}
-                  {/* Div / overall rank — always shown; current from whatIfStats, simulated from server */}
-                  {(() => {
+                  {/* Div / overall rank — always shown; current from whatIfStats, simulated from server.
+                      Hidden during live matches (server returns { available: false }) since rank
+                      simulation requires whole-field data. Per #410. */}
+                  {serverRank?.available === false ? (
+                    <p className="text-xs text-muted-foreground italic pt-1">
+                      Available after match completes
+                    </p>
+                  ) : (() => {
                     const currentDivRank = data.whatIfStats?.[selectedComp.id]?.actualDivRank ?? null;
                     const currentOverallRank = data.whatIfStats?.[selectedComp.id]?.actualOverallRank ?? null;
                     const simDivRank = serverRank?.newDivRank ?? null;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -683,6 +683,14 @@ export interface WhatIfSimulationResponse {
   newMatchAvgOverallPercent: number | null;
   newDivRank:                number | null;
   newOverallRank:            number | null;
+  /**
+   * Set when the route declined to compute results because the match isn't
+   * complete yet. When present, all other fields are absent and consumers
+   * should render an "available after match completes" state instead of
+   * displaying numeric output. See #410.
+   */
+  available?: false;
+  reason?: "match-not-complete";
 }
 
 // ── Backfill ─────────────────────────────────────────────────────────────────
@@ -937,12 +945,20 @@ export type {
 // ── AI Coaching Tips ─────────────────────────────────────────────────────────
 
 export interface CoachingTipResponse {
-  tip: string;                // 1–2 sentence coaching insight
-  generatedAt: string;        // ISO timestamp of generation
-  model: string;              // model identifier used (e.g. "@cf/meta/llama-3.1-8b-instruct")
-  competitorId: number;
-  matchId: string;
-  ct: string;
+  tip?: string;                // 1–2 sentence coaching insight (absent when available === false)
+  generatedAt?: string;        // ISO timestamp of generation
+  model?: string;              // model identifier used (e.g. "@cf/meta/llama-3.1-8b-instruct")
+  competitorId?: number;
+  matchId?: string;
+  ct?: string;
+  /**
+   * Set when the coaching route declined to compute a tip because the match
+   * isn't complete yet. When present, the other fields are absent and
+   * consumers should render an "available after match completes" empty
+   * state instead of treating the response as a tip. See #410.
+   */
+  available?: false;
+  reason?: "match-not-complete";
 }
 
 export interface CoachingAvailability {


### PR DESCRIPTION
## Summary
UI surfaces for the live-views-only redesign (#410). Backend gating already landed in PR-C-1; this PR makes live matches stop looking subtly broken by rendering explicit "Available after match completes" empty states wherever whole-field data is now unavailable.

## What changed
- **\`CoachingTipResponse\` / \`WhatIfSimulationResponse\`** -- extend with optional \`{ available?: false; reason?: "match-not-complete" }\` discriminator. Happy-path consumers continue to typecheck; new consumers branch on \`data?.available === false\`.
- **\`components/coaching-tip.tsx\`** -- when the response says unavailable, render the empty state instead of falling through to the Generate button (which would pointlessly re-fetch).
- **\`components/stage-simulator.tsx\`** -- rank-simulation panel renders the empty state when the route declines. The widget itself still self-hides below 80% scoring; this only affects the corner case where someone manually toggles into it during a live match.
- **\`components/comparison-table.tsx\`** -- single-line notice near the top of the table when every stage has \`field_median_hf == null\` (the data-derived live indicator). Copy: "Stage-winner benchmarks and field rankings: available after match completes".
- **\`app/api/og/match/[ct]/[id]/route.tsx\`** -- pass \`isComplete\` through to \`matchOverviewImage\`; render a red LIVE pill in the brand row while the match is actively scoring. Overview "status complete" logic now respects the canonical \`isMatchComplete\` predicate instead of the raw 95%-scoring threshold.

## What I'd like you to eyeball in the browser
I can't run the dev server here, so verification before merge would be appreciated. Specific spots to check:

1. **A live match's match page**: visit one mid-scoring; confirm the comparison table renders the new italic notice near the top and that "Stage rankings" / "Field median" columns gracefully show "—" rather than showing zeros or other broken values.
2. **AI coaching popover during live**: open the popover on a competitor in a live match. Should now say "Available after match completes" instead of (a) infinite spinner or (b) the broken "tip is undefined" path.
3. **Simulator during live**: trigger an adjustment on a stage; the Div rank / Overall rank rows should be replaced with the empty-state line rather than rendering "—" / "—".
4. **OG image preview**: \`/api/og/match/{ct}/{id}\` for a live match (no competitors selected). Should show a red LIVE pill in the upper-right of the image.
5. **A completed match**: nothing should change visibly. All four UI surfaces should look the same as today.

## What's not in this PR
- Single/multi competitor OG variants -- they currently render the "no stats" fallback during live (carried over from PR-C-2). A follow-up "OG polish" PR can add per-competitor selected-stats rendering once we decide the layout.
- Match-page-level explicit "live match" banner -- the comparison-table notice covers the relevant section, and the page already has live indicators (cache age badge, scoring %).

## Test plan
- [x] \`pnpm -w run typecheck\` clean
- [x] \`pnpm -w run lint\` clean
- [x] \`pnpm -w test\` -- 57 files / 1687 tests pass
- [x] OG image tests (17) pass
- [ ] Browser verification on a live match (will request your eyes)

## Refs
- #410 (parent meta-issue)
- #406 (this resolves the bulk of it; OG selected-variant polish is a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)