### PR TITLE
chore(schema): flag deprecated SSI fields in validate-ssi-queries

### DIFF
--- a/scripts/check-ssi-schema.ts
+++ b/scripts/check-ssi-schema.ts
@@ -51,6 +51,9 @@ interface FieldEntry {
   name: string;
   type: string;
   args: FieldArg[];
+  /** Only persisted when SSI marks the field deprecated. Drives the
+   *  validate-ssi-queries deprecation check. */
+  deprecationReason?: string;
 }
 
 type Snapshot = Record<string, FieldEntry[]>;
@@ -107,14 +110,22 @@ async function introspectType(typeName: string, endpoint: string, apiKey: string
     body: JSON.stringify({ query }),
   });
   if (!r.ok) throw new Error(`SSI HTTP ${r.status}`);
-  const json = (await r.json()) as { data?: { __type?: { fields?: { name: string; type: RawType; args: { name: string; type: RawType }[] }[] | null } | null } };
+  const json = (await r.json()) as { data?: { __type?: { fields?: { name: string; isDeprecated?: boolean; deprecationReason?: string | null; type: RawType; args: { name: string; type: RawType }[] }[] | null } | null } };
   const fields = json.data?.__type?.fields ?? [];
   return fields
-    .map((f): FieldEntry => ({
-      name: f.name,
-      type: typeRef(f.type),
-      args: (f.args ?? []).map((a): FieldArg => ({ name: a.name, type: typeRef(a.type) })),
-    }))
+    .map((f): FieldEntry => {
+      const entry: FieldEntry = {
+        name: f.name,
+        type: typeRef(f.type),
+        args: (f.args ?? []).map((a): FieldArg => ({ name: a.name, type: typeRef(a.type) })),
+      };
+      if (f.isDeprecated) {
+        // Persist only the reason — the boolean is implicit in its presence.
+        // Keeps the snapshot diff small (only deprecated fields gain a key).
+        entry.deprecationReason = f.deprecationReason ?? "(no reason given)";
+      }
+      return entry;
+    })
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 

--- a/scripts/ssi-schema-snapshot.json
+++ b/scripts/ssi-schema-snapshot.json
@@ -1789,7 +1789,8 @@
     {
       "name": "scoring_completed",
       "type": "Decimal!",
-      "args": []
+      "args": [],
+      "deprecationReason": "Always returns 0. Use scoring_progress / squad_scoring_progress on stages instead."
     },
     {
       "name": "serie_type",
@@ -3116,7 +3117,8 @@
     {
       "name": "scoring_completed",
       "type": "Decimal!",
-      "args": []
+      "args": [],
+      "deprecationReason": "Always returns 0. Use scoring_progress / squad_scoring_progress on stages instead."
     },
     {
       "name": "serie_type",
@@ -3728,7 +3730,8 @@
     {
       "name": "scoring_completed",
       "type": "Decimal!",
-      "args": []
+      "args": [],
+      "deprecationReason": "Always returns 0. Use scoring_progress / squad_scoring_progress instead."
     },
     {
       "name": "scoring_progress",
@@ -3980,12 +3983,14 @@
     {
       "name": "get_scoring_history",
       "type": "[VersionNode!]!",
-      "args": []
+      "args": [],
+      "deprecationReason": "Use top-level `get_history_versions(content_type, id)` query instead."
     },
     {
       "name": "get_scoring_history_as_list",
       "type": "[String!]!",
-      "args": []
+      "args": [],
+      "deprecationReason": "Use top-level `get_history_versions(content_type, id)` query instead."
     },
     {
       "name": "hitfactor",
@@ -4802,7 +4807,8 @@
     {
       "name": "scoring_history",
       "type": "[VersionNode!]!",
-      "args": []
+      "args": [],
+      "deprecationReason": "Use top-level `get_history_versions(content_type, id)` query instead."
     },
     {
       "name": "scoring_progress",

--- a/scripts/validate-ssi-queries.ts
+++ b/scripts/validate-ssi-queries.ts
@@ -62,6 +62,9 @@ interface FieldEntry {
   name: string;
   type: string;
   args: FieldArg[];
+  /** Present only when SSI marks the field deprecated; the value is the
+   *  reason string from the upstream schema. */
+  deprecationReason?: string;
 }
 
 type Snapshot = Record<string, FieldEntry[]>;
@@ -150,6 +153,15 @@ function validateField(
         message: `field \`${fieldName}\` not found on type \`${parentType}\``,
       });
       return;
+    }
+
+    // Flag deprecated fields. SSI's deprecation reason often points at the
+    // replacement field, so surfacing it inline saves a trip to the docs.
+    if (entry.deprecationReason !== undefined) {
+      errors.push({
+        path: fieldPath.join("."),
+        message: `field \`${parentType}.${fieldName}\` is deprecated: ${entry.deprecationReason}`,
+      });
     }
 
     // Validate provided arguments exist on the field signature. We do not


### PR DESCRIPTION
## Summary

Permanent CI guard for the next time SSI deprecates a field we use.

- `scripts/check-ssi-schema.ts` now persists `deprecationReason` on every snapshot entry SSI marks deprecated. Only the reason string is stored (its presence implies the boolean), so the snapshot diff stays small — only the deprecated fields gain a key.
- `scripts/validate-ssi-queries.ts` turns any deprecated-field selection into a hard error, surfacing SSI's `deprecationReason` inline (which usually points at the replacement field, e.g. _"Always returns 0. Use scoring_progress / squad_scoring_progress on stages instead."_).

## Audit

Ran the new validator against `main` after refreshing the snapshot:

```
[validate-ssi-queries] OK — 5 queries valid against snapshot
```

The 6 deprecated fields visible in the snapshot:

- `EventInterface.scoring_completed`, `IpscMatchNode.scoring_completed`, `IpscStageNode.scoring_completed` — all deprecated with reason _"Always returns 0. Use scoring_progress / squad_scoring_progress instead."_ Already migrated in #432.
- `IpscScoreCardNode.get_scoring_history`, `IpscScoreCardNode.get_scoring_history_as_list`, `IpscCompetitorNode.scoring_history` — _"Use top-level `get_history_versions(content_type, id)` query instead."_ Never used in this codebase.

So nothing to fix in this PR. Pure plumbing — but next time SSI deprecates a field we depend on, CI fails and the reason string tells us where to look.

Sanity-check that the validator actually fires:

```js
// inject `scoring_completed` reference into a probe query → expected error:
{
  "path": "RootQuery.event.... on IpscMatchNode.scoring_completed",
  "message": "field `IpscMatchNode.scoring_completed` is deprecated:
              Always returns 0. Use scoring_progress / squad_scoring_progress
              on stages instead."
}
```

## Test plan

- [x] `pnpm -w run lint` — clean
- [x] `pnpm -w run typecheck` — clean
- [x] `pnpm -w test` — 1708 / 1708
- [x] `pnpm tsx scripts/check-ssi-schema.ts` — no drift
- [x] `pnpm validate:ssi-queries` — 0 deprecated-field hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)