### PR TITLE
feat(ci): E2E guard for live short-circuit + document SCORECARDS_QUERY status

### DIFF
--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -974,10 +974,11 @@ export const SCORECARD_NODE_FIELDS = `
 // the canonical reference for the scorecard field set, but new runtime
 // paths must NOT call it.
 //
-// Empirical 2026-05-04: returns `[]` for live matches with `results=org`
-// (organizer-only visibility) — same gate applies to all scorecard paths
-// under API-key auth. Use only for matches where `isMatchCompleteFromEvent`
-// is true.
+// Current status (2026-05-04): all callers that previously ran this on live
+// matches have been short-circuited (#416 / PR-3) and now return early. The
+// live else-branch in compare/route.ts and stages/route.ts is preserved for
+// revival but is currently unreachable code. Only `cachedWholeMatchArchive`
+// (post-match path, `isMatchCompleteFromEvent === true`) reaches SSI now.
 export const SCORECARDS_QUERY = `
   query GetMatchScorecards($ct: Int!, $id: String!) {
     event(content_type: $ct, id: $id) {

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -158,6 +158,18 @@ const MOCK_COMPARE: CompareResponse = {
   ],
 };
 
+// Far-future date keeps daysSinceMatchStart and daysSinceEnd negative, which
+// prevents detectMatchView from ever flipping to "coaching" as time passes.
+// scoring_completed=75 + results_status="org" → effectiveMode === "live".
+const MOCK_LIVE_MATCH: typeof MOCK_MATCH = {
+  ...MOCK_MATCH,
+  date: "2099-12-30T09:00:00+00:00",
+  ends: "2099-12-31T09:00:00+00:00",
+  scoring_completed: 75,
+  results_status: "org",
+  match_status: "on",
+};
+
 const MOCK_COMPARE_2: CompareResponse = {
   ...MOCK_COMPARE,
   competitors: [MOCK_MATCH.competitors[0], MOCK_MATCH.competitors[1]],
@@ -519,5 +531,32 @@ test.describe("Mobile 390px viewport", () => {
       () => document.documentElement.scrollWidth > window.innerWidth
     );
     expect(hasOverflow).toBe(false);
+  });
+
+  test("live match shows 'Match in progress' notice and never calls compare API", async ({ page }) => {
+    let compareCallCount = 0;
+    await page.route("/api/match/22/99999999", (route) =>
+      route.fulfill({ json: MOCK_LIVE_MATCH })
+    );
+    await page.route(/\/api\/compare/, (route) => {
+      compareCallCount++;
+      route.fulfill({ json: { scorecardsRestricted: true, stages: [], competitors: [] } });
+    });
+
+    await page.goto("/match/22/99999999");
+    await expect(page.getByText("Test IPSC Match")).toBeVisible();
+
+    // "Match in progress" notice should be visible immediately (no selection needed)
+    await expect(page.getByText("Match in progress")).toBeVisible();
+    await expect(page.getByText(/scoring is complete/i)).toBeVisible();
+
+    // Select a competitor — notice should still be shown, not a comparison table
+    await page.getByRole("button", { name: /add competitor/i }).click();
+    await page.getByRole("option", { name: /alice/i }).click();
+    await expect(page.getByText("Match in progress")).toBeVisible();
+    await expect(page.getByRole("table")).not.toBeVisible();
+
+    // Compare API must never have been called
+    expect(compareCallCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- Add `MOCK_LIVE_MATCH` E2E fixture (far-future date so `detectMatchView` always returns "live" regardless of when the test runs)
- Add E2E test: visits a live match, verifies "Match in progress" notice is shown and the compare API is never called
- Update `SCORECARDS_QUERY` comment in `lib/graphql.ts` to reflect current runtime status: all live-path callers are short-circuited by PR-3; the live else-branches are preserved as fallback but currently unreachable

Part of #410. Follows #418 (post-match fan-out), #419 (live empty-state UI), #420 (live short-circuit).

## Test plan

- [ ] `pnpm test:e2e --grep "live match"` passes
- [ ] `pnpm -w run typecheck && pnpm -w test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)