### PR TITLE
feat(live): re-enable live scores via is_live_scores_accessible

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -73,7 +73,7 @@ export default function AboutPage() {
               <ul className="space-y-2 list-disc list-inside">
                 <li>
                   Search competitions by name, country, level, or date range,
-                  and see which matches are live right now
+                  and see which matches are scoring right now
                 </li>
                 <li>
                   Compare up to 12 competitors side-by-side across every stage,
@@ -96,7 +96,10 @@ export default function AboutPage() {
                 </li>
                 <li>
                   Live, Pre-match, and Coaching views — auto-selected to match
-                  the phase of the event, with a manual override
+                  the phase of the event, with a manual override. Live per-stage
+                  scores appear when the match organizer has enabled live
+                  publication on ShootNScoreIt; otherwise the page shows a
+                  &ldquo;Match in progress&rdquo; notice until scoring completes
                 </li>
               </ul>
             </div>

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -46,6 +46,7 @@ interface RawMatchData {
     scoring_completed?: string | number | null;
     status?: string | null;
     results?: string | null;
+    is_live_scores_accessible?: boolean | null;
     has_geopos?: boolean | null;
     lat?: number | string | null;
     lng?: number | string | null;
@@ -177,12 +178,16 @@ export async function GET(req: Request) {
     }
   }
 
-  // Short-circuit for live matches (#416 / PR-3): SSI does not publish
-  // per-stage scorecards while results visibility is "org". Skip the scorecards
-  // fetch entirely and return a minimal response with scorecardsRestricted=true.
-  // The live branch below is preserved so the route can be re-enabled by removing
-  // this guard if SSI reinstates live scorecard access.
-  if (!isComplete) {
+  // Short-circuit for live matches whose organizer has not enabled live
+  // scorecard access. SSI's `is_live_scores_accessible` is a per-requester
+  // permission flag — true when the bot can fetch per-stage scorecards
+  // (organizer flipped the "Resultat" setting to one of the public options
+  // OR our bot is invited as Staff). When false during an active match,
+  // return a minimal response with scorecardsRestricted=true so the UI shows
+  // the "Match in progress" empty state. Originally added in #416/PR-3 as
+  // an unconditional !isComplete guard; gated on the field in #432.
+  const isLiveScoresAccessible = matchData.event?.is_live_scores_accessible === true;
+  if (!isComplete && !isLiveScoresAccessible) {
     const payload: CompareResponse = {
       match_id: parseInt(id, 10),
       mode,
@@ -211,9 +216,12 @@ export async function GET(req: Request) {
   // Post-match: per-stage archival fan-out (#410). Permanent cache, no SWR
   // refresh needed (results are immutable once results=all).
   //
-  // Live: legacy whole-match path — kept as fallback if SSI reinstates live
-  // scorecard access. Currently unreachable because the short-circuit above
-  // returns early for all non-complete matches (#416).
+  // Live: legacy whole-match SCORECARDS_QUERY path. Reachable only when
+  // `is_live_scores_accessible` is true (organizer enabled live publication
+  // or our bot is Staff). Falls through to a 502 with SSI's
+  // "User must be authenticated" message if SSI rejects the fetch despite
+  // the flag — the next request will see the cached error and the SWR
+  // refresh will pick up any subsequent flag flip.
   const scorecardsKey = gqlCacheKey("GetMatchScorecards", { ct: ctNum, id });
   let scorecardsData: RawScorecardsData;
   let scorecardsCachedAt: string | null;

--- a/app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts
+++ b/app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts
@@ -89,11 +89,12 @@ export async function GET(
     resultsStatus: match.results_status,
   });
 
-  // Short-circuit for live matches (#416 / PR-3): SSI withholds per-stage
-  // scorecards while results visibility is "org". Return placeholder (all-null)
-  // stage entries immediately without touching SSI. Preserved live branch below
-  // can be re-enabled by removing this guard if SSI reinstates live access.
-  if (!isComplete) {
+  // Short-circuit for live matches whose organizer has not enabled live
+  // scorecard access (`is_live_scores_accessible=false`). Return placeholder
+  // (all-null) stage entries immediately without touching SSI. When the flag
+  // is true the legacy live branch below runs and surfaces real per-stage
+  // data. See compare/route.ts for the full rationale.
+  if (!isComplete && !match.is_live_scores_accessible) {
     const sortedMatchStages = [...match.stages].sort(
       (a, b) => a.stage_number - b.stage_number,
     );
@@ -140,9 +141,9 @@ export async function GET(
     }
     // Archive entries are permanent; no TTL upgrade or SWR refresh needed.
   } else {
-    // Live: legacy whole-match path — currently unreachable because the
-    // short-circuit above returns early for all non-complete matches (#416).
-    // Preserved as fallback if SSI reinstates live scorecard access.
+    // Live: legacy whole-match SCORECARDS_QUERY path. Reachable when
+    // `is_live_scores_accessible` is true (organizer-enabled live publication
+    // or bot-Staff bypass).
     try {
       ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
         await cachedExecuteQuery<RawScorecardsData>(

--- a/app/legal/page.tsx
+++ b/app/legal/page.tsx
@@ -84,9 +84,11 @@ export default function LegalPage() {
               <h3 className="font-medium">5. Disclaimer of warranties</h3>
               <p className="text-muted-foreground">
                 SSI Scoreboard is provided &quot;as is&quot; without warranties of any
-                kind. Match data is fetched in real time and may be incomplete,
-                delayed, or inaccurate. Do not use this application for
-                official scoring or results disputes.
+                kind. Match data is fetched from ShootNScoreIt and cached for
+                short periods; live per-stage data is only available for
+                matches whose organizer has enabled live publication. Anything
+                shown here may be incomplete, delayed, or inaccurate. Do not
+                use this application for official scoring or results disputes.
               </p>
             </div>
           </div>

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -235,12 +235,18 @@ export default function MatchPageClient() {
       })
     : false;
 
-  // Compare query: only fires for completed matches (coaching mode). Live
-  // matches return empty scorecards from SSI (#410), so there is nothing to
-  // render -- the "Match in progress" empty-state is shown instead. Pre-match
-  // is skipped for the same reason (no scores yet).
+  // Compare query: fires for completed matches (coaching mode) and for live
+  // matches whose organizer has enabled live scorecard access (or where our
+  // bot has Staff bypass) — gated on `is_live_scores_accessible`. When that
+  // flag is false during a live match, SSI returns empty scorecards (#410)
+  // and we render the "Match in progress" empty state instead. Pre-match is
+  // always skipped (no scores yet by definition).
+  const liveScoresAccessible =
+    matchQuery.data?.is_live_scores_accessible === true;
   const compareMode: CompareMode = effectiveMode === "coaching" ? "coaching" : "live";
-  const compareEnabled = effectiveMode === "coaching";
+  const compareEnabled =
+    effectiveMode === "coaching" ||
+    (effectiveMode === "live" && liveScoresAccessible);
   const compareQuery = useCompareQuery(
     ct,
     id,
@@ -646,7 +652,7 @@ export default function MatchPageClient() {
               </PopoverHeader>
               <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
                 <p><strong>Pre-match</strong> — squad rotation, weather, registered field, and AI brief. Useful when your squad hasn&apos;t shot yet, even if early squads have finished.</p>
-                <p><strong>Live</strong> — for active matches. SSI does not publish per-stage scorecards while scoring is in progress, so detailed results are not available until the match completes.</p>
+                <p><strong>Live</strong> — for active matches. Per-stage scores appear when the match organizer has enabled live publication on SSI; otherwise the page shows a &ldquo;Match in progress&rdquo; notice until scoring completes.</p>
                 <p><strong>Coaching</strong> — for completed matches. Full analysis: style fingerprints, archetype breakdown, course-length splits, constraint performance, and the stage simulator.</p>
                 <p>The view is auto-detected: pre-match before scoring really gets going, live once scoring is underway, and coaching for ≥ 95% scored or matches older than 3 days. Tap any mode to override, or tap the active mode to reset to auto.</p>
               </div>
@@ -657,7 +663,9 @@ export default function MatchPageClient() {
           {effectiveMode === "prematch"
             ? "Squad rotation, weather, and registered field. No scores shown."
             : effectiveMode === "live"
-            ? "Scoring in progress -- detailed results available when the match is complete."
+            ? liveScoresAccessible
+              ? "Live scores published by the organizer. Coaching analysis unlocks once the match is complete."
+              : "Scoring in progress. Detailed results unlock when the organizer publishes live scores or when the match completes."
             : "Full analysis with style fingerprints, breakdowns, and simulator."}
         </p>
       </div>
@@ -791,19 +799,23 @@ export default function MatchPageClient() {
         />
       )}
 
-      {/* Match in progress -- scorecards are not published by SSI until scoring completes */}
-      {effectiveMode === "live" && (
+      {/* Match in progress -- shown when SSI/organizer has not enabled live
+          scorecard access for this match. When the organizer flips "Resultat"
+          to a public option (or our bot has Staff bypass), the comparison
+          renders below in live mode instead. */}
+      {effectiveMode === "live" && !match.is_live_scores_accessible && (
         <div
           role="status"
           className="rounded-lg border bg-muted/40 p-4 space-y-2"
         >
           <h2 className="font-semibold">Match in progress</h2>
           <p className="text-sm text-muted-foreground">
-            Detailed stage results and analysis are available once scoring is complete
+            The organizer has not made live scores public for this match.
+            Detailed stage results will be available once scoring is complete
             {match.scoring_completed > 0
               ? ` (${Math.round(match.scoring_completed)}% scored so far)`
               : ""}
-            . Check back when the match is done.
+            .
           </p>
           {match.ssi_url && (
             <p className="text-sm">
@@ -822,9 +834,22 @@ export default function MatchPageClient() {
         </div>
       )}
 
-      {/* Comparison views -- only rendered for completed matches (coaching mode) */}
-      {effectiveMode === "coaching" && selectedIds.length > 0 && (
+      {/* Comparison views — rendered for completed matches (coaching mode)
+          and for live matches whose organizer has enabled live scorecard access. */}
+      {(effectiveMode === "coaching" ||
+        (effectiveMode === "live" && match.is_live_scores_accessible)) &&
+        selectedIds.length > 0 && (
         <div className="space-y-6">
+          {effectiveMode === "live" &&
+            match.is_live_scores_accessible &&
+            match.results_status !== "all" && (
+              <div
+                role="status"
+                className="rounded-md border border-dashed bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+              >
+                Live scores published by the organizer. Final standings appear once the match completes.
+              </div>
+            )}
           {compareQuery.isLoading && (
             <div className="rounded-lg border p-4 space-y-3">
               <Skeleton className="h-5 w-28" />

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -43,5 +43,10 @@ export const MAX_COMPETITORS = 12;
  *  16 → added visibility, get_visibility_display to IpscMatchNode in
  *       MATCH_QUERY; `visibility: { class, rawCode, displayName }` on
  *       MatchResponse (issue #426 — organizer-published private matches).
+ *  17 → added is_live_scores_accessible to IpscMatchNode in MATCH_QUERY and
+ *       MATCH_UPDATED_PROBE_QUERY; `is_live_scores_accessible: boolean` on
+ *       MatchResponse. Drives the live scorecards short-circuit so matches
+ *       whose organizer enables the SSI "Resultat" setting (or where our
+ *       bot has Staff bypass) once again surface live per-stage data.
  */
-export const CACHE_SCHEMA_VERSION = 16;
+export const CACHE_SCHEMA_VERSION = 17;

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -243,6 +243,7 @@ export const MATCH_QUERY = `
         scoring_completed
         visibility
         get_visibility_display
+        is_live_scores_accessible
         region
         sub_rule
         get_full_rule_display
@@ -334,6 +335,7 @@ export const MATCH_UPDATED_PROBE_QUERY = `
       results
       ... on IpscMatchNode {
         updated
+        is_live_scores_accessible
       }
     }
   }
@@ -344,6 +346,7 @@ interface MatchUpdatedProbeData {
     updated?: string | null;
     status?: string | null;
     results?: string | null;
+    is_live_scores_accessible?: boolean | null;
   } | null;
 }
 
@@ -358,10 +361,16 @@ interface ProbeState {
   updated: string | null;
   status: string | null;
   results: string | null;
+  isLiveScoresAccessible: boolean | null;
 }
 
 function probesEqual(a: ProbeState, b: ProbeState): boolean {
-  return a.updated === b.updated && a.status === b.status && a.results === b.results;
+  return (
+    a.updated === b.updated &&
+    a.status === b.status &&
+    a.results === b.results &&
+    a.isLiveScoresAccessible === b.isLiveScoresAccessible
+  );
 }
 
 /** Kill switch: when set to "off", the probe-aware refresh degrades to the
@@ -557,6 +566,7 @@ export async function refreshCachedMatchQuery<T>(
       updated: ev.updated ?? null,
       status: ev.status ?? null,
       results: ev.results ?? null,
+      isLiveScoresAccessible: ev.is_live_scores_accessible ?? null,
     };
     upstreamUpdatedIso = currentState.updated;
     prevUpstreamUpdatedIso = prevState?.updated ?? null;

--- a/lib/match-data.ts
+++ b/lib/match-data.ts
@@ -113,6 +113,8 @@ export interface RawMatchData {
     visibility?: string | null;
     /** SSI's human-readable visibility label, e.g. "Public, searchable and details/names for all". */
     get_visibility_display?: string | null;
+    /** Per-requester permission for live scorecards. Added in cache schema v17. */
+    is_live_scores_accessible?: boolean | null;
     region?: string | null;
     sub_rule?: string | null;
     get_full_rule_display?: string | null;
@@ -393,6 +395,7 @@ export async function fetchMatchData(
     is_squadding_possible: ev.is_squadding_possible ?? false,
     ssi_url: `https://shootnscoreit.com/event/${ct}/${id}/`,
     visibility,
+    is_live_scores_accessible: ev.is_live_scores_accessible ?? false,
     stages,
     competitors,
     squads,

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -11,11 +11,33 @@ import type { Release } from "@/lib/types";
  * differs from the value stored in localStorage("whats-new-seen-id").
  */
 /** The `id` of the newest release. Used by e2e tests to suppress the What's New dialog. */
-export const LATEST_RELEASE_ID = "2026-05-04-post-match-only";
+export const LATEST_RELEASE_ID = "2026-05-10-organizer-live-scores";
 
 export const RELEASES: Release[] = [
   {
     id: LATEST_RELEASE_ID,
+    date: "May 10, 2026",
+    title: "Live scores are back -- when the organizer says so",
+    screenshotScenes: ["comparison-table"],
+    sections: [
+      {
+        heading: "What changed",
+        items: [
+          "Live per-stage scores are available again for matches whose organizer has enabled live publication on ShootNScoreIt (the \"Resultat\" setting in the SSI match admin). The comparison table, hit-factor chart, and stage breakdowns refresh every 30 seconds while you watch.",
+          "Matches whose organizer has not enabled live publication still show the \"Match in progress\" notice with current scoring percentage -- once scoring completes, full analysis appears as before.",
+          "Coaching analysis (style fingerprint, archetype, simulator) still unlocks only after the match is complete. Live mode shows the lighter table + chart view.",
+        ],
+      },
+      {
+        heading: "Organizers",
+        items: [
+          "If you run a match and want to share live scores, set Resultat to \"Resultat och poäng visas för alla\" (or \"...endast för arrangörer, men poäng visas för alla\") in the SSI match admin.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "2026-05-04-post-match-only",
     date: "May 4, 2026",
     title: "Post-match analysis, reimagined",
     screenshotScenes: ["comparison-table"],
@@ -23,8 +45,8 @@ export const RELEASES: Release[] = [
       {
         heading: "What changed",
         items: [
-          "ShootNScoreIt stopped publishing per-stage scorecards for active matches. Stage results, hit zones, and coaching analysis are now only available once scoring is complete.",
-          "While a match is in progress, the app shows a notice with the current scoring percentage and a link to follow live on ShootNScoreIt.",
+          "ShootNScoreIt changed how per-stage scorecards are exposed during active matches. Stage results, hit zones, and coaching analysis are now gated on a per-match \"Resultat\" setting that the organizer controls (see the May 10 release for the full reopening).",
+          "While a match is in progress without that setting enabled, the app shows a notice with the current scoring percentage and a link to follow live on ShootNScoreIt.",
           "For completed matches, nothing changes -- all analysis is still there and loads faster thanks to a new per-stage archival cache that replaces the old whole-match query.",
         ],
       },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -106,6 +106,13 @@ export interface MatchResponse {
   match_status: string;
   /** SSI results visibility: "org" organizers-only | "stg" scores-public | "cmp" participants-only | "all" publicly published */
   results_status: string;
+  /** SSI's per-requester permission flag for live scorecards. True when our
+   *  bot can fetch per-stage scorecard data while the match is active —
+   *  driven by the organizer's `results` setting AND the bot's role on the
+   *  match. Used as the short-circuit gate in compare/route.ts and
+   *  stages/route.ts: when false during an active match we render the
+   *  "Match in progress" empty state instead of attempting the fetch. */
+  is_live_scores_accessible: boolean;
   /** Registration status code: "op" open | "cl" closed | "ax" auto-approve on payment | "ox" waiting list + auto-approve | etc. */
   registration_status: string;
   /** When registration opens (ISO timestamp); null if not set. */

--- a/scripts/check-ssi-schema.ts
+++ b/scripts/check-ssi-schema.ts
@@ -67,14 +67,43 @@ function typeRef(t: RawType): string {
   return t.name ?? t.kind;
 }
 
-async function introspectType(typeName: string, endpoint: string, token: string): Promise<FieldEntry[]> {
+// SSI requires JWT on every resolver as of #425, including __type. Acquire a
+// short-lived JWT via the token_auth mutation; same flow as lib/ssi-auth.ts
+// but standalone (no Redis) since this is a CLI script.
+async function loginForJwt(endpoint: string, apiKey: string, email: string, password: string): Promise<string> {
+  const query = "mutation Login($email: String!, $pwd: String!) { token_auth(email: $email, password: $pwd) { success errors token { token } } }";
+  const r = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": apiKey },
+    body: JSON.stringify({ query, variables: { email, pwd: password } }),
+  });
+  if (!r.ok) throw new Error(`token_auth HTTP ${r.status}`);
+  const json = (await r.json()) as {
+    data?: { token_auth?: { success?: boolean; errors?: unknown; token?: { token?: string } | null } | null };
+    errors?: { message: string }[];
+  };
+  if (json.errors?.length) throw new Error(`token_auth GraphQL error: ${json.errors.map((e) => e.message).join("; ")}`);
+  const tok = json.data?.token_auth?.token?.token;
+  if (!tok) throw new Error(`token_auth rejected: ${JSON.stringify(json.data?.token_auth?.errors ?? "unknown")}`);
+  return tok;
+}
+
+async function introspectType(typeName: string, endpoint: string, apiKey: string, jwt: string): Promise<FieldEntry[]> {
   // Five levels of `ofType` lets us name types like `[ChronoCardNode!]!`
   // (NON_NULL → LIST → NON_NULL → ChronoCardNode), which the previous
   // three-level walk reduced to the placeholder `[NON_NULL]!`.
-  const query = `{ __type(name: "${typeName}") { fields { name type { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind } } } } } args { name type { name kind ofType { name kind ofType { name kind ofType { name kind } } } } } } } }`;
+  //
+  // `includeDeprecated: true` is critical: SSI hides deprecated fields from
+  // default introspection (e.g. `IpscMatchNode.scoring_completed` is marked
+  // deprecated as of 2026-05 with reason "Always returns 0. Use
+  // scoring_progress / squad_scoring_progress on stages instead."). Without
+  // this flag, deprecated-but-still-resolvable fields show up as removed and
+  // produce false-positive drift reports for queries that still reference
+  // them legitimately.
+  const query = `{ __type(name: "${typeName}") { fields(includeDeprecated: true) { name isDeprecated deprecationReason type { name kind ofType { name kind ofType { name kind ofType { name kind ofType { name kind } } } } } args { name type { name kind ofType { name kind ofType { name kind ofType { name kind } } } } } } } }`;
   const r = await fetch(endpoint, {
     method: "POST",
-    headers: { "Content-Type": "application/json", Authorization: `Token ${token}`, "x-api-key": token },
+    headers: { "Content-Type": "application/json", Authorization: `JWT ${jwt}`, "x-api-key": apiKey },
     body: JSON.stringify({ query }),
   });
   if (!r.ok) throw new Error(`SSI HTTP ${r.status}`);
@@ -125,17 +154,23 @@ function saveSnapshot(s: Snapshot): void {
 
 async function main() {
   const apiKey = process.env.SSI_API_KEY;
-  if (!apiKey) {
-    console.error("[check-ssi-schema] SSI_API_KEY not set");
+  const email = process.env.SSI_SERVICE_EMAIL;
+  const password = process.env.SSI_SERVICE_PASSWORD;
+  if (!apiKey || !email || !password) {
+    console.error(
+      "[check-ssi-schema] SSI_API_KEY, SSI_SERVICE_EMAIL, and SSI_SERVICE_PASSWORD must be set. " +
+        "Schema introspection requires JWT auth (see #425).",
+    );
     process.exit(2);
   }
   const endpoint = "https://shootnscoreit.com/graphql/";
   const update = process.argv.includes("--update");
   const jsonMode = process.argv.includes("--json");
 
+  const jwt = await loginForJwt(endpoint, apiKey, email, password);
   const live: Snapshot = {};
   for (const t of TRACKED_TYPES) {
-    live[t] = await introspectType(t, endpoint, apiKey);
+    live[t] = await introspectType(t, endpoint, apiKey, jwt);
   }
 
   const previous = loadSnapshot();

--- a/scripts/release-mock-data.ts
+++ b/scripts/release-mock-data.ts
@@ -30,6 +30,7 @@ export const MOCK_MATCH: MatchResponse = {
   scoring_completed: 100,
   match_status: "cp",
   results_status: "all",
+  is_live_scores_accessible: true,
   registration_status: "cl",
   registration_starts: null,
   registration_closes: null,

--- a/scripts/ssi-schema-snapshot.json
+++ b/scripts/ssi-schema-snapshot.json
@@ -25,8 +25,54 @@
       ]
     },
     {
+      "name": "chronocard",
+      "type": "ChronoCardInterface!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
       "name": "competitor",
       "type": "CompetitorInterface!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "competitor_scorecards",
+      "type": "[ScoreCardInterface!]!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
+        },
+        {
+          "name": "updated_after",
+          "type": "String!"
+        }
+      ]
+    },
+    {
+      "name": "competitor_scorecards_count",
+      "type": "Int!",
       "args": [
         {
           "name": "content_type",
@@ -274,6 +320,20 @@
         {
           "name": "tg_id",
           "type": "Int!"
+        }
+      ]
+    },
+    {
+      "name": "get_history_versions",
+      "type": "[VersionNode!]!",
+      "args": [
+        {
+          "name": "content_type",
+          "type": "Int!"
+        },
+        {
+          "name": "id",
+          "type": "String!"
         }
       ]
     },

--- a/tests/components/match-header.test.tsx
+++ b/tests/components/match-header.test.tsx
@@ -19,6 +19,7 @@ const baseMatch: MatchResponse = {
   scoring_completed: 56,
   match_status: "on",
   results_status: "org",
+  is_live_scores_accessible: false,
   registration_status: "cl",
   registration_starts: null,
   registration_closes: null,

--- a/tests/e2e/drawer-collapsible-toggle.spec.ts
+++ b/tests/e2e/drawer-collapsible-toggle.spec.ts
@@ -20,6 +20,7 @@ const MOCK_MATCH: MatchResponse = {
   scoring_completed: 100,
   match_status: "cp",
   results_status: "org",
+  is_live_scores_accessible: false,
   registration_status: "cl",
   registration_starts: null,
   registration_closes: null,

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -18,6 +18,7 @@ const MOCK_MATCH: MatchResponse = {
   scoring_completed: 75,
   match_status: "on",
   results_status: "org",
+  is_live_scores_accessible: false,
   registration_status: "cl",
   registration_starts: null,
   registration_closes: null,

--- a/tests/unit/__snapshots__/api-v1-routes.test.ts.snap
+++ b/tests/unit/__snapshots__/api-v1-routes.test.ts.snap
@@ -77,6 +77,7 @@ exports[`/api/v1/match/[ct]/[id] > returns the match payload through the v1 enve
   "date": "2026-04-26T00:00:00",
   "discipline": "IPSC Handgun",
   "ends": "2026-04-27T00:00:00",
+  "is_live_scores_accessible": true,
   "is_registration_possible": false,
   "is_squadding_possible": false,
   "lat": 59.3293,

--- a/tests/unit/api-v1-routes.test.ts
+++ b/tests/unit/api-v1-routes.test.ts
@@ -152,6 +152,7 @@ describe("/api/v1/match/[ct]/[id]", () => {
       scoring_completed: 100,
       match_status: "cp",
       results_status: "all",
+      is_live_scores_accessible: true,
       registration_status: "cl",
       registration_starts: null,
       registration_closes: null,

--- a/tests/unit/refresh-cached-match-query.test.ts
+++ b/tests/unit/refresh-cached-match-query.test.ts
@@ -52,7 +52,16 @@ const VARS = { ct: 22, id: "26547" };
 const MATCH = { ct: 22, id: "26547" };
 const SIDECAR = "probe:match-state:22:26547";
 
-function probeResponse(body: { updated?: string | null; status?: string | null; results?: string | null } | null) {
+function probeResponse(
+  body:
+    | {
+        updated?: string | null;
+        status?: string | null;
+        results?: string | null;
+        is_live_scores_accessible?: boolean | null;
+      }
+    | null,
+) {
   return new Response(JSON.stringify({ data: { event: body } }), {
     status: 200,
     headers: { "content-type": "application/json" },
@@ -97,7 +106,7 @@ describe("refreshCachedMatchQuery — probe-aware refresh", () => {
     const freshCachedAt = new Date(Date.now() - 5_000).toISOString(); // 5s ago
     cacheMock.get.mockImplementation(async (k) => {
       if (k === SIDECAR) {
-        return JSON.stringify({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org" });
+        return JSON.stringify({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org", isLiveScoresAccessible: false });
       }
       if (k === KEY) {
         return JSON.stringify({ data: {}, cachedAt: freshCachedAt, v: 1 });
@@ -105,7 +114,7 @@ describe("refreshCachedMatchQuery — probe-aware refresh", () => {
       return null;
     });
     fetchSpy.mockResolvedValue(
-      probeResponse({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org" }),
+      probeResponse({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org", is_live_scores_accessible: false }),
     );
 
     await refreshCachedMatchQuery(KEY, QUERY, VARS, 90, MATCH);
@@ -121,7 +130,7 @@ describe("refreshCachedMatchQuery — probe-aware refresh", () => {
     const staleCachedAt = new Date(Date.now() - 10 * 60_000).toISOString(); // 10 min ago
     cacheMock.get.mockImplementation(async (k) => {
       if (k === SIDECAR) {
-        return JSON.stringify({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org" });
+        return JSON.stringify({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org", isLiveScoresAccessible: false });
       }
       if (k === KEY) {
         return JSON.stringify({ data: {}, cachedAt: staleCachedAt, v: 1 });
@@ -131,7 +140,7 @@ describe("refreshCachedMatchQuery — probe-aware refresh", () => {
     // Probe says nothing changed, but the cached entry is older than the
     // 5-minute safety ceiling — we must refetch anyway.
     fetchSpy
-      .mockResolvedValueOnce(probeResponse({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org" }))
+      .mockResolvedValueOnce(probeResponse({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org", is_live_scores_accessible: false }))
       .mockResolvedValueOnce(fullResponse());
 
     await refreshCachedMatchQuery(KEY, QUERY, VARS, 90, MATCH);
@@ -163,12 +172,12 @@ describe("refreshCachedMatchQuery — probe-aware refresh", () => {
     const { refreshCachedMatchQuery } = await import("@/lib/graphql");
     cacheMock.get.mockImplementation(async (k) => {
       if (k === SIDECAR) {
-        return JSON.stringify({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org" });
+        return JSON.stringify({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org", isLiveScoresAccessible: false });
       }
       return null;
     });
     fetchSpy
-      .mockResolvedValueOnce(probeResponse({ updated: "2026-04-28T10:05:00Z", status: "on", results: "org" }))
+      .mockResolvedValueOnce(probeResponse({ updated: "2026-04-28T10:05:00Z", status: "on", results: "org", is_live_scores_accessible: false }))
       .mockResolvedValueOnce(fullResponse());
 
     await refreshCachedMatchQuery(KEY, QUERY, VARS, 90, MATCH);
@@ -187,7 +196,7 @@ describe("refreshCachedMatchQuery — probe-aware refresh", () => {
     const { refreshCachedMatchQuery } = await import("@/lib/graphql");
     cacheMock.get.mockResolvedValue(null);
     fetchSpy
-      .mockResolvedValueOnce(probeResponse({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org" }))
+      .mockResolvedValueOnce(probeResponse({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org", is_live_scores_accessible: false }))
       .mockResolvedValueOnce(fullResponse());
 
     await refreshCachedMatchQuery(KEY, QUERY, VARS, 90, MATCH);
@@ -237,12 +246,12 @@ describe("refreshCachedMatchQuery — probe-aware refresh", () => {
     const { refreshCachedMatchQuery } = await import("@/lib/graphql");
     cacheMock.get.mockImplementation(async (k) => {
       if (k === SIDECAR) {
-        return JSON.stringify({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org" });
+        return JSON.stringify({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org", isLiveScoresAccessible: false });
       }
       return null;
     });
     fetchSpy.mockResolvedValue(
-      probeResponse({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org" }),
+      probeResponse({ updated: "2026-04-28T10:00:00Z", status: "on", results: "org", is_live_scores_accessible: false }),
     );
 
     await refreshCachedMatchQuery(KEY, QUERY, VARS, null, MATCH);


### PR DESCRIPTION
## Summary

- Live per-stage scorecards return for matches whose organizer enables a public option in SSI's "Resultat" setting (`stg`, `cmp`, `all`) -- or where our bot has Staff bypass on the match. Gated on `IpscMatchNode.is_live_scores_accessible` per request.
- Match page renders the live comparison (table + hit-factor + stage breakdowns, no coaching analytics) when accessible, with a "Live scores published by organizer" notice. Otherwise falls back to the "Match in progress" empty state.
- Copy refreshed across the about page, legal disclaimer, popovers, and a new release-notes entry. The earlier May 4 entry was softened to reflect that this was a per-organizer setting, not a flat outage.
- `CACHE_SCHEMA_VERSION` bumped 16 -> 17 so deployed isolates self-heal once.

### Tooling fix (bonus)

- `scripts/check-ssi-schema.ts` now uses JWT auth and `includeDeprecated: true`. SSI requires JWT on every resolver as of #425 (including `__type`), and Django-graphene hides deprecated fields by default. The previous Token-auth path produced false drift -- six "removed" fields that weren't actually gone.
- Surfaced finding worth a follow-up: `IpscMatchNode.scoring_completed` is officially deprecated with reason _"Always returns 0. Use scoring_progress / squad_scoring_progress on stages instead."_ -- which validates why `effectiveMatchScoringPct()` already falls back to per-stage values. Migration to `scoring_progress` is a future PR.
- New SSI fields visible after the JWT fix that we don't yet use: `RootQuery.competitor_scorecards`, `competitor_scorecards_count`, `chronocard`, `get_history_versions`. The first two may be SSI's blessed live-scorecards path (more efficient than the legacy whole-match `SCORECARDS_QUERY` we revived here). Worth investigating in a follow-up.

### Where the gate lives

- `app/api/compare/route.ts` -- `if (!isComplete && !is_live_scores_accessible)` short-circuits with `scorecardsRestricted: true`. When accessible, the legacy `SCORECARDS_QUERY` else-branch (preserved since #416) comes back to life.
- `app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts` -- mirror gate for per-competitor stage results.
- `app/match/[ct]/[id]/match-page-client.tsx` -- `compareEnabled` now includes `effectiveMode === "live" && match.is_live_scores_accessible`.

### Policy decision

When `results=org` but our bot has Staff bypass (`is_live_scores_accessible=true`), we expose the data publicly. Mirrors the precedent from #427 (organizer-published private matches): if the organizer invited the bot, that's their consent for our service to surface the data. The "Live scores published by organizer" notice signals this when `results !== "all"`.

### Validated against

Live probe of match 22/28223 (test match owned by repo author) confirmed `is_live_scores_accessible=true` despite `results=org` and `visibility=csd`, validating the per-requester semantics. Match has zero scorecards so the data path itself wasn't exercised end-to-end -- if SSI rejects `competitor_scorecards` despite the flag in the wild, the route returns the cached error and the next SWR cycle picks up any organizer toggle change (the probe state now includes this field, so flipping it triggers a fresh fetch).

### Routes intentionally NOT changed

`/coaching`, `/simulate`, `/data/match/.../results`, and `/og` stay gated on `isComplete` -- they are heavy/specialized analyses or the OG image, not the courtside-live use case.

## Test plan

- [x] `pnpm -w run lint` -- clean
- [x] `pnpm -w run typecheck` -- clean
- [x] `pnpm -w test` -- 1720 / 1720 pass (snapshot for v1 match overview updated; refresh-cached-match-query probe-state tests updated for the new ProbeState field)
- [x] `pnpm validate:ssi-queries` -- clean
- [x] `pnpm tsx scripts/check-ssi-schema.ts` -- no drift (snapshot regenerated under JWT introspection + `includeDeprecated: true`)
- [ ] Manual smoke: load a live match where `is_live_scores_accessible=true` and confirm comparison + chart render with the organizer-published notice
- [ ] Manual smoke: load a live match where it's `false` (default) and confirm "Match in progress" still renders with the new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)