### PR TITLE
feat(deploy): guard against unbound Cloudflare secrets

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -42,6 +42,32 @@ jobs:
           echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "BUILD_DATE=$(date -u +%Y.%m.%d)" >> $GITHUB_ENV
 
+      - name: Verify required Cloudflare secrets are bound
+        # Catches the "added via dashboard as a plain-text Variable" trap:
+        # wrangler.toml's [vars] block is treated as the complete Variables
+        # list on each deploy, so any dashboard-added Variable gets clobbered.
+        # Secrets persist across deploys -- enforce that bot credentials live
+        # there. See PR-bug 2026-05-09 for the full story.
+        run: |
+          REQUIRED="SSI_API_KEY SSI_SERVICE_EMAIL SSI_SERVICE_PASSWORD UPSTASH_REDIS_REST_URL UPSTASH_REDIS_REST_TOKEN CACHE_PURGE_SECRET"
+          ACTUAL=$(npx wrangler secret list | jq -r '.[].name')
+          missing=""
+          for name in $REQUIRED; do
+            if ! echo "$ACTUAL" | grep -qx "$name"; then
+              missing="$missing $name"
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Missing Cloudflare Worker secrets:$missing"
+            echo "These must be set as Secrets (not Variables) so they survive deploys."
+            echo "Run for each missing name: pnpm exec wrangler secret put <NAME>"
+            exit 1
+          fi
+          echo "All required secrets bound."
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Apply D1 migrations (production)
         run: npx wrangler d1 migrations apply APP_DB --remote
         env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -56,6 +56,27 @@ jobs:
           echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "BUILD_DATE=$(date -u +%Y.%m.%d)" >> $GITHUB_ENV
 
+      - name: Verify required Cloudflare secrets are bound
+        # See deploy-cloudflare.yml for context (PR-bug 2026-05-09).
+        run: |
+          REQUIRED="SSI_API_KEY SSI_SERVICE_EMAIL SSI_SERVICE_PASSWORD UPSTASH_REDIS_REST_URL UPSTASH_REDIS_REST_TOKEN CACHE_PURGE_SECRET"
+          ACTUAL=$(npx wrangler secret list --env staging | jq -r '.[].name')
+          missing=""
+          for name in $REQUIRED; do
+            if ! echo "$ACTUAL" | grep -qx "$name"; then
+              missing="$missing $name"
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Missing Cloudflare Worker secrets (staging):$missing"
+            echo "Run for each missing name: pnpm exec wrangler secret put <NAME> --env staging"
+            exit 1
+          fi
+          echo "All required staging secrets bound."
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Apply D1 migrations (staging)
         run: npx wrangler d1 migrations apply APP_DB --env staging --remote
         env:

--- a/app/api/admin/cache/health/route.ts
+++ b/app/api/admin/cache/health/route.ts
@@ -31,6 +31,13 @@ export async function GET(req: Request) {
       : "MISSING",
     CACHE_PURGE_SECRET: secret ? "set" : "MISSING",
     SSI_API_KEY: process.env.SSI_API_KEY ? "set" : "MISSING",
+    // JWT auth (lib/ssi-auth.ts) -- without these the bot can't re-mint the
+    // cached JWT, and every match fetch will 404 once the cache (30 min) expires.
+    // See PR-bug from 2026-05-09: SSI_SERVICE_EMAIL was set as a dashboard
+    // "Variable" rather than a Secret, so each deploy clobbered it via
+    // wrangler.toml's [vars] block. Health-check guard catches this in CI.
+    SSI_SERVICE_EMAIL: process.env.SSI_SERVICE_EMAIL ? "set" : "MISSING",
+    SSI_SERVICE_PASSWORD: process.env.SSI_SERVICE_PASSWORD ? "set" : "MISSING",
   };
 
   // Live round-trip: write a probe key, read it back, then delete it.


### PR DESCRIPTION
## Summary

Pre-deploy step in `deploy-cloudflare.yml` and `deploy-staging.yml` that runs `wrangler secret list` and fails the workflow if any of:

- `SSI_API_KEY`
- `SSI_SERVICE_EMAIL`
- `SSI_SERVICE_PASSWORD`
- `UPSTASH_REDIS_REST_URL`
- `UPSTASH_REDIS_REST_TOKEN`
- `CACHE_PURGE_SECRET`

is missing.

## Why

Today's incident: `SSI_SERVICE_EMAIL` had been added via the Cloudflare dashboard as a plain-text **Variable** (not a Secret). `wrangler.toml`'s `[vars]` block is treated as the complete authoritative Variables list on each deploy, so it clobbered the dashboard entry. The cached JWT in Upstash Redis masked the missing env var for ~30 minutes per cache cycle; once `DELETE /api/admin/auth/jwt` forced a re-mint, `loginJwt` threw `SSI_SERVICE_EMAIL / SSI_SERVICE_PASSWORD not configured` and every match overview started returning 404.

The guard catches "secret missing" pre-deploy. It does not catch "secret bound but with the wrong value" -- but that's a different class of failure.

Also extends `/api/admin/cache/health` to report `SSI_SERVICE_EMAIL` / `SSI_SERVICE_PASSWORD` presence, so operators can spot-check runtime state when the CI guard is bypassed (dashboard-triggered deploys, etc.).

## Test plan

- [x] `pnpm -w run typecheck` -- clean
- [x] `pnpm -w run lint` -- clean
- [ ] Verify next staging deploy emits "All required staging secrets bound." in the workflow log
- [ ] Optional: temporarily delete a secret on staging, confirm the guard fails with a clear `::error::` message, then re-add it

🤖 Generated with [Claude Code](https://claude.com/claude-code)