### PR TITLE
feat(live): short-circuit compare and stages routes for live matches

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -177,16 +177,43 @@ export async function GET(req: Request) {
     }
   }
 
+  // Short-circuit for live matches (#416 / PR-3): SSI does not publish
+  // per-stage scorecards while results visibility is "org". Skip the scorecards
+  // fetch entirely and return a minimal response with scorecardsRestricted=true.
+  // The live branch below is preserved so the route can be re-enabled by removing
+  // this guard if SSI reinstates live scorecard access.
+  if (!isComplete) {
+    const payload: CompareResponse = {
+      match_id: parseInt(id, 10),
+      mode,
+      stages: [],
+      competitors: [],
+      penaltyStats: {},
+      efficiencyStats: {},
+      consistencyStats: {},
+      lossBreakdownStats: {},
+      whatIfStats: null,
+      styleFingerprintStats: null,
+      fieldFingerprintPoints: null,
+      archetypePerformance: null,
+      courseLengthPerformance: null,
+      constraintPerformance: null,
+      stageDegradationData: null,
+      stageConditions: null,
+      scorecardsRestricted: true,
+      cacheInfo: { cachedAt: matchCachedAt },
+    };
+    return NextResponse.json(payload);
+  }
+
   // Step 2 — fetch scorecards.
   //
   // Post-match: per-stage archival fan-out (#410). Permanent cache, no SWR
   // refresh needed (results are immutable once results=all).
   //
-  // Live: legacy whole-match path. Returns `[]` for results=org matches
-  // (the gate is the match's results visibility, not the query shape — see
-  // #410 round-2 comment trail). Kept here so the route still functions if
-  // SSI later restores live access; PR-3 (#416) will short-circuit this
-  // entirely so we don't even hit SSI for live calls.
+  // Live: legacy whole-match path — kept as fallback if SSI reinstates live
+  // scorecard access. Currently unreachable because the short-circuit above
+  // returns early for all non-complete matches (#416).
   const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
   let scorecardsData: RawScorecardsData;
   let scorecardsCachedAt: string | null;

--- a/app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts
+++ b/app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts
@@ -89,6 +89,42 @@ export async function GET(
     resultsStatus: match.results_status,
   });
 
+  // Short-circuit for live matches (#416 / PR-3): SSI withholds per-stage
+  // scorecards while results visibility is "org". Return placeholder (all-null)
+  // stage entries immediately without touching SSI. Preserved live branch below
+  // can be re-enabled by removing this guard if SSI reinstates live access.
+  if (!isComplete) {
+    const sortedMatchStages = [...match.stages].sort(
+      (a, b) => a.stage_number - b.stage_number,
+    );
+    const placeholderStages: CompetitorStageResult[] = sortedMatchStages.map((s) => ({
+      stage_number: s.stage_number,
+      stage_id: s.id,
+      time_seconds: null,
+      scorecard_updated_at: null,
+      hit_factor: null,
+      stage_points: null,
+      stage_pct: null,
+      alphas: null,
+      charlies: null,
+      deltas: null,
+      misses: null,
+      no_shoots: null,
+      procedurals: null,
+      dq: false,
+    }));
+    const response: CompetitorStageResults = {
+      ct: ctNum,
+      matchId: matchIdNum,
+      competitorId: competitor.id,
+      shooterId: competitor.shooterId,
+      division: competitor.division,
+      stages: placeholderStages,
+      cacheInfo: { cachedAt: matchResult.cachedAt },
+    };
+    return NextResponse.json(response);
+  }
+
   const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
   let scorecardsData: RawScorecardsData;
   let scorecardsCachedAt: string | null;
@@ -104,8 +140,9 @@ export async function GET(
     }
     // Archive entries are permanent; no TTL upgrade or SWR refresh needed.
   } else {
-    // Live: legacy whole-match path. Returns `[]` for results=org matches —
-    // PR-3 (#416) will short-circuit so this branch never fires for live.
+    // Live: legacy whole-match path — currently unreachable because the
+    // short-circuit above returns early for all non-complete matches (#416).
+    // Preserved as fallback if SSI reinstates live scorecard access.
     try {
       ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
         await cachedExecuteQuery<RawScorecardsData>(


### PR DESCRIPTION
## Summary

- `compare` route: returns `CompareResponse{ scorecardsRestricted: true }` immediately after match-metadata check when `!isComplete` -- skips the whole-match scorecards fetch and all downstream ranking computation
- `competitor/stages` route: returns placeholder all-null stage entries per match stage when `!isComplete` -- same early exit
- Both live branches preserved (commented) as fallback in case SSI reinstates live scorecard access
- Closes #416

Part of #410. Follows PR #419 (live empty-state UI).

## Test plan

- [ ] `GET /api/compare?ct=22&id=<live_match>&competitor_ids=1` returns `{ scorecardsRestricted: true }` with empty stages/competitors
- [ ] `GET /api/match/22/<live_match>/competitor/123/stages` returns placeholder null-field stages for each match stage
- [ ] Same routes for a completed match still return full data
- [ ] typecheck, lint, tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)