### PR TITLE
fix(auth): add JWT token_auth flow for SSI GraphQL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Key directories:
 - `app/api/compare/logic.ts` -- **pure function** `computeGroupRankings()`, no I/O, fully unit-tested
 - `app/api/mcp/route.ts` -- MCP HTTP endpoint (JSON-RPC, single-shot transport); optional `MCP_SECRET` bearer auth
 - `lib/graphql.ts` -- GQL query strings + `executeQuery()`, server-only (no NEXT_PUBLIC_ prefix)
+- `lib/ssi-auth.ts` -- JWT lifecycle for SSI's `Authorization: JWT <token>` header. Single-flighted, Redis-shared, refreshes via `refresh_token` then falls back to `token_auth(email, password)`. Driven by `SSI_SERVICE_EMAIL`/`SSI_SERVICE_PASSWORD` (bot account)
 - `lib/cache.ts` -- `CacheAdapter` interface (get/set/persist/del/expire/scanCachedMatchKeys)
 - `lib/cache-node.ts` -- ioredis implementation (Docker / Node.js target)
 - `lib/cache-edge.ts` -- @upstash/redis HTTP implementation (Cloudflare Pages target)

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -2,7 +2,9 @@
 
 | Variable | Where used | Target | Notes |
 |---|---|---|---|
-| `SSI_API_KEY` | `lib/graphql.ts` (server-only) | Both | Never use `NEXT_PUBLIC_` prefix |
+| `SSI_API_KEY` | `lib/graphql.ts`, `lib/ssi-auth.ts` (server-only) | Both | Sent as the `x-api-key` header on every upstream call. As of 2026-05 the API key alone is not sufficient -- a JWT is also required (see `SSI_SERVICE_EMAIL`/`PASSWORD`). Never use `NEXT_PUBLIC_` prefix. |
+| `SSI_SERVICE_EMAIL` | `lib/ssi-auth.ts` (server-only) | Both | Email for the dedicated SSI bot account that backs every upstream request. SSI now requires a logged-in user (JWT obtained via `token_auth(email, password)`) on every GraphQL resolver. Use a dedicated bot account, never a real user. Never `NEXT_PUBLIC_`. |
+| `SSI_SERVICE_PASSWORD` | `lib/ssi-auth.ts` (server-only) | Both | Password for the bot account. Set via `wrangler secret put`. Quote with single quotes in `.env.local` so shell `$`/`!` chars survive. Never `NEXT_PUBLIC_`. |
 | `CACHE_PURGE_SECRET` | `app/api/admin/cache/purge/route.ts`, `app/api/admin/cache/health/route.ts` | Both | Any strong random string; never `NEXT_PUBLIC_` |
 | `MIN_CACHE_TTL_SECONDS` | `lib/match-ttl.ts` (server-only) | Both | Minimum TTL floor for all non-permanent cache entries. Default `30` (s) -- keeps active matches near-real-time so courtside polling picks up fresh scorecards within seconds. Raise it to reduce upstream load on shared deployments. Set to `0` to disable. Never `NEXT_PUBLIC_`. |
 | `MATCH_COMPLETE_DAYS_SINCE` | `lib/match-ttl.ts` (server-only) | Both | Hard time gate (days) before a match can be permanently pinned to durable cache. Default `3`. Even SSI flag flips (`status=cp`, `results=all`) cannot pin earlier than this -- protects against the Skepplanda-style premature pinning bug where a mid-match flag flip caused stale data to stick. Raise for events with very long scoring tails (e.g. World Shoots that run 5+ days). Never `NEXT_PUBLIC_`. |

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -10,6 +10,7 @@ import { parseMatchCacheKey, persistActiveMatchToD1 } from "@/lib/match-data-sto
 import { markUpstreamDegraded } from "@/lib/upstream-status";
 import { upstreamTelemetry, hashVariables, type UpstreamOutcome } from "@/lib/upstream-telemetry";
 import { cacheTelemetry } from "@/lib/cache-telemetry";
+import { getJwt, JWT_EXPIRED_ERROR_PATTERNS } from "@/lib/ssi-auth";
 
 /**
  * Check if the current request is an admin-authenticated request
@@ -71,6 +72,14 @@ export async function executeQuery<T>(
     return await executeQueryOnce<T>(query, variables, revalidate, options);
   } catch (err) {
     const msg = err instanceof Error ? err.message : "";
+    if (JWT_EXPIRED_ERROR_PATTERNS.some((m) => msg.includes(m))) {
+      // JWT rejected by SSI — force-refresh once and retry. Covers the
+      // window where our cached JWT has expired but the next isolate hasn't
+      // re-minted yet, and the cold-start case where a stale Redis entry
+      // outlives its actual exp claim.
+      await getJwt({ force: true });
+      return await executeQueryOnce<T>(query, variables, revalidate, options);
+    }
     if (RETRY_GRAPHQL_MESSAGES.some((m) => msg.includes(m))) {
       // Single immediate retry. We don't back off — the failure mode is a
       // dropped body at SSI's gateway, not load shedding, so a retry helps
@@ -89,6 +98,10 @@ async function executeQueryOnce<T>(
 ): Promise<T> {
   const apiKey = process.env.SSI_API_KEY;
   if (!apiKey) throw new Error("SSI_API_KEY is not configured");
+
+  // SSI now requires both `x-api-key` AND a JWT (`Authorization: JWT <token>`)
+  // on every resolver. See lib/ssi-auth.ts for the lifecycle.
+  const jwt = await getJwt();
 
   // Extract the operation name for log context, e.g. "GetMatchScorecards"
   const operationName = query.match(/query\s+(\w+)/)?.[1] ?? "unknown";
@@ -119,7 +132,7 @@ async function executeQueryOnce<T>(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Api-Key ${apiKey}`,
+        Authorization: `JWT ${jwt}`,
         "x-api-key": apiKey,
       },
       body: JSON.stringify({ query, variables }),

--- a/lib/ssi-auth.ts
+++ b/lib/ssi-auth.ts
@@ -27,6 +27,14 @@ import cache from "@/lib/cache-impl";
 const GRAPHQL_ENDPOINT = "https://shootnscoreit.com/graphql/";
 const CACHE_KEY = "ssi:jwt:v1";
 
+// Sentinel API key set by the CI e2e job (.github/workflows/ci.yml). When seen
+// we skip JWT acquisition entirely and return a placeholder -- e2e tests mock
+// every /api/* call, so the placeholder never reaches the wire. Without this
+// short-circuit every server-side render (e.g. generateMetadata) would throw
+// from missing creds, slowing navigations enough to flake URL-timing tests.
+const E2E_SENTINEL_API_KEY = "dummy_key_for_e2e";
+const E2E_PLACEHOLDER_JWT = "e2e-placeholder-jwt";
+
 // Refresh tokens live ~7 days per SSI. Re-mint when <24h remain so no in-flight
 // request hits an expired refresh and has to fall back to password login.
 const REFRESH_RENEW_BEFORE_SECONDS = 24 * 60 * 60;
@@ -78,6 +86,10 @@ let inflight: Promise<string> | null = null;
  * an upstream call fails with a JWT-expiry GraphQL error.
  */
 export async function getJwt(opts: { force?: boolean } = {}): Promise<string> {
+  if (process.env.SSI_API_KEY === E2E_SENTINEL_API_KEY) {
+    return E2E_PLACEHOLDER_JWT;
+  }
+
   if (!opts.force) {
     // Single-flight within this isolate. Concurrent callers all wait on the
     // same promise so we only do one network roundtrip per cold-start burst.

--- a/lib/ssi-auth.ts
+++ b/lib/ssi-auth.ts
@@ -1,0 +1,260 @@
+// SSI GraphQL JWT manager — server-only.
+//
+// As of 2026-05, every SSI GraphQL resolver requires both `x-api-key` AND a
+// JWT obtained via the `token_auth(email, password)` mutation. API-key-only
+// access returns "User must be authenticated" on every field. See:
+// https://shootnscoreit.com/about-the-api/
+//
+// This module owns the JWT lifecycle:
+//  - Acquire on demand (cold start): refresh_token if we have one cached,
+//    else token_auth(email, password).
+//  - Cache in Redis (`ssi:jwt:v1`) so all worker isolates share one token —
+//    avoids hammering token_auth on cold deploys / scale-out.
+//  - Single-flight via a module-level promise so concurrent getJwt() calls
+//    inside one isolate dedupe.
+//  - Refresh-on-expired: callers signal {force:true} to skip the cache and
+//    re-mint after a JWT-expiry rejection.
+//
+// Failure modes:
+//  - Missing creds → throw at acquisition time. Surfaces at first upstream
+//    request after a misconfiguration; not at module load.
+//  - refresh_token failure → fall back to token_auth(email, password) once.
+//  - token_auth failure → propagate the error message verbatim so operators
+//    can see "invalid_credentials" / "account locked" / etc.
+
+import cache from "@/lib/cache-impl";
+
+const GRAPHQL_ENDPOINT = "https://shootnscoreit.com/graphql/";
+const CACHE_KEY = "ssi:jwt:v1";
+
+// Refresh tokens live ~7 days per SSI. Re-mint when <24h remain so no in-flight
+// request hits an expired refresh and has to fall back to password login.
+const REFRESH_RENEW_BEFORE_SECONDS = 24 * 60 * 60;
+
+// JWTs expire faster than refresh tokens (typically ~1h). We cache them with
+// a conservative TTL so the next isolate / next request picks up a fresh one
+// well before SSI rejects it. The actual JWT exp claim is opaque to us.
+const JWT_CACHE_TTL_SECONDS = 30 * 60;
+
+interface CachedAuth {
+  jwt: string;
+  refreshToken: string;
+  // ISO timestamp of refresh-token expiry, used to trigger renewal.
+  refreshExpiresAt: string;
+  // When this cache entry was minted (ms epoch). Used to bound JWT freshness.
+  cachedAt: number;
+}
+
+interface TokenAuthResponse {
+  data?: {
+    token_auth?: {
+      success: boolean;
+      errors: unknown;
+      token?: { token: string } | null;
+      refresh_token?: { token: string; expires_at: string } | null;
+    } | null;
+  };
+  errors?: { message: string }[];
+}
+
+interface RefreshTokenResponse {
+  data?: {
+    refresh_token?: {
+      success: boolean;
+      errors: unknown;
+      token?: { token: string } | null;
+      refresh_token?: { token: string; expires_at: string } | null;
+    } | null;
+  };
+  errors?: { message: string }[];
+}
+
+let inflight: Promise<string> | null = null;
+
+/**
+ * Returns a JWT suitable for `Authorization: JWT <token>`.
+ *
+ * Pass `{force:true}` to bypass the cache and re-mint — use this after
+ * an upstream call fails with a JWT-expiry GraphQL error.
+ */
+export async function getJwt(opts: { force?: boolean } = {}): Promise<string> {
+  if (!opts.force) {
+    // Single-flight within this isolate. Concurrent callers all wait on the
+    // same promise so we only do one network roundtrip per cold-start burst.
+    if (inflight) return inflight;
+  }
+
+  const promise = acquireJwt(opts.force ?? false).finally(() => {
+    if (inflight === promise) inflight = null;
+  });
+  inflight = promise;
+  return promise;
+}
+
+async function acquireJwt(force: boolean): Promise<string> {
+  // Cache hit — happy path.
+  if (!force) {
+    const cached = await readCache();
+    if (cached) return cached.jwt;
+  }
+
+  // No cache or forced refresh. Try refresh_token first (cheaper than login).
+  const cached = await readCache();
+  if (cached?.refreshToken) {
+    const remainingSec = Math.floor(
+      (new Date(cached.refreshExpiresAt).getTime() - Date.now()) / 1000,
+    );
+    if (remainingSec > REFRESH_RENEW_BEFORE_SECONDS) {
+      try {
+        const fresh = await refreshJwt(cached.refreshToken);
+        await writeCache(fresh);
+        return fresh.jwt;
+      } catch (err) {
+        // Refresh failed (revoked / bad token). Fall through to password login.
+        console.warn(
+          `[ssi-auth] refresh_token failed, falling back to token_auth: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
+  const fresh = await loginJwt();
+  await writeCache(fresh);
+  return fresh.jwt;
+}
+
+async function readCache(): Promise<CachedAuth | null> {
+  try {
+    const raw = await cache.get(CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CachedAuth;
+    if (!parsed.jwt || !parsed.refreshToken || !parsed.refreshExpiresAt) return null;
+    return parsed;
+  } catch (err) {
+    console.warn(`[ssi-auth] cache read failed: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
+}
+
+async function writeCache(auth: CachedAuth): Promise<void> {
+  try {
+    await cache.set(CACHE_KEY, JSON.stringify(auth), JWT_CACHE_TTL_SECONDS);
+  } catch (err) {
+    // A cache write failure is non-fatal — every request will just re-login.
+    // Surface it in logs so operators notice persistent failures.
+    console.warn(`[ssi-auth] cache write failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+async function loginJwt(): Promise<CachedAuth> {
+  const email = process.env.SSI_SERVICE_EMAIL;
+  const password = process.env.SSI_SERVICE_PASSWORD;
+  const apiKey = process.env.SSI_API_KEY;
+  if (!email || !password) {
+    throw new Error("SSI_SERVICE_EMAIL / SSI_SERVICE_PASSWORD not configured");
+  }
+  if (!apiKey) {
+    throw new Error("SSI_API_KEY not configured");
+  }
+
+  const body = JSON.stringify({
+    query:
+      "mutation Login($email: String!, $pwd: String!) { token_auth(email: $email, password: $pwd) { success errors token { token } refresh_token { token expires_at } } }",
+    variables: { email, pwd: password },
+  });
+
+  const res = await fetch(GRAPHQL_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": apiKey },
+    body,
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error(`token_auth HTTP ${res.status} ${res.statusText}`);
+  }
+
+  const json = (await res.json()) as TokenAuthResponse;
+  if (json.errors?.length) {
+    throw new Error(`token_auth GraphQL error: ${json.errors.map((e) => e.message).join("; ")}`);
+  }
+  const ta = json.data?.token_auth;
+  if (!ta?.success || !ta.token?.token || !ta.refresh_token?.token) {
+    const errMsg = formatAuthErrors(ta?.errors);
+    throw new Error(`token_auth rejected: ${errMsg ?? "unknown"}`);
+  }
+
+  return {
+    jwt: ta.token.token,
+    refreshToken: ta.refresh_token.token,
+    refreshExpiresAt: ta.refresh_token.expires_at,
+    cachedAt: Date.now(),
+  };
+}
+
+async function refreshJwt(refreshToken: string): Promise<CachedAuth> {
+  const apiKey = process.env.SSI_API_KEY;
+  if (!apiKey) throw new Error("SSI_API_KEY not configured");
+
+  const body = JSON.stringify({
+    query:
+      "mutation Refresh($rt: String!) { refresh_token(refresh_token: $rt, revoke_refresh_token: false) { success errors token { token } refresh_token { token expires_at } } }",
+    variables: { rt: refreshToken },
+  });
+
+  const res = await fetch(GRAPHQL_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": apiKey },
+    body,
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error(`refresh_token HTTP ${res.status} ${res.statusText}`);
+  }
+
+  const json = (await res.json()) as RefreshTokenResponse;
+  if (json.errors?.length) {
+    throw new Error(`refresh_token GraphQL error: ${json.errors.map((e) => e.message).join("; ")}`);
+  }
+  const r = json.data?.refresh_token;
+  if (!r?.success || !r.token?.token || !r.refresh_token?.token) {
+    const errMsg = formatAuthErrors(r?.errors);
+    throw new Error(`refresh_token rejected: ${errMsg ?? "unknown"}`);
+  }
+  return {
+    jwt: r.token.token,
+    refreshToken: r.refresh_token.token,
+    refreshExpiresAt: r.refresh_token.expires_at,
+    cachedAt: Date.now(),
+  };
+}
+
+function formatAuthErrors(errors: unknown): string | null {
+  if (!errors) return null;
+  // SSI returns either a list or a dict like { nonFieldErrors: [{message,code}] }.
+  try {
+    return JSON.stringify(errors);
+  } catch {
+    return String(errors);
+  }
+}
+
+/**
+ * GraphQL error messages from SSI that mean "your JWT is no longer accepted".
+ * Used by lib/graphql.ts to decide whether to refresh + retry once.
+ */
+export const JWT_EXPIRED_ERROR_PATTERNS = [
+  "Signature has expired",
+  "Error decoding signature",
+  "Invalid token",
+  // SSI also surfaces unauthenticated errors as "User must be authenticated"
+  // when the JWT is missing/rejected — covered so a stale cached token
+  // (e.g. after a backend restart) recovers on the next request.
+  "User must be authenticated",
+];
+
+/** Test-only reset — clears the in-isolate single-flight promise. */
+export function __resetForTests(): void {
+  inflight = null;
+}

--- a/tests/unit/refresh-cached-match-query.test.ts
+++ b/tests/unit/refresh-cached-match-query.test.ts
@@ -33,6 +33,10 @@ vi.mock("@/lib/background-impl", () => ({
 vi.mock("next/headers", () => ({
   headers: () => Promise.resolve(new Map()),
 }));
+vi.mock("@/lib/ssi-auth", () => ({
+  getJwt: vi.fn(() => Promise.resolve("test-jwt")),
+  JWT_EXPIRED_ERROR_PATTERNS: ["Signature has expired", "Invalid token", "User must be authenticated"],
+}));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 

--- a/tests/unit/refresh-cached-query.test.ts
+++ b/tests/unit/refresh-cached-query.test.ts
@@ -34,6 +34,10 @@ vi.mock("@/lib/background-impl", () => ({
 vi.mock("next/headers", () => ({
   headers: () => Promise.resolve(new Map()),
 }));
+vi.mock("@/lib/ssi-auth", () => ({
+  getJwt: vi.fn(() => Promise.resolve("test-jwt")),
+  JWT_EXPIRED_ERROR_PATTERNS: ["Signature has expired", "Invalid token", "User must be authenticated"],
+}));
 
 // ─── Tests ────────────────────────────────────────────────────────────────
 

--- a/tests/unit/ssi-auth.test.ts
+++ b/tests/unit/ssi-auth.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const cacheMock = vi.hoisted(() => ({
+  get: vi.fn<(key: string) => Promise<string | null>>(),
+  set: vi.fn<(key: string, val: string, ttl?: number | null) => Promise<void>>(),
+  del: vi.fn<(...keys: string[]) => Promise<void>>(),
+  persist: vi.fn(() => Promise.resolve()),
+  expire: vi.fn(() => Promise.resolve()),
+  setIfAbsent: vi.fn(() => Promise.resolve(true)),
+  scanCachedMatchKeys: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/lib/cache-impl", () => ({ default: cacheMock }));
+
+import { getJwt, __resetForTests } from "@/lib/ssi-auth";
+
+const FUTURE_ISO = () => new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+const NEAR_EXPIRY_ISO = () => new Date(Date.now() + 60 * 1000).toISOString(); // 1 min left
+
+function tokenAuthOk(jwt: string, refreshToken: string, expiresAt = FUTURE_ISO()) {
+  return new Response(
+    JSON.stringify({
+      data: {
+        token_auth: {
+          success: true,
+          errors: null,
+          token: { token: jwt },
+          refresh_token: { token: refreshToken, expires_at: expiresAt },
+        },
+      },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function refreshOk(jwt: string, refreshToken: string, expiresAt = FUTURE_ISO()) {
+  return new Response(
+    JSON.stringify({
+      data: {
+        refresh_token: {
+          success: true,
+          errors: null,
+          token: { token: jwt },
+          refresh_token: { token: refreshToken, expires_at: expiresAt },
+        },
+      },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function tokenAuthFail(reason = "invalid_credentials") {
+  return new Response(
+    JSON.stringify({
+      data: {
+        token_auth: {
+          success: false,
+          errors: { nonFieldErrors: [{ message: "nope", code: reason }] },
+          token: null,
+          refresh_token: null,
+        },
+      },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function refreshFail() {
+  return new Response(
+    JSON.stringify({
+      data: {
+        refresh_token: {
+          success: false,
+          errors: { nonFieldErrors: [{ message: "expired", code: "expired" }] },
+          token: null,
+          refresh_token: null,
+        },
+      },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+describe("ssi-auth getJwt", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    cacheMock.get.mockReset();
+    cacheMock.set.mockReset();
+    cacheMock.get.mockResolvedValue(null);
+    cacheMock.set.mockResolvedValue(undefined);
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    process.env.SSI_API_KEY = "test-key";
+    process.env.SSI_SERVICE_EMAIL = "bot@example.com";
+    process.env.SSI_SERVICE_PASSWORD = "pw";
+    __resetForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("logs in via token_auth on cold start (no cache)", async () => {
+    fetchSpy.mockResolvedValueOnce(tokenAuthOk("JWT-A", "REF-A"));
+
+    const jwt = await getJwt();
+
+    expect(jwt).toBe("JWT-A");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.headers["x-api-key"]).toBe("test-key");
+    expect(JSON.parse(init.body).query).toContain("token_auth");
+
+    // Cached the result
+    expect(cacheMock.set).toHaveBeenCalledWith(
+      "ssi:jwt:v1",
+      expect.stringContaining("JWT-A"),
+      expect.any(Number),
+    );
+  });
+
+  it("returns cached JWT without any network call", async () => {
+    cacheMock.get.mockResolvedValue(
+      JSON.stringify({
+        jwt: "CACHED-JWT",
+        refreshToken: "CACHED-REF",
+        refreshExpiresAt: FUTURE_ISO(),
+        cachedAt: Date.now(),
+      }),
+    );
+
+    const jwt = await getJwt();
+
+    expect(jwt).toBe("CACHED-JWT");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("force=true bypasses cache and calls refresh_token first", async () => {
+    cacheMock.get.mockResolvedValue(
+      JSON.stringify({
+        jwt: "OLD-JWT",
+        refreshToken: "GOOD-REF",
+        refreshExpiresAt: FUTURE_ISO(),
+        cachedAt: Date.now(),
+      }),
+    );
+    fetchSpy.mockResolvedValueOnce(refreshOk("NEW-JWT", "NEW-REF"));
+
+    const jwt = await getJwt({ force: true });
+
+    expect(jwt).toBe("NEW-JWT");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(JSON.parse(init.body).query).toContain("refresh_token");
+  });
+
+  it("force=true falls back to token_auth when refresh_token fails", async () => {
+    cacheMock.get.mockResolvedValue(
+      JSON.stringify({
+        jwt: "OLD-JWT",
+        refreshToken: "BAD-REF",
+        refreshExpiresAt: FUTURE_ISO(),
+        cachedAt: Date.now(),
+      }),
+    );
+    fetchSpy
+      .mockResolvedValueOnce(refreshFail())
+      .mockResolvedValueOnce(tokenAuthOk("LOGIN-JWT", "LOGIN-REF"));
+
+    const jwt = await getJwt({ force: true });
+
+    expect(jwt).toBe("LOGIN-JWT");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(fetchSpy.mock.calls[0][1].body).query).toContain("refresh_token");
+    expect(JSON.parse(fetchSpy.mock.calls[1][1].body).query).toContain("token_auth");
+  });
+
+  it("force=true skips refresh when refresh-token is near expiry and goes straight to login", async () => {
+    cacheMock.get.mockResolvedValue(
+      JSON.stringify({
+        jwt: "OLD-JWT",
+        refreshToken: "EXPIRING-REF",
+        refreshExpiresAt: NEAR_EXPIRY_ISO(),
+        cachedAt: Date.now(),
+      }),
+    );
+    fetchSpy.mockResolvedValueOnce(tokenAuthOk("FRESH-JWT", "FRESH-REF"));
+
+    const jwt = await getJwt({ force: true });
+
+    expect(jwt).toBe("FRESH-JWT");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchSpy.mock.calls[0][1].body).query).toContain("token_auth");
+  });
+
+  it("single-flights concurrent callers within one isolate", async () => {
+    let resolveFetch: (r: Response) => void = () => {};
+    const pending = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    fetchSpy.mockReturnValueOnce(pending);
+
+    const p1 = getJwt();
+    const p2 = getJwt();
+    const p3 = getJwt();
+
+    resolveFetch(tokenAuthOk("ONLY-JWT", "ONLY-REF"));
+
+    const [j1, j2, j3] = await Promise.all([p1, p2, p3]);
+    expect(j1).toBe("ONLY-JWT");
+    expect(j2).toBe("ONLY-JWT");
+    expect(j3).toBe("ONLY-JWT");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when env vars are missing", async () => {
+    delete process.env.SSI_SERVICE_EMAIL;
+    await expect(getJwt()).rejects.toThrow(/SSI_SERVICE_EMAIL/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("propagates token_auth rejection (e.g. invalid_credentials)", async () => {
+    fetchSpy.mockResolvedValueOnce(tokenAuthFail());
+
+    await expect(getJwt()).rejects.toThrow(/token_auth rejected/);
+  });
+
+  it("survives cache-read failure (treats it as a miss)", async () => {
+    cacheMock.get.mockRejectedValueOnce(new Error("redis is down"));
+    fetchSpy.mockResolvedValueOnce(tokenAuthOk("RECOVERED-JWT", "RECOVERED-REF"));
+
+    const jwt = await getJwt();
+    expect(jwt).toBe("RECOVERED-JWT");
+  });
+});

--- a/tests/unit/ssi-auth.test.ts
+++ b/tests/unit/ssi-auth.test.ts
@@ -226,6 +226,18 @@ describe("ssi-auth getJwt", () => {
     await expect(getJwt()).rejects.toThrow(/token_auth rejected/);
   });
 
+  it("short-circuits to a placeholder JWT when API key is the e2e sentinel", async () => {
+    process.env.SSI_API_KEY = "dummy_key_for_e2e";
+    delete process.env.SSI_SERVICE_EMAIL;
+    delete process.env.SSI_SERVICE_PASSWORD;
+
+    const jwt = await getJwt();
+
+    expect(jwt).toBe("e2e-placeholder-jwt");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(cacheMock.get).not.toHaveBeenCalled();
+  });
+
   it("survives cache-read failure (treats it as a miss)", async () => {
     cacheMock.get.mockRejectedValueOnce(new Error("redis is down"));
     fetchSpy.mockResolvedValueOnce(tokenAuthOk("RECOVERED-JWT", "RECOVERED-REF"));

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,10 +4,14 @@
 #
 # Secrets must be set via wrangler CLI, NOT committed here:
 #   Production:  wrangler secret put SSI_API_KEY
+#                wrangler secret put SSI_SERVICE_EMAIL          # bot account login (lib/ssi-auth.ts)
+#                wrangler secret put SSI_SERVICE_PASSWORD       # bot account password
 #                wrangler secret put UPSTASH_REDIS_REST_URL
 #                wrangler secret put UPSTASH_REDIS_REST_TOKEN
 #                wrangler secret put CACHE_PURGE_SECRET
 #   Staging:     wrangler secret put SSI_API_KEY --env staging
+#                wrangler secret put SSI_SERVICE_EMAIL --env staging
+#                wrangler secret put SSI_SERVICE_PASSWORD --env staging
 #                wrangler secret put UPSTASH_REDIS_REST_URL --env staging
 #                wrangler secret put UPSTASH_REDIS_REST_TOKEN --env staging
 #                wrangler secret put CACHE_PURGE_SECRET --env staging


### PR DESCRIPTION
## Summary

- Production has been dark for upstream-dependent features since SSI tightened auth: every GraphQL resolver now returns `"User must be authenticated"` because the API-key-only path is no longer accepted. Per the [updated SSI docs](https://shootnscoreit.com/about-the-api/), every request needs both `x-api-key` AND `Authorization: JWT <token>`, with the JWT obtained via `token_auth(email, password)` and refreshed via `refresh_token`.
- New `lib/ssi-auth.ts` owns the JWT lifecycle: cold-start login, `refresh_token` thereafter, single-flight per isolate, Redis-shared 30-min cache (`ssi:jwt:v1`) so all isolates share one token, fall back to full login when `refresh_token` fails or is within 24h of its 7-day expiry, and a force-refresh API for retry-on-expired.
- `lib/graphql.ts` now sends the JWT alongside the API key and auto-refreshes + retries once when SSI rejects with a known JWT-expiry pattern.

## Behaviour after this PR

- Cold isolate: 1x `token_auth` mutation, then ~30 min of cached JWT before next mint
- Concurrent burst at cold start: deduped to one `token_auth` via per-isolate single-flight
- Cached JWT goes stale: silent re-mint via `refresh_token` (cheaper than full login)
- Refresh token expires/revoked: falls back to `token_auth(email, password)` automatically
- SSI rejects a request as JWT-expired mid-flight: force-refresh + single retry, transparent to callers

## Required env vars (new)

| Var | Purpose |
|---|---|
| `SSI_SERVICE_EMAIL` | Dedicated bot account email for `token_auth` |
| `SSI_SERVICE_PASSWORD` | Bot account password |

`SSI_API_KEY` is still required (sent as `x-api-key`).

**Deploy steps after merge:**

```bash
pnpm exec wrangler secret put SSI_SERVICE_EMAIL --env staging
pnpm exec wrangler secret put SSI_SERVICE_PASSWORD --env staging
pnpm exec wrangler secret put SSI_API_KEY --env staging   # rotated bot key
# then prod (no --env):
pnpm exec wrangler secret put SSI_SERVICE_EMAIL
pnpm exec wrangler secret put SSI_SERVICE_PASSWORD
pnpm exec wrangler secret put SSI_API_KEY
```

## Test plan

- [x] Unit: 9 new tests in `tests/unit/ssi-auth.test.ts` cover cold start, cache hit, force-refresh-via-refresh-token, fallback-to-login when refresh fails, near-expiry skip-to-login, single-flight, missing env, propagated rejection, cache-failure recovery
- [x] Unit: `tests/unit/refresh-cached-{query,match-query}.test.ts` mock `@/lib/ssi-auth` so existing fetch-stub tests continue to assert one upstream call
- [x] Full unit suite: `pnpm -w test` -> 1691/1691 pass
- [x] Lint clean: `pnpm -w run lint`
- [x] Typecheck clean: `pnpm -w run typecheck`
- [x] Live smoke test against real SSI through `pnpm dev`:
  - `GET /api/events?q=spsk` -> HTTP 200, 13 events
  - `GET /api/match/22/22157` -> HTTP 200, 147 competitors
  - Second `GET /api/events` reuses minted JWT (single-flight verified in dev log)
- [ ] Staging deploy + smoke test of `/api/events`, `/match/[ct]/[id]`, `/api/v1/events`, `/api/v1/shooter/{id}`
- [ ] Production deploy, watch upstream telemetry for `outcome=ok` returning to baseline
- [ ] Post-deploy: verify Redis hits the `ssi:jwt:v1` key and only ~1 `token_auth`/`refresh_token` call per ~30 min in upstream telemetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)