### PR TITLE
fix(visibility): exclude non-public matches from popular-matches

### DIFF
--- a/app/api/popular-matches/route.ts
+++ b/app/api/popular-matches/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import db from "@/lib/db-impl";
 import { getMatchDataWithFallback } from "@/lib/match-data-store";
 import { maybeTagAsMcp } from "@/lib/telemetry-context";
+import { isPublicMatchData } from "@/lib/visibility";
 import type { PopularMatch } from "@/lib/types";
 
 /** Maximum age (seconds) a match access must be within to qualify. */
@@ -15,6 +16,8 @@ interface RawMatchEvent {
   venue?: string | null;
   starts?: string | null;
   scoring_completed?: string | number | null;
+  /** Raw SSI visibility code: "pub" | "lim" | "res" | "csd" | "clb". */
+  visibility?: string | null;
 }
 
 interface MatchCacheEntry {
@@ -54,6 +57,12 @@ export async function GET(req: Request) {
 
         const entry = JSON.parse(raw) as MatchCacheEntry;
         if (!entry.data?.event) continue;
+
+        // Visibility gate: never surface unlisted / organizer-published
+        // matches even if their popularity rows pre-date the write-time
+        // filter in lib/graphql.ts. See feedback memory
+        // `feedback_popular_matches_visibility.md`.
+        if (!isPublicMatchData(entry.data)) continue;
 
         // Key format: gql:GetMatch:{"ct":22,"id":"26547"}
         const vars = JSON.parse(key.slice("gql:GetMatch:".length)) as {

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -10,6 +10,7 @@ import { parseMatchCacheKey, persistActiveMatchToD1 } from "@/lib/match-data-sto
 import { markUpstreamDegraded } from "@/lib/upstream-status";
 import { upstreamTelemetry, hashVariables, type UpstreamOutcome } from "@/lib/upstream-telemetry";
 import { cacheTelemetry } from "@/lib/cache-telemetry";
+import { isPublicMatchData } from "@/lib/visibility";
 import { getJwt, JWT_EXPIRED_ERROR_PATTERNS } from "@/lib/ssi-auth";
 
 /**
@@ -862,7 +863,11 @@ export async function cachedExecuteQuery<T>(
       // Schema version gate: entries without a version or with an older version
       // are treated as misses. They will be overwritten on the next fetch.
       if (entry.v === CACHE_SCHEMA_VERSION) {
-        if (cacheKey.startsWith("gql:GetMatch:") && !(await isAdminRequest())) {
+        if (
+          cacheKey.startsWith("gql:GetMatch:") &&
+          !(await isAdminRequest()) &&
+          isPublicMatchData(entry.data)
+        ) {
           afterResponse(db.recordMatchAccess(cacheKey).catch(() => {}));
         }
         return { data: entry.data, cachedAt: entry.cachedAt };
@@ -880,7 +885,11 @@ export async function cachedExecuteQuery<T>(
       if (d1Raw) {
         const entry = JSON.parse(d1Raw) as CacheEntry<T>;
         if (entry.v === CACHE_SCHEMA_VERSION) {
-          if (cacheKey.startsWith("gql:GetMatch:") && !(await isAdminRequest())) {
+          if (
+            cacheKey.startsWith("gql:GetMatch:") &&
+            !(await isAdminRequest()) &&
+            isPublicMatchData(entry.data)
+          ) {
             afterResponse(db.recordMatchAccess(cacheKey).catch(() => {}));
           }
           return { data: entry.data, cachedAt: entry.cachedAt };
@@ -912,7 +921,13 @@ export async function cachedExecuteQuery<T>(
   }
 
   // Record access for popularity tracking (fire-and-forget, non-fatal).
-  if (cacheKey.startsWith("gql:GetMatch:") && !(await isAdminRequest())) {
+  // Skip non-public matches (unlisted / organizer-published) so they never
+  // surface on the popular-matches grid -- see lib/visibility.ts.
+  if (
+    cacheKey.startsWith("gql:GetMatch:") &&
+    !(await isAdminRequest()) &&
+    isPublicMatchData(data)
+  ) {
     void db.recordMatchAccess(cacheKey).catch(() => {});
   }
 

--- a/lib/visibility.ts
+++ b/lib/visibility.ts
@@ -29,3 +29,31 @@ export function classifyVisibility(rawCode: string | null | undefined): Visibili
   if (!rawCode) return "organizer-published";
   return CLASS_BY_RAW[rawCode] ?? "organizer-published";
 }
+
+/**
+ * True only if the given cached match data (raw GraphQL response or shaped
+ * MatchResponse) classifies as a fully public match. Used to keep
+ * non-public matches (unlisted / organizer-published) out of any "popular"
+ * or "trending" surface, matching the searchEvents publication boundary.
+ *
+ * Defensive on shape: missing or unrecognized visibility codes are treated
+ * as non-public via classifyVisibility's fallback. The data field can be
+ * either the raw event node (`{ visibility: "pub" }`) or the shaped
+ * MatchResponse (`{ visibility: { class: "public" } }`).
+ */
+export function isPublicMatchData(data: unknown): boolean {
+  if (!data || typeof data !== "object") return false;
+  const event = (data as { event?: unknown }).event;
+  if (event && typeof event === "object") {
+    const raw = (event as { visibility?: unknown }).visibility;
+    if (typeof raw === "string") {
+      return classifyVisibility(raw) === "public";
+    }
+  }
+  const shaped = (data as { visibility?: unknown }).visibility;
+  if (shaped && typeof shaped === "object") {
+    const cls = (shaped as { class?: unknown }).class;
+    return cls === "public";
+  }
+  return false;
+}

--- a/tests/unit/popular-matches-route.test.ts
+++ b/tests/unit/popular-matches-route.test.ts
@@ -1,0 +1,141 @@
+// Regression: /api/popular-matches must never expose non-public matches.
+//
+// SSI's visibility enum collapses into three classes (see lib/visibility.ts):
+// public ("pub"), unlisted ("lim"), organizer-published ("res"|"csd"|"clb").
+// Only "public" may surface here -- unlisted / organizer-published matches
+// are intentionally not advertised by the organizer, and the popular grid is
+// a discovery surface (used in the UI homepage and via the MCP
+// `get_popular_matches` tool). See feedback memory
+// `feedback_popular_matches_visibility.md` for the rationale.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => ({
+  getPopularKeys: vi.fn<
+    (maxAgeSeconds: number, limit: number) => Promise<{ key: string; hits: number }[]>
+  >(),
+}));
+const matchStoreMock = vi.hoisted(() => ({
+  getMatchDataWithFallback: vi.fn<(key: string) => Promise<string | null>>(),
+}));
+const tagMock = vi.hoisted(() => ({
+  maybeTagAsMcp: vi.fn(),
+}));
+
+vi.mock("@/lib/db-impl", () => ({ default: dbMock }));
+vi.mock("@/lib/match-data-store", () => matchStoreMock);
+vi.mock("@/lib/telemetry-context", () => tagMock);
+
+function cacheKey(ct: number, id: string): string {
+  return `gql:GetMatch:${JSON.stringify({ ct, id })}`;
+}
+
+function entry(opts: {
+  name: string;
+  visibility: string;
+  scoringCompleted?: number;
+}): string {
+  return JSON.stringify({
+    data: {
+      event: {
+        name: opts.name,
+        venue: "Test Range",
+        starts: "2026-05-01T08:00:00Z",
+        scoring_completed: opts.scoringCompleted ?? 100,
+        visibility: opts.visibility,
+      },
+    },
+    cachedAt: "2026-05-01T10:00:00Z",
+  });
+}
+
+beforeEach(() => {
+  dbMock.getPopularKeys.mockReset();
+  matchStoreMock.getMatchDataWithFallback.mockReset();
+  tagMock.maybeTagAsMcp.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe("GET /api/popular-matches -- visibility filter", () => {
+  it("includes matches with visibility=pub", async () => {
+    const { GET } = await import("@/app/api/popular-matches/route");
+    const k = cacheKey(22, "100");
+    dbMock.getPopularKeys.mockResolvedValue([{ key: k, hits: 10 }]);
+    matchStoreMock.getMatchDataWithFallback.mockImplementation(async (key) =>
+      key === k ? entry({ name: "Public Open", visibility: "pub" }) : null,
+    );
+
+    const res = await GET(new Request("http://x/api/popular-matches"));
+    const body = (await res.json()) as Array<{ id: string; name: string }>;
+
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({ id: "100", name: "Public Open" });
+  });
+
+  it.each([
+    ["lim", "Unlisted Cup"],
+    ["res", "Restricted Match"],
+    ["csd", "Closed Match"],
+    ["clb", "Club-Only Match"],
+  ])("excludes matches with visibility=%s", async (visibility, name) => {
+    const { GET } = await import("@/app/api/popular-matches/route");
+    const k = cacheKey(22, "200");
+    dbMock.getPopularKeys.mockResolvedValue([{ key: k, hits: 99 }]);
+    matchStoreMock.getMatchDataWithFallback.mockImplementation(async (key) =>
+      key === k ? entry({ name, visibility }) : null,
+    );
+
+    const res = await GET(new Request("http://x/api/popular-matches"));
+    const body = (await res.json()) as unknown[];
+
+    expect(body).toEqual([]);
+  });
+
+  it("excludes matches with missing visibility (defensive)", async () => {
+    // classifyVisibility() falls back to organizer-published on
+    // null/undefined/unknown codes, so missing visibility must be treated
+    // as non-public to avoid leaking a future SSI enum addition.
+    const { GET } = await import("@/app/api/popular-matches/route");
+    const k = cacheKey(22, "300");
+    dbMock.getPopularKeys.mockResolvedValue([{ key: k, hits: 5 }]);
+    const payload = JSON.stringify({
+      data: { event: { name: "Mystery", venue: null, starts: null, scoring_completed: 0 } },
+      cachedAt: "now",
+    });
+    matchStoreMock.getMatchDataWithFallback.mockResolvedValue(payload);
+
+    const res = await GET(new Request("http://x/api/popular-matches"));
+    const body = (await res.json()) as unknown[];
+
+    expect(body).toEqual([]);
+  });
+
+  it("filters a mixed batch -- keeps public, drops the rest", async () => {
+    const { GET } = await import("@/app/api/popular-matches/route");
+    const kPub = cacheKey(22, "1");
+    const kLim = cacheKey(22, "2");
+    const kRes = cacheKey(22, "3");
+    const kPub2 = cacheKey(22, "4");
+    dbMock.getPopularKeys.mockResolvedValue([
+      { key: kLim, hits: 100 },
+      { key: kPub, hits: 50 },
+      { key: kRes, hits: 30 },
+      { key: kPub2, hits: 10 },
+    ]);
+    matchStoreMock.getMatchDataWithFallback.mockImplementation(async (key) => {
+      if (key === kPub) return entry({ name: "Pub A", visibility: "pub" });
+      if (key === kLim) return entry({ name: "Lim", visibility: "lim" });
+      if (key === kRes) return entry({ name: "Res", visibility: "res" });
+      if (key === kPub2) return entry({ name: "Pub B", visibility: "pub" });
+      return null;
+    });
+
+    const res = await GET(new Request("http://x/api/popular-matches"));
+    const body = (await res.json()) as Array<{ id: string; name: string }>;
+
+    expect(body.map((m) => m.id)).toEqual(["1", "4"]);
+  });
+});

--- a/tests/unit/visibility.test.ts
+++ b/tests/unit/visibility.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { classifyVisibility } from "@/lib/visibility";
+import { classifyVisibility, isPublicMatchData } from "@/lib/visibility";
 
 describe("classifyVisibility", () => {
   it("maps pub -> public", () => {
@@ -27,5 +27,39 @@ describe("classifyVisibility", () => {
     expect(classifyVisibility(null)).toBe("organizer-published");
     expect(classifyVisibility(undefined)).toBe("organizer-published");
     expect(classifyVisibility("")).toBe("organizer-published");
+  });
+});
+
+describe("isPublicMatchData", () => {
+  it("accepts raw GraphQL shape with event.visibility=pub", () => {
+    expect(isPublicMatchData({ event: { visibility: "pub" } })).toBe(true);
+  });
+
+  it("accepts shaped MatchResponse with visibility.class=public", () => {
+    expect(isPublicMatchData({ visibility: { class: "public" } })).toBe(true);
+  });
+
+  it.each(["lim", "res", "csd", "clb", "xyz"])(
+    "rejects raw event.visibility=%s",
+    (code) => {
+      expect(isPublicMatchData({ event: { visibility: code } })).toBe(false);
+    },
+  );
+
+  it.each(["unlisted", "organizer-published"])(
+    "rejects shaped visibility.class=%s",
+    (cls) => {
+      expect(isPublicMatchData({ visibility: { class: cls } })).toBe(false);
+    },
+  );
+
+  it("rejects missing / malformed shapes (defensive)", () => {
+    expect(isPublicMatchData(null)).toBe(false);
+    expect(isPublicMatchData(undefined)).toBe(false);
+    expect(isPublicMatchData({})).toBe(false);
+    expect(isPublicMatchData({ event: {} })).toBe(false);
+    expect(isPublicMatchData({ event: null })).toBe(false);
+    expect(isPublicMatchData({ visibility: null })).toBe(false);
+    expect(isPublicMatchData("pub")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- `recordMatchAccess()` ran on every `GetMatch` cache hit/miss without checking visibility, so any organizer-published / unlisted match that anyone reached via a direct URL accrued popularity rows and surfaced on `/api/popular-matches` (and the MCP `get_popular_matches` tool).
- Adds defense in depth: write-time gate on all three `recordMatchAccess()` call sites in `lib/graphql.ts`, plus a read-time filter in the route handler so pre-existing rows don't leak (they age out via the existing 14-day `last_seen_at` window).
- New `isPublicMatchData()` helper in `lib/visibility.ts` -- defensive: missing/unknown codes default to non-public, matching `classifyVisibility`'s existing fallback for future-proof safety against new SSI enum codes.

## Test plan

- [x] `pnpm -w run typecheck` -- clean
- [x] `pnpm -w run lint` -- clean
- [x] `pnpm -w test` -- 1720 pass (24 in the touched files)
- [x] New `tests/unit/popular-matches-route.test.ts`: asserts `pub` is included; `lim` / `res` / `csd` / `clb` / missing visibility are all excluded; mixed batches filter correctly.
- [x] Extended `tests/unit/visibility.test.ts` with `isPublicMatchData` cases (raw GraphQL shape, shaped MatchResponse, malformed inputs).
- [ ] Spot-check `/api/popular-matches` in prod after deploy: confirm only `visibility: "pub"` matches appear; check telemetry for any drop in `match_popularity` write rate (expected -- non-public writes now skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)