### PR TITLE
feat(discord): gate live-data commands behind scorecardsRestricted (#416 / PR-6)

### DIFF
--- a/discord/src/commands/leaderboard.ts
+++ b/discord/src/commands/leaderboard.ts
@@ -74,6 +74,20 @@ export async function handleLeaderboard(
     tracked.map((t) => t.competitorId),
   );
 
+  // SSI withholds per-stage scorecards while a match is live. Return a holding
+  // message instead of an empty leaderboard. Preserved: remove this gate if SSI
+  // reinstates live scorecard access.
+  if (compareResult.scorecardsRestricted) {
+    const matchUrl = `${baseUrl}/match/${matchCt}/${matchId}`;
+    return {
+      content:
+        `**${matchName}** is currently in progress (${match.scoring_completed}% scored).\n` +
+        `Leaderboard data isn't available during active scoring — check back once the match is complete.\n` +
+        matchUrl,
+      embeds: [],
+    };
+  }
+
   // Compute per-shooter stats
   const shooterStats: Array<{
     name: string;

--- a/discord/src/commands/summary.ts
+++ b/discord/src/commands/summary.ts
@@ -92,6 +92,20 @@ export async function handleSummary(
     tracked.map((t) => t.competitorId),
   );
 
+  // SSI withholds per-stage scorecards while a match is live. Return a holding
+  // message instead of an empty table. Preserved: remove this gate if SSI
+  // reinstates live scorecard access.
+  if (compareResult.scorecardsRestricted) {
+    const matchUrl = `${baseUrl}/match/${matchCt}/${matchId}`;
+    return {
+      content:
+        `**${matchName}** is currently in progress (${match.scoring_completed}% scored).\n` +
+        `Stage-by-stage results aren't available during active scoring — check back once the match is complete.\n` +
+        matchUrl,
+      embeds: [],
+    };
+  }
+
   // Build per-shooter summaries
   const summaries: ShooterSummary[] = [];
   for (const t of tracked) {

--- a/discord/src/commands/watch.ts
+++ b/discord/src/commands/watch.ts
@@ -133,6 +133,23 @@ export async function handleWatch(
       ? `${fullMatch.scoring_completed}% scored`
       : "Not started yet";
 
+  // SSI currently withholds per-stage scorecards while a match is live, so
+  // live stage notifications are unavailable until scoring completes. The watch
+  // state is stored anyway so results post automatically once done. If SSI
+  // reinstates live access, this branch can be removed to restore real-time
+  // notifications.
+  const isLive =
+    fullMatch.scoring_completed < 95 &&
+    (() => {
+      if (!fullMatch.date) return true;
+      const daysSince =
+        (Date.now() - new Date(fullMatch.date).getTime()) / (1000 * 60 * 60 * 24);
+      return daysSince <= 3;
+    })();
+  const footerText = isLive
+    ? "Detailed results will post once scoring is complete. Use /unwatch to cancel."
+    : "I'll post here when these shooters finish a stage. Use /unwatch to stop.";
+
   const embed: APIEmbed = {
     title: `Now watching: ${matchName}`,
     url: matchUrl,
@@ -143,10 +160,7 @@ export async function handleWatch(
       { name: "Competitors", value: String(fullMatch.competitors_count), inline: true },
       { name: "Tracking", value: trackedNames.join(", "), inline: false },
     ],
-    footer: {
-      text:
-        "I'll post here when these shooters finish a stage. Use /unwatch to stop.",
-    },
+    footer: { text: footerText },
   };
 
   return { content: "", embeds: [embed] };

--- a/discord/src/notifications/stage-scored.ts
+++ b/discord/src/notifications/stage-scored.ts
@@ -93,6 +93,25 @@ async function pollGuildWatch(
     trackedCompetitors.map((c) => c.competitorId),
   );
 
+  // SSI withholds per-stage scorecards while results visibility is "org" (live
+  // matches). stages will be empty; skip detection and let the auto-unwatch
+  // below fire when scoring eventually completes. Preserved: if SSI reinstates
+  // live scorecard access, remove this early-return and detection resumes.
+  if (compareResult.scorecardsRestricted) {
+    if (isMatchDone(match.scoring_completed, match.date)) {
+      await env.BOT_KV.delete(watchKey(guildId));
+      const label = match.scoring_completed >= 95
+        ? `**${state.matchName}** is fully scored!`
+        : `**${state.matchName}** appears to be done (${match.scoring_completed}% scored, match date passed).`;
+      await postChannelMessage(
+        env.DISCORD_BOT_TOKEN,
+        state.channelId,
+        `${label} Stopped watching.\nFull results: ${env.SCOREBOARD_BASE_URL}/match/${state.matchCt}/${state.matchId}`,
+      );
+    }
+    return;
+  }
+
   // Detect newly scored stages per competitor
   const newScores: NewStageScore[] = [];
   const updatedNotified = { ...state.notifiedStages };

--- a/discord/src/types.ts
+++ b/discord/src/types.ts
@@ -160,6 +160,12 @@ export interface CompareResult {
     division: string | null;
     club: string | null;
   }>;
+  /**
+   * True when the match is still live and SSI withholds per-stage scorecards.
+   * stages will be empty; callers should surface a "check back after scoring"
+   * message instead of showing empty data.
+   */
+  scorecardsRestricted?: boolean;
 }
 
 export interface CompetitorStageResult {


### PR DESCRIPTION
## Summary

- Adds `scorecardsRestricted?: boolean` to `CompareResult` in Discord types
- **`pollWatchedMatches` cron** (`stage-scored.ts`): when `scorecardsRestricted`, skips the stage-detection loop (which would silently find nothing anyway) and runs the auto-unwatch check directly
- **`/watch`**: updates the confirmation embed footer to set correct expectations for live matches ("results will post once scoring is complete" instead of implying real-time stage-by-stage updates)
- **`/summary`** and **`/leaderboard`**: early return with a plain-English message when the match is live; users see a link to check back after scoring
- **`/predict reveal`**: already gated at `scoring_completed < 95` -- no change needed
- **Achievements cron**: uses the shooter dashboard (not compare) -- unaffected

All existing code paths are preserved as early-return gates only. If SSI reinstates live scorecard access, remove the `scorecardsRestricted` guards to restore real-time behavior.

## Test plan

- [ ] `pnpm run typecheck` passes in `discord/`
- [ ] `pnpm test` passes in `discord/` (81 tests)
- [ ] `pnpm -w run typecheck` passes at workspace root

🤖 Generated with [Claude Code](https://claude.com/claude-code)