### PR TITLE
feat(scorecards): post-match per-stage archival fan-out via stage(ct, id) (PR-1 for #410)

### DIFF
--- a/app/api/coaching/[ct]/[id]/[competitorId]/route.ts
+++ b/app/api/coaching/[ct]/[id]/[competitorId]/route.ts
@@ -6,8 +6,9 @@ import {
   checkCoachingEligibility,
   COACHING_PROMPT_VERSION,
 } from "@/lib/coaching-prompt";
-import { cachedExecuteQuery, gqlCacheKey, MATCH_QUERY, SCORECARDS_QUERY } from "@/lib/graphql";
+import { cachedExecuteQuery, gqlCacheKey, MATCH_QUERY } from "@/lib/graphql";
 import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
+import { cachedWholeMatchArchive } from "@/lib/scorecards-archive";
 import {
   computeGroupRankings,
   computePenaltyStats,
@@ -22,7 +23,7 @@ import {
   computeStageDegradationData,
   type RawScorecard,
 } from "@/app/api/compare/logic";
-import { computeMatchTtl, isMatchComplete } from "@/lib/match-ttl";
+import { isMatchComplete } from "@/lib/match-ttl";
 import { effectiveMatchScoringPct } from "@/lib/match-data";
 import { extractDivision } from "@/lib/divisions";
 import { decodeShooterId } from "@/lib/shooter-index";
@@ -228,23 +229,17 @@ export async function GET(
 
   const matchName = matchData.event.name ?? "Unknown Match";
 
-  // 5. Fetch scorecards (reuses existing Redis cache)
-  const dataTtl = computeMatchTtl(
-    scoringPct,
-    daysSince,
-    matchData.event.starts ?? null,
-    undefined,
-    signals,
-  );
-  const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
+  // 5. Fetch scorecards via per-stage archival fan-out (#410). Gated above
+  // on isComplete, so this is the post-match path: ttl=null (permanent),
+  // first request pays the fan-out cost, all subsequent reads are cache
+  // hits.
+  const stageRefs = (matchData.event.stages ?? []).map((s) => ({
+    ct: 24,
+    id: s.id,
+  }));
   let scorecardsData: RawScorecardsData;
   try {
-    ({ data: scorecardsData } = await cachedExecuteQuery<RawScorecardsData>(
-      scorecardsKey,
-      SCORECARDS_QUERY,
-      { ct: ctNum, id },
-      dataTtl,
-    ));
+    ({ data: scorecardsData } = await cachedWholeMatchArchive(ctNum, id, stageRefs));
   } catch (err) {
     const message = err instanceof Error ? err.message : "Upstream error";
     return NextResponse.json({ error: message }, { status: 502 });

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -4,6 +4,7 @@ import { reportError } from "@/lib/error-telemetry";
 import { usageTelemetry } from "@/lib/usage-telemetry";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { cachedExecuteQuery, gqlCacheKey, SCORECARDS_QUERY, MATCH_QUERY, refreshCachedMatchQuery } from "@/lib/graphql";
+import { cachedWholeMatchArchive } from "@/lib/scorecards-archive";
 import cache from "@/lib/cache-impl";
 import { computeMatchFreshness, computeMatchSwrTtl, isMatchComplete } from "@/lib/match-ttl";
 import { persistToMatchStore } from "@/lib/match-data-store";
@@ -176,52 +177,74 @@ export async function GET(req: Request) {
     }
   }
 
-  // Step 2 — fetch scorecards with TTL determined by match state
+  // Step 2 — fetch scorecards.
+  //
+  // Post-match: per-stage archival fan-out (#410). Permanent cache, no SWR
+  // refresh needed (results are immutable once results=all).
+  //
+  // Live: legacy whole-match path. Returns `[]` for results=org matches
+  // (the gate is the match's results visibility, not the query shape — see
+  // #410 round-2 comment trail). Kept here so the route still functions if
+  // SSI later restores live access; PR-3 (#416) will short-circuit this
+  // entirely so we don't even hit SSI for live calls.
   const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
   let scorecardsData: RawScorecardsData;
   let scorecardsCachedAt: string | null;
-  try {
-    ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
-      await cachedExecuteQuery<RawScorecardsData>(
-        scorecardsKey,
-        SCORECARDS_QUERY,
-        { ct: ctNum, id },
-        dataTtl,
-      ));
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Upstream error";
-    return NextResponse.json({ error: message }, { status: 502 });
-  }
-
-  // Upgrade scorecards cache entry TTL based on match state
-  try {
-    if (dataTtl === null) {
-      const raw = await cache.get(scorecardsKey);
-      if (raw) {
-        await cache.persist(scorecardsKey);
-        // Persist completed scorecard data to D1/SQLite for durable storage
-        afterResponse(persistToMatchStore(scorecardsKey, raw));
-      }
-    } else if (!scorecardsCachedAt) {
-      await cache.expire(scorecardsKey, dataTtl);
+  if (isComplete) {
+    const stageRefs = (matchData.event?.stages ?? []).map((s) => ({
+      ct: 24,
+      id: s.id,
+    }));
+    try {
+      ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
+        await cachedWholeMatchArchive(ctNum, id, stageRefs));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Upstream error";
+      return NextResponse.json({ error: message }, { status: 502 });
     }
-  } catch (err) {
-    reportError("compare.scorecards-ttl-apply", err, { matchKey: scorecardsKey });
-  }
-
-  // SWR for scorecards (the slowest upstream call) — same single-flight pattern.
-  if (scorecardsCachedAt && dataTtl != null && matchFreshness != null) {
-    const age = (Date.now() - new Date(scorecardsCachedAt).getTime()) / 1000;
-    if (age > matchFreshness) {
-      afterResponse(
-        refreshCachedMatchQuery<RawScorecardsData>(
+    // Archive entries are permanent by construction; no TTL upgrade or SWR
+    // refresh applies. The cache wrapper already mirrors to D1.
+  } else {
+    try {
+      ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
+        await cachedExecuteQuery<RawScorecardsData>(
           scorecardsKey,
           SCORECARDS_QUERY,
           { ct: ctNum, id },
           dataTtl,
-          { ct: ctNum, id },
-        ),
-      );
+        ));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Upstream error";
+      return NextResponse.json({ error: message }, { status: 502 });
+    }
+    // Upgrade scorecards cache entry TTL based on match state
+    try {
+      if (dataTtl === null) {
+        const raw = await cache.get(scorecardsKey);
+        if (raw) {
+          await cache.persist(scorecardsKey);
+          afterResponse(persistToMatchStore(scorecardsKey, raw));
+        }
+      } else if (!scorecardsCachedAt) {
+        await cache.expire(scorecardsKey, dataTtl);
+      }
+    } catch (err) {
+      reportError("compare.scorecards-ttl-apply", err, { matchKey: scorecardsKey });
+    }
+    // SWR for scorecards on live matches — same single-flight pattern.
+    if (scorecardsCachedAt && dataTtl != null && matchFreshness != null) {
+      const age = (Date.now() - new Date(scorecardsCachedAt).getTime()) / 1000;
+      if (age > matchFreshness) {
+        afterResponse(
+          refreshCachedMatchQuery<RawScorecardsData>(
+            scorecardsKey,
+            SCORECARDS_QUERY,
+            { ct: ctNum, id },
+            dataTtl,
+            { ct: ctNum, id },
+          ),
+        );
+      }
     }
   }
 

--- a/app/api/data/match/[ct]/[id]/results/route.ts
+++ b/app/api/data/match/[ct]/[id]/results/route.ts
@@ -4,8 +4,9 @@
 // Uses cachedExecuteQuery — stale/missing cache entries are auto-refreshed from GraphQL.
 
 import { NextResponse, type NextRequest } from "next/server";
-import { cachedExecuteQuery, gqlCacheKey, MATCH_QUERY, SCORECARDS_QUERY } from "@/lib/graphql";
+import { cachedExecuteQuery, gqlCacheKey, MATCH_QUERY } from "@/lib/graphql";
 import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
+import { cachedWholeMatchArchive } from "@/lib/scorecards-archive";
 import { computeFullFieldRankings } from "@/app/api/compare/logic";
 import { decodeShooterId } from "@/lib/shooter-index";
 import { effectiveMatchScoringPct } from "@/lib/match-data";
@@ -92,11 +93,19 @@ export async function GET(
     });
   }
 
-  // Load scorecards — auto-refreshes stale/missing entries from GraphQL
-  const scKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
+  // Load scorecards via the per-stage archival fan-out (#410). Cache key
+  // matches the legacy SCORECARDS_QUERY layout so D1 mirroring works
+  // unchanged. First post-completion request pays the fan-out cost
+  // (~3-5s for a typical 8-12 stage match); subsequent reads are cache
+  // hits. ct=24 hardcoded because IpscStageNode's content_type is stable
+  // across all IPSC disciplines.
+  const stageRefs = (matchData.event.stages ?? []).map((s) => ({
+    ct: 24,
+    id: s.id,
+  }));
   let scorecardsData: RawScorecardsData;
   try {
-    ({ data: scorecardsData } = await cachedExecuteQuery<RawScorecardsData>(scKey, SCORECARDS_QUERY, { ct: ctNum, id }, null));
+    ({ data: scorecardsData } = await cachedWholeMatchArchive(ctNum, id, stageRefs));
   } catch {
     return NextResponse.json({ error: "Failed to fetch scorecards" }, { status: 502 });
   }

--- a/app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts
+++ b/app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts
@@ -10,9 +10,14 @@ import { afterResponse } from "@/lib/background-impl";
 import cache from "@/lib/cache-impl";
 import { reportError } from "@/lib/error-telemetry";
 import { cachedExecuteQuery, gqlCacheKey, refreshCachedMatchQuery, SCORECARDS_QUERY } from "@/lib/graphql";
+import { cachedWholeMatchArchive } from "@/lib/scorecards-archive";
 import { fetchMatchData } from "@/lib/match-data";
 import { persistToMatchStore } from "@/lib/match-data-store";
-import { computeMatchFreshness, computeMatchSwrTtl } from "@/lib/match-ttl";
+import {
+  computeMatchFreshness,
+  computeMatchSwrTtl,
+  isMatchCompleteFromEvent,
+} from "@/lib/match-ttl";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
 import { maybeTagAsMcp } from "@/lib/telemetry-context";
@@ -77,59 +82,78 @@ export async function GET(
     signals,
   );
 
+  const isComplete = isMatchCompleteFromEvent({
+    scoringPct: match.scoring_completed,
+    startDate: match.date,
+    status: match.match_status,
+    resultsStatus: match.results_status,
+  });
+
   const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
   let scorecardsData: RawScorecardsData;
   let scorecardsCachedAt: string | null;
-  try {
-    ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
-      await cachedExecuteQuery<RawScorecardsData>(
-        scorecardsKey,
-        SCORECARDS_QUERY,
-        { ct: ctNum, id },
-        dataTtl,
-      ));
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Upstream error";
-    return NextResponse.json({ error: message }, { status: 502 });
-  }
-
-  // Promote the scorecards cache TTL to match the resolved match state.
-  try {
-    if (dataTtl === null) {
-      const raw = await cache.get(scorecardsKey);
-      if (raw) {
-        await cache.persist(scorecardsKey);
-        afterResponse(persistToMatchStore(scorecardsKey, raw));
-      }
-    } else if (!scorecardsCachedAt) {
-      await cache.expire(scorecardsKey, dataTtl);
+  if (isComplete) {
+    // Post-match: per-stage archival fan-out (#410). Permanent cache.
+    const stageRefs = match.stages.map((s) => ({ ct: 24, id: String(s.id) }));
+    try {
+      ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
+        await cachedWholeMatchArchive(ctNum, id, stageRefs));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Upstream error";
+      return NextResponse.json({ error: message }, { status: 502 });
     }
-  } catch (err) {
-    reportError("competitor-stages.scorecards-ttl-apply", err, {
-      matchKey: scorecardsKey,
-    });
-  }
-
-  // SWR for scorecards — single-flighted inside refreshCachedMatchQuery.
-  const matchFreshness = computeMatchFreshness(
-    match.scoring_completed,
-    daysSince,
-    match.date,
-    signals,
-  );
-  if (scorecardsCachedAt && dataTtl != null && matchFreshness != null) {
-    const age =
-      (Date.now() - new Date(scorecardsCachedAt).getTime()) / 1000;
-    if (age > matchFreshness) {
-      afterResponse(
-        refreshCachedMatchQuery<RawScorecardsData>(
+    // Archive entries are permanent; no TTL upgrade or SWR refresh needed.
+  } else {
+    // Live: legacy whole-match path. Returns `[]` for results=org matches —
+    // PR-3 (#416) will short-circuit so this branch never fires for live.
+    try {
+      ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
+        await cachedExecuteQuery<RawScorecardsData>(
           scorecardsKey,
           SCORECARDS_QUERY,
           { ct: ctNum, id },
           dataTtl,
-          { ct: ctNum, id },
-        ),
-      );
+        ));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Upstream error";
+      return NextResponse.json({ error: message }, { status: 502 });
+    }
+    try {
+      if (dataTtl === null) {
+        const raw = await cache.get(scorecardsKey);
+        if (raw) {
+          await cache.persist(scorecardsKey);
+          afterResponse(persistToMatchStore(scorecardsKey, raw));
+        }
+      } else if (!scorecardsCachedAt) {
+        await cache.expire(scorecardsKey, dataTtl);
+      }
+    } catch (err) {
+      reportError("competitor-stages.scorecards-ttl-apply", err, {
+        matchKey: scorecardsKey,
+      });
+    }
+    // SWR for scorecards on live — single-flighted inside refreshCachedMatchQuery.
+    const matchFreshness = computeMatchFreshness(
+      match.scoring_completed,
+      daysSince,
+      match.date,
+      signals,
+    );
+    if (scorecardsCachedAt && dataTtl != null && matchFreshness != null) {
+      const age =
+        (Date.now() - new Date(scorecardsCachedAt).getTime()) / 1000;
+      if (age > matchFreshness) {
+        afterResponse(
+          refreshCachedMatchQuery<RawScorecardsData>(
+            scorecardsKey,
+            SCORECARDS_QUERY,
+            { ct: ctNum, id },
+            dataTtl,
+            { ct: ctNum, id },
+          ),
+        );
+      }
     }
   }
 

--- a/app/api/og/match/[ct]/[id]/route.tsx
+++ b/app/api/og/match/[ct]/[id]/route.tsx
@@ -1,7 +1,8 @@
 import { ImageResponse } from "next/og";
 import { fetchOgMatchData, type OgMatchData } from "@/lib/og-data";
-import { cachedExecuteQuery, gqlCacheKey, SCORECARDS_QUERY } from "@/lib/graphql";
-import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
+import { cachedExecuteQuery, gqlCacheKey, MATCH_QUERY } from "@/lib/graphql";
+import { parseRawScorecards } from "@/lib/scorecard-data";
+import { cachedWholeMatchArchive, type StageRef } from "@/lib/scorecards-archive";
 import {
   computeGroupRankings,
   computeConsistencyStats,
@@ -192,13 +193,21 @@ async function fetchOgCompareStatsImpl(
   if (isNaN(ctNum)) return null;
 
   try {
-    const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
-    const { data } = await cachedExecuteQuery<RawScorecardsData>(
-      scorecardsKey,
-      SCORECARDS_QUERY,
-      { ct: ctNum, id },
-      3600, // fallback TTL on cache miss; compare route will correct it later
-    );
+    // Get stage IDs from the match cache (almost always cache-hit since the
+    // outer route already warmed it). Then run the per-stage archival fan-out
+    // (#410). Caller already gates this whole function on isComplete, so the
+    // archive's permanent-cache contract is correct.
+    const matchKey = gqlCacheKey("GetMatch", { ct: ctNum, id });
+    const { data: matchData } = await cachedExecuteQuery<{
+      event: { stages?: { id: string }[] } | null;
+    }>(matchKey, MATCH_QUERY, { ct: ctNum, id }, 30);
+    if (!matchData.event) return null;
+
+    const stageRefs: StageRef[] = (matchData.event.stages ?? []).map((s) => ({
+      ct: 24,
+      id: s.id,
+    }));
+    const { data } = await cachedWholeMatchArchive(ctNum, id, stageRefs);
 
     if (!data.event) return null;
 

--- a/app/api/simulate/route.ts
+++ b/app/api/simulate/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
-import { cachedExecuteQuery, gqlCacheKey, MATCH_QUERY, SCORECARDS_QUERY } from "@/lib/graphql";
+import { cachedExecuteQuery, gqlCacheKey, MATCH_QUERY } from "@/lib/graphql";
 import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
+import { cachedWholeMatchArchive } from "@/lib/scorecards-archive";
 import { applyAdjustmentsToScorecards } from "@/lib/simulate-apply";
 import { effectiveMatchScoringPct } from "@/lib/match-data";
 import { isMatchCompleteFromEvent } from "@/lib/match-ttl";
@@ -14,14 +15,15 @@ interface NotAvailableResponse {
   reason: "match-not-complete";
 }
 
-// Minimal shape used to evaluate match completeness without pulling scorecards.
+// Minimal shape used to evaluate match completeness and feed the per-stage
+// archival fan-out without pulling scorecards.
 interface MatchEventForGate {
   event: {
     starts?: string | null;
     status?: string | null;
     results?: string | null;
     scoring_completed?: string | number | null;
-    stages?: Array<{ scoring_completed?: string | number | null }>;
+    stages?: Array<{ id: string; scoring_completed?: string | number | null }>;
   } | null;
 }
 
@@ -107,11 +109,16 @@ export async function POST(req: Request) {
     return NextResponse.json(payload);
   }
 
-  // Fetch scorecards (reuses the same cache key as the compare route)
-  const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
+  // Fetch scorecards via per-stage archival fan-out (#410). Gated above on
+  // isComplete; cache key matches the legacy SCORECARDS_QUERY layout so it
+  // hits the same Redis/D1 entries the compare route warms (and vice versa).
+  const stageRefs = (matchData.event.stages ?? []).map((s) => ({
+    ct: 24,
+    id: s.id,
+  }));
   let scorecardsData: RawScorecardsData;
   try {
-    ({ data: scorecardsData } = await cachedExecuteQuery<RawScorecardsData>(scorecardsKey, SCORECARDS_QUERY, { ct: ctNum, id }, 30));
+    ({ data: scorecardsData } = await cachedWholeMatchArchive(ctNum, id, stageRefs));
   } catch (err) {
     const message = err instanceof Error ? err.message : "Upstream error";
     return NextResponse.json({ error: message }, { status: 502 });

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -820,11 +820,25 @@ export async function refreshCachedQuery<T>(
  * Callers that want stale-while-revalidate should compare `cachedAt` against
  * a freshness window and schedule `refreshCachedQuery()` when exceeded.
  */
+export interface CachedExecuteQueryOptions<T> {
+  /**
+   * Override the upstream fetch on cache miss. When provided, the cache
+   * layer skips its built-in `executeQuery(query, variables)` call and
+   * uses this function instead. Used by `lib/scorecards-archive.ts` to
+   * substitute a per-stage fan-out for a single GraphQL call without
+   * giving up the existing Redis + D1 cache plumbing. The `query` and
+   * `variables` arguments are still used for telemetry / diagnostics
+   * (and for legibility of cache-miss logs).
+   */
+  fetcher?: () => Promise<T>;
+}
+
 export async function cachedExecuteQuery<T>(
   cacheKey: string,
   query: string,
   variables: Record<string, unknown>,
   ttlSeconds: number | null,
+  options: CachedExecuteQueryOptions<T> = {},
 ): Promise<{ data: T; cachedAt: string | null }> {
   try {
     const raw = await cache.get(cacheKey);
@@ -862,7 +876,9 @@ export async function cachedExecuteQuery<T>(
     }
   }
 
-  const data = await executeQuery<T>(query, variables);
+  const data = options.fetcher
+    ? await options.fetcher()
+    : await executeQuery<T>(query, variables);
   const cachedAt = new Date().toISOString();
 
   const entry: CacheEntry<T> = { data, cachedAt, v: CACHE_SCHEMA_VERSION };
@@ -890,12 +906,16 @@ export async function cachedExecuteQuery<T>(
 }
 
 // ─── Shared scorecard field set ──────────────────────────────────────────────
-// CRITICAL: SCORECARDS_QUERY and SCORECARDS_DELTA_QUERY MUST request the same
-// scorecard fields. The delta merge (#362, lib/scorecard-merge.ts) writes
-// delta entries into the cached full snapshot — if the delta is missing fields
-// the full query has, the merge silently corrupts the cached entry.
+// CRITICAL: SCORECARDS_QUERY, SCORECARDS_DELTA_QUERY, and STAGE_SCORECARDS_QUERY
+// MUST request the same scorecard fields. The delta merge (#362,
+// lib/scorecard-merge.ts) writes delta entries into the cached full snapshot —
+// if the delta is missing fields the full query has, the merge silently
+// corrupts the cached entry. The per-stage archival fan-out
+// (lib/scorecards-archive.ts) reassembles per-stage responses into the same
+// RawScorecardsData shape, so it must project the same field set too.
 //
-// This shared constant is interpolated into both queries so they CANNOT drift.
+// This shared constant is interpolated into all three queries so they CANNOT
+// drift. Exported so the archive module can reuse it without copying.
 //
 // When adding a scorecard field, see CLAUDE.md → "Delta-merge contract" for
 // the full list of files that must be updated together. In short:
@@ -905,7 +925,7 @@ export async function cachedExecuteQuery<T>(
 //   4. Copy in deltaToCacheCard() (lib/scorecard-merge.ts)
 //   5. Bump CACHE_SCHEMA_VERSION (lib/constants.ts)
 //   6. Run `pnpm check:ssi-schema --update` and commit the snapshot diff
-const SCORECARD_NODE_FIELDS = `
+export const SCORECARD_NODE_FIELDS = `
   ... on IpscScoreCardNode {
     created
     points
@@ -944,9 +964,20 @@ const SCORECARD_NODE_FIELDS = `
 
 // ─── Query: all stage scorecards for a match ─────────────────────────────────
 // Returns raw scorecard data for every competitor on every stage.
-// `get_results` (official placement) is blocked during active matches — this
-// query uses the raw scorecards path which is always accessible.
-// Filter the response to the desired competitor IDs server-side.
+//
+// **DEPRECATION NOTICE:** SSI announced 2026-05-04 that
+// `EventInterface.scorecards` is being deprecated in favour of
+// `StageInterface.scorecards`. The replacement runtime path is the per-stage
+// archival fan-out via root `stage(content_type, id) { scorecards }` —
+// implemented in `lib/scorecards-archive.ts`. This query is kept as a
+// fallback so callers can switch back if SSI re-exposes live data, and as
+// the canonical reference for the scorecard field set, but new runtime
+// paths must NOT call it.
+//
+// Empirical 2026-05-04: returns `[]` for live matches with `results=org`
+// (organizer-only visibility) — same gate applies to all scorecard paths
+// under API-key auth. Use only for matches where `isMatchCompleteFromEvent`
+// is true.
 export const SCORECARDS_QUERY = `
   query GetMatchScorecards($ct: Int!, $id: String!) {
     event(content_type: $ct, id: $id) {
@@ -961,6 +992,37 @@ export const SCORECARDS_QUERY = `
           scorecards {
             ${SCORECARD_NODE_FIELDS}
           }
+        }
+      }
+    }
+  }
+`;
+
+// ─── Query: per-stage scorecards ─────────────────────────────────────────────
+// SSI's blessed path post-2026-05-04: fetch one stage at a time via the root
+// `stage(content_type, id)` query. Compared to the legacy whole-match query
+// it is empirically 2-5× faster on cold loads for completed matches because
+// SSI parallelizes 8-10 small per-stage queries instead of one big blocking
+// one (verified against matches 26193, 27046, 27704 on 2026-05-04).
+//
+// Variables:
+//   $ct  - IpscStageNode content_type (24)
+//   $id  - the stage's primary key (NOT the match's id)
+//
+// Used by `lib/scorecards-archive.ts` for the post-match archival fetch.
+// Like the deprecated SCORECARDS_QUERY, returns `scorecards: []` for live
+// matches with `results=org` because the gate is on the match's results
+// visibility, not the query shape.
+export const STAGE_SCORECARDS_QUERY = `
+  query GetStageScorecards($ct: Int!, $id: String!) {
+    stage(content_type: $ct, id: $id) {
+      id
+      number
+      name
+      ... on IpscStageNode {
+        max_points
+        scorecards {
+          ${SCORECARD_NODE_FIELDS}
         }
       }
     }

--- a/lib/scorecards-archive.ts
+++ b/lib/scorecards-archive.ts
@@ -1,0 +1,157 @@
+// Server-only — post-match scorecards archive via SSI's per-stage root query.
+//
+// Why a separate module:
+//   SSI deprecated the whole-match `event { stages { scorecards } }` path on
+//   2026-05-04 (see lib/graphql.ts:SCORECARDS_QUERY). The new SSI-blessed path
+//   is `stage(content_type, id) { scorecards }`, fetched per stage. We
+//   parallel-fetch all stages for a match and reassemble them into the same
+//   `RawScorecardsData` shape downstream parsers consume — no caller-side
+//   refactor needed.
+//
+// Cold-load latency vs the deprecated path (matches 26193, 27046, 27704,
+// measured 2026-05-04):
+//   legacy whole-match:           8-17s wall-clock
+//   per-stage parallel fan-out:   2.6-3.5s wall-clock
+//
+// **Post-match only.** Live matches return `scorecards: []` from every API
+// path (results=org gate is on the match's visibility setting, not the query
+// shape). Callers MUST check `isMatchCompleteFromEvent` before calling into
+// this module, otherwise the archive would be cached as empty and never
+// refresh once the match flips to results=all.
+
+import {
+  cachedExecuteQuery,
+  executeQuery,
+  gqlCacheKey,
+  STAGE_SCORECARDS_QUERY,
+} from "@/lib/graphql";
+import type {
+  RawScorecardsData,
+  RawStage,
+  RawScCard,
+} from "@/lib/scorecard-data";
+
+// ─── Raw response shape ──────────────────────────────────────────────────────
+
+interface SingleStageResponse {
+  stage: {
+    id: string;
+    number: number;
+    name: string;
+    max_points?: number | null;
+    scorecards?: RawScCard[];
+  } | null;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/** Identifies a stage to fetch via the root `stage(ct, id)` query. */
+export interface StageRef {
+  /** IpscStageNode content_type (always 24 for IPSC). */
+  ct: number;
+  /** Stage primary key as a string (SSI's id type). */
+  id: string;
+}
+
+/**
+ * Permanent-cache wrapper around the per-stage archival fetch.
+ *
+ * On cache hit returns the assembled `RawScorecardsData` directly. On miss,
+ * fan-outs across `stages` (concurrency-limited), reassembles into the legacy
+ * shape, and writes the entry with `ttl=null` (permanent). Subsequent reads
+ * are pure cache hits.
+ *
+ * The cache key intentionally matches the legacy SCORECARDS_QUERY key
+ * (`gql:GetMatchScorecards:{...}`) so existing match-cache infrastructure
+ * (D1 mirror via `match_data_cache`, force-refresh sentinel, etc.) keeps
+ * working without churn. Callers don't see a difference.
+ */
+export async function cachedWholeMatchArchive(
+  matchCt: number,
+  matchId: string,
+  stages: StageRef[],
+): Promise<{ data: RawScorecardsData; cachedAt: string | null }> {
+  const cacheKey = gqlCacheKey("GetMatchScorecards", { ct: matchCt, id: matchId });
+  return cachedExecuteQuery<RawScorecardsData>(
+    cacheKey,
+    // The query string is a no-op for the cache layer (it's the cache value
+    // we care about), but `cachedExecuteQuery` will use it on a cache miss
+    // for diagnostics/telemetry. Hand it the per-stage query as a hint of
+    // what shape lives behind this key. If the cache misses, our custom
+    // fetcher below replaces the would-be GraphQL call.
+    STAGE_SCORECARDS_QUERY,
+    { ct: matchCt, id: matchId },
+    null,
+    {
+      // Override the upstream fetcher: instead of executing
+      // STAGE_SCORECARDS_QUERY once with the match's (ct, id) — which would
+      // be wrong, those args belong to the stage — fan out per-stage and
+      // assemble.
+      fetcher: () => fetchWholeMatchArchive(stages),
+    },
+  );
+}
+
+/**
+ * Uncached parallel per-stage fetch + assembly. Use this only when you
+ * intentionally want to bypass the cache (e.g. force-refresh path). Most
+ * callers should use `cachedWholeMatchArchive` instead.
+ */
+export async function fetchWholeMatchArchive(
+  stages: StageRef[],
+): Promise<RawScorecardsData> {
+  if (stages.length === 0) {
+    return { event: { stages: [] } };
+  }
+  const responses = await mapWithConcurrency(stages, MAX_CONCURRENCY, (s) =>
+    executeQuery<SingleStageResponse>(STAGE_SCORECARDS_QUERY, { ct: s.ct, id: s.id }),
+  );
+  const out: RawStage[] = [];
+  for (let i = 0; i < responses.length; i++) {
+    const r = responses[i];
+    if (!r?.stage) continue;
+    out.push({
+      id: r.stage.id,
+      number: r.stage.number,
+      name: r.stage.name,
+      max_points: r.stage.max_points ?? null,
+      scorecards: r.stage.scorecards ?? [],
+    });
+  }
+  // Sort by stage number so downstream consumers see the same ordering as
+  // the legacy whole-match query.
+  out.sort((a, b) => a.number - b.number);
+  return { event: { stages: out } };
+}
+
+// ─── Internals ───────────────────────────────────────────────────────────────
+
+/**
+ * Concurrency cap for the per-stage fan-out. SSI's 2026-05-04 admin message
+ * flagged "many seconds" as a sign of inefficiency; per-stage queries
+ * empirically take 1-2s each so a 4-in-flight cap keeps a 10-stage match's
+ * total wall-clock under ~5s while never having more than 4 outstanding
+ * upstream connections.
+ */
+const MAX_CONCURRENCY = 4;
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T, idx: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      results[idx] = await fn(items[idx], idx);
+    }
+  }
+  const workers: Promise<void>[] = [];
+  const n = Math.min(concurrency, items.length);
+  for (let i = 0; i < n; i++) workers.push(worker());
+  await Promise.all(workers);
+  return results;
+}

--- a/scripts/validate-ssi-queries.ts
+++ b/scripts/validate-ssi-queries.ts
@@ -49,6 +49,7 @@ import {
   UPCOMING_STATUS_QUERY,
   SCORECARDS_QUERY,
   SCORECARDS_DELTA_QUERY,
+  STAGE_SCORECARDS_QUERY,
 } from "../lib/graphql";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -80,6 +81,7 @@ const QUERIES: { name: string; src: string }[] = [
   { name: "UPCOMING_STATUS_QUERY", src: UPCOMING_STATUS_QUERY },
   { name: "SCORECARDS_QUERY", src: SCORECARDS_QUERY },
   { name: "SCORECARDS_DELTA_QUERY", src: SCORECARDS_DELTA_QUERY },
+  { name: "STAGE_SCORECARDS_QUERY", src: STAGE_SCORECARDS_QUERY },
 ];
 
 export function loadSnapshot(): Snapshot {

--- a/tests/unit/scorecards-archive.test.ts
+++ b/tests/unit/scorecards-archive.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the graphql module so we can stub `executeQuery` without touching the
+// real upstream. The archive module imports STAGE_SCORECARDS_QUERY,
+// gqlCacheKey, executeQuery, and cachedExecuteQuery — only executeQuery and
+// cachedExecuteQuery need stubbing for the parallel-fan-out tests.
+const executeQueryMock = vi.fn();
+
+vi.mock("@/lib/graphql", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/graphql")>("@/lib/graphql");
+  return {
+    ...actual,
+    executeQuery: (...args: Parameters<typeof actual.executeQuery>) =>
+      executeQueryMock(...args),
+  };
+});
+
+import {
+  fetchWholeMatchArchive,
+  type StageRef,
+} from "@/lib/scorecards-archive";
+import type { RawScCard } from "@/lib/scorecard-data";
+
+beforeEach(() => {
+  executeQueryMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function makeStageResponse(
+  stageId: string,
+  number: number,
+  cards: Partial<RawScCard>[] = [],
+) {
+  return {
+    stage: {
+      id: stageId,
+      number,
+      name: `Stage ${number}`,
+      max_points: 60,
+      scorecards: cards.map((c, i) => ({
+        created: "2026-05-04T08:00:00Z",
+        points: 50,
+        hitfactor: 5,
+        time: 10,
+        disqualified: false,
+        zeroed: false,
+        stage_not_fired: false,
+        incomplete: false,
+        ascore: 8,
+        bscore: 0,
+        cscore: 2,
+        dscore: 0,
+        miss: 0,
+        penalty: 0,
+        procedural: 0,
+        competitor: { id: String(i + 1) },
+        ...c,
+      })),
+    },
+  };
+}
+
+describe("fetchWholeMatchArchive", () => {
+  it("returns an empty stages array when given no stage refs (no upstream call)", async () => {
+    const out = await fetchWholeMatchArchive([]);
+    expect(out).toEqual({ event: { stages: [] } });
+    expect(executeQueryMock).not.toHaveBeenCalled();
+  });
+
+  it("fans out one upstream call per stage with the per-stage (ct,id) pair", async () => {
+    const refs: StageRef[] = [
+      { ct: 24, id: "100" },
+      { ct: 24, id: "101" },
+      { ct: 24, id: "102" },
+    ];
+    executeQueryMock.mockImplementation((_q, vars) => {
+      const stageId = vars.id as string;
+      return Promise.resolve(makeStageResponse(stageId, parseInt(stageId, 10) - 99, [{}]));
+    });
+
+    await fetchWholeMatchArchive(refs);
+
+    expect(executeQueryMock).toHaveBeenCalledTimes(3);
+    const calledIds = executeQueryMock.mock.calls.map((c) => (c[1] as { id: string }).id);
+    expect(calledIds.sort()).toEqual(["100", "101", "102"]);
+    // Confirm we always pass the IpscStageNode content_type, not the match's.
+    for (const call of executeQueryMock.mock.calls) {
+      expect((call[1] as { ct: number }).ct).toBe(24);
+    }
+  });
+
+  it("reassembles per-stage responses into the legacy whole-match shape, sorted by stage number", async () => {
+    // Pass in shuffled stage order — output should still be sorted ascending.
+    const refs: StageRef[] = [
+      { ct: 24, id: "300" },
+      { ct: 24, id: "100" },
+      { ct: 24, id: "200" },
+    ];
+    executeQueryMock.mockImplementation((_q, vars) => {
+      const id = vars.id as string;
+      const number = id === "100" ? 1 : id === "200" ? 2 : 3;
+      return Promise.resolve(
+        makeStageResponse(id, number, [{ competitor: { id: "1" } }, { competitor: { id: "2" } }]),
+      );
+    });
+
+    const out = await fetchWholeMatchArchive(refs);
+
+    expect(out.event?.stages).toBeDefined();
+    expect(out.event!.stages!.map((s) => s.number)).toEqual([1, 2, 3]);
+    expect(out.event!.stages!.map((s) => s.id)).toEqual(["100", "200", "300"]);
+    for (const stage of out.event!.stages!) {
+      expect(stage.scorecards).toHaveLength(2);
+      expect(stage.max_points).toBe(60);
+    }
+  });
+
+  it("preserves null max_points and empty scorecards arrays from upstream", async () => {
+    executeQueryMock.mockResolvedValueOnce({
+      stage: {
+        id: "100",
+        number: 1,
+        name: "Stage 1",
+        max_points: null,
+        scorecards: undefined,
+      },
+    });
+    const out = await fetchWholeMatchArchive([{ ct: 24, id: "100" }]);
+    expect(out.event!.stages![0].max_points).toBeNull();
+    expect(out.event!.stages![0].scorecards).toEqual([]);
+  });
+
+  it("filters out null stage responses (e.g. permission errors on a single stage)", async () => {
+    executeQueryMock
+      .mockResolvedValueOnce(makeStageResponse("100", 1, [{}]))
+      .mockResolvedValueOnce({ stage: null })
+      .mockResolvedValueOnce(makeStageResponse("102", 3, [{}]));
+    const out = await fetchWholeMatchArchive([
+      { ct: 24, id: "100" },
+      { ct: 24, id: "101" },
+      { ct: 24, id: "102" },
+    ]);
+    expect(out.event!.stages!.map((s) => s.id)).toEqual(["100", "102"]);
+  });
+
+  it("respects the concurrency cap (≤ 4 in flight at a time)", async () => {
+    let inFlight = 0;
+    let peakInFlight = 0;
+    executeQueryMock.mockImplementation(async (_q, vars) => {
+      inFlight++;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      // Yield twice so concurrency can build up.
+      await Promise.resolve();
+      await Promise.resolve();
+      inFlight--;
+      return makeStageResponse(vars.id as string, parseInt(vars.id as string, 10), [{}]);
+    });
+
+    // 10 stages → if concurrency cap works, peak in-flight should be ≤ 4.
+    const refs: StageRef[] = Array.from({ length: 10 }, (_, i) => ({
+      ct: 24,
+      id: String(i + 1),
+    }));
+    await fetchWholeMatchArchive(refs);
+
+    expect(peakInFlight).toBeLessThanOrEqual(4);
+    expect(executeQueryMock).toHaveBeenCalledTimes(10);
+  });
+
+  it("propagates a single-stage upstream failure as a rejection (caller decides fallback)", async () => {
+    executeQueryMock
+      .mockResolvedValueOnce(makeStageResponse("100", 1, [{}]))
+      .mockRejectedValueOnce(new Error("Upstream 500"));
+    await expect(
+      fetchWholeMatchArchive([
+        { ct: 24, id: "100" },
+        { ct: 24, id: "101" },
+      ]),
+    ).rejects.toThrow("Upstream 500");
+  });
+});


### PR DESCRIPTION
## Summary
The post-match scorecards path now uses SSI's blessed root \`stage(content_type, id) { scorecards }\` query, fanned out across all stages of a completed match in parallel. Cold-load wall time for 8-10 stage matches drops from **8-17s** (legacy \`event{stages{scorecards}}\`) to **2.6-3.5s** — verified 2026-05-04 against matches 26193 (1014 cards), 27046 (1198 cards), 27704 (1298 cards).

The archive cache is permanent (TTL=null) and never SWR-refreshed: first request per match per cache lifetime, then pure cache reads. Live matches keep using the legacy path for now (returns \`[]\` for results=org -- the gate is the match's visibility setting, not the query shape; see #410 round-2 trail). PR-3 will short-circuit the live path entirely.

## Why now
SSI announced 2026-05-04 that \`EventInterface.scorecards\` is being deprecated in favour of \`StageInterface.scorecards\`. The fan-out is the SSI-blessed shape. Empirically also faster on cold loads: SSI parallelizes 8-10 small queries instead of one big blocking one.

## What's in the box
- **\`lib/scorecards-archive.ts\`** (new): \`fetchWholeMatchArchive\`, \`cachedWholeMatchArchive\`, \`STAGE_SCORECARDS_QUERY\` (reuses the same \`SCORECARD_NODE_FIELDS\` as \`SCORECARDS_QUERY\` so on-disk shape stays identical).
- **\`cachedExecuteQuery\`**: new optional \`fetcher\` override so the cache layer can substitute a custom fan-out for the built-in single-query call without giving up Redis + D1 plumbing.
- **\`SCORECARDS_QUERY\`**: kept as fallback for the live path (returns \`[]\` for \`results=org\` but kept in case SSI re-instates live access). Doc-comment marks it deprecated with explicit "do not use for new runtime paths".
- **Migrated post-match callers** to \`cachedWholeMatchArchive\`:
  - \`/api/compare\` (post-match branch only; live path stays on SCORECARDS_QUERY pending PR-3)
  - \`/api/match/{ct}/{id}/competitor/{competitorId}/stages\` (post-match branch)
  - \`/api/data/match/{ct}/{id}/results\` (already gated post-match by PR-C-1)
  - \`/api/coaching/{ct}/{id}/{competitorId}\` (already gated by PR-C-1)
  - \`/api/simulate\` (already gated by PR-C-1)
  - \`/api/og/match/{ct}/{id}\` (already gated by PR-C-2)
- **7 unit tests** for the archive module: fan-out, parallel, concurrency cap, empty input, sorting, null-stage handling, error propagation.
- **\`validate:ssi-queries\`** now covers \`STAGE_SCORECARDS_QUERY\` (8 queries valid).

## Schema-snapshot drift (noted, not addressed here)
- \`competitor_scorecards\` / \`competitor_scorecards_count\`: present in live but unused by us (JWT-gated; #405 closed).
- \`scoring_completed\`: removed from \`EventInterface\` / \`IpscMatchNode\` / \`IpscStageNode\` introspection BUT still resolves at runtime. Verified directly via \`event(ct, id) { ... on IpscMatchNode { scoring_completed } }\` against match 22/27190. Will re-evaluate in PR-4.

## Test plan
- [x] \`pnpm -w run typecheck\` clean
- [x] \`pnpm -w run lint\` clean
- [x] \`pnpm -w test\` -- 57 files / 1682 tests pass (7 new for archive)
- [x] \`pnpm validate:ssi-queries\` -- 8 queries valid
- [x] Live-API verification: per-stage fan-out returns 1014 / 1198 / 1298 cards as expected for the three test matches in 2.6-3.5s
- [ ] Post-deploy: spot-check a completed match's compare view; confirm cache-hit on second load

## Refs
- #410 (parent meta-issue, redesign round 2)
- #404 (this resolves it; will close after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)