### PR TITLE
chore(match-ttl): add isMatchCompleteFromRawEvent + co-locate computeMatchScoringPct

### DIFF
--- a/app/api/data/match/[ct]/[id]/results/route.ts
+++ b/app/api/data/match/[ct]/[id]/results/route.ts
@@ -9,8 +9,7 @@ import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data
 import { getMatchScorecards } from "@/lib/scorecards-archive";
 import { computeFullFieldRankings } from "@/app/api/compare/logic";
 import { decodeShooterId } from "@/lib/shooter-index";
-import { computeMatchScoringPct } from "@/lib/match-data";
-import { isMatchCompleteFromEvent } from "@/lib/match-ttl";
+import { computeMatchScoringPct, isMatchCompleteFromRawEvent } from "@/lib/match-ttl";
 
 interface RawMatchData {
   event: {
@@ -79,12 +78,7 @@ export async function GET(
   // during live (the per-competitor live path covers selected competitors
   // only). Match metadata is small and almost always cache-hit, so this is
   // a cheap pre-check that saves the heavy scorecards fetch on live calls.
-  const isComplete = isMatchCompleteFromEvent({
-    scoringPct: computeMatchScoringPct(matchData.event),
-    startDate: matchData.event.starts ?? null,
-    status: matchData.event.status,
-    resultsStatus: matchData.event.results,
-  });
+  const isComplete = isMatchCompleteFromRawEvent(matchData.event);
   if (!isComplete) {
     return NextResponse.json({
       available: false,

--- a/app/api/simulate/route.ts
+++ b/app/api/simulate/route.ts
@@ -3,8 +3,7 @@ import { cachedExecuteQuery, gqlCacheKey, MATCH_QUERY } from "@/lib/graphql";
 import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
 import { getMatchScorecards } from "@/lib/scorecards-archive";
 import { applyAdjustmentsToScorecards } from "@/lib/simulate-apply";
-import { computeMatchScoringPct } from "@/lib/match-data";
-import { isMatchCompleteFromEvent } from "@/lib/match-ttl";
+import { isMatchCompleteFromRawEvent } from "@/lib/match-ttl";
 import type { WhatIfSimulationRequest, WhatIfSimulationResponse } from "@/lib/types";
 
 // Shape returned when the route is invoked on a live (not-yet-complete) match.
@@ -94,12 +93,7 @@ export async function POST(req: Request) {
   if (!matchData.event) {
     return NextResponse.json({ error: "Match not found" }, { status: 404 });
   }
-  const isComplete = isMatchCompleteFromEvent({
-    scoringPct: computeMatchScoringPct(matchData.event),
-    startDate: matchData.event.starts ?? null,
-    status: matchData.event.status,
-    resultsStatus: matchData.event.results,
-  });
+  const isComplete = isMatchCompleteFromRawEvent(matchData.event);
   if (!isComplete) {
     const payload: NotAvailableResponse = {
       available: false,

--- a/lib/match-data.ts
+++ b/lib/match-data.ts
@@ -5,7 +5,7 @@
 import { cache } from "react";
 import { cachedExecuteQuery, gqlCacheKey, MATCH_QUERY, refreshCachedMatchQuery } from "@/lib/graphql";
 import cacheAdapter from "@/lib/cache-impl";
-import { computeMatchFreshness, computeMatchSwrTtl, isMatchComplete } from "@/lib/match-ttl";
+import { computeMatchFreshness, computeMatchScoringPct, computeMatchSwrTtl, isMatchComplete } from "@/lib/match-ttl";
 import { extractDivision } from "@/lib/divisions";
 import { decodeShooterId, indexMatchShooters } from "@/lib/shooter-index";
 import { afterResponse } from "@/lib/background-impl";
@@ -17,34 +17,10 @@ import { classifyVisibility } from "@/lib/visibility";
 import { visibilityTelemetry } from "@/lib/visibility-telemetry";
 import type { MatchResponse, StageInfo, CompetitorInfo, SquadInfo, Visibility } from "@/lib/types";
 
-// ── Match-level scoring percentage ──────────────────────────────────────────
-//
-// SSI exposes scoring progress as integer counts on each `IpscStageNode` via
-// `scoring_progress { scored, total }`. The match-level percentage is the
-// weighted ratio across all stages — i.e. the share of (competitor × stage)
-// pairs that have been scored. This matches SSI's own match-page progress
-// indicator and stays meaningful when stages have unequal squad sizes.
-//
-// (The legacy `IpscMatchNode.scoring_completed` field was deprecated by SSI
-// with the note "Always returns 0. Use scoring_progress / squad_scoring_progress
-// on stages instead." We do exactly that.)
-
-interface MatchEventForScoring {
-  stages?: Array<{ scoring_progress?: { scored?: number | null; total?: number | null } | null }> | null;
-}
-
-export function computeMatchScoringPct(event: MatchEventForScoring | null | undefined): number {
-  if (!event?.stages?.length) return 0;
-  let scored = 0;
-  let total = 0;
-  for (const s of event.stages) {
-    const sp = s?.scoring_progress;
-    if (!sp) continue;
-    if (typeof sp.scored === "number") scored += sp.scored;
-    if (typeof sp.total === "number") total += sp.total;
-  }
-  return total > 0 ? (scored / total) * 100 : 0;
-}
+// `computeMatchScoringPct` lives in lib/match-ttl.ts (alongside the other
+// scoring-state helpers); re-exported here for back-compat with existing
+// imports from `@/lib/match-data`.
+export { computeMatchScoringPct } from "@/lib/match-ttl";
 
 // ── Raw GraphQL response shapes ─────────────────────────────────────────────
 

--- a/lib/match-ttl.ts
+++ b/lib/match-ttl.ts
@@ -115,12 +115,13 @@ export function isMatchComplete(
  * and the signals object internally so each call site doesn't repeat that
  * arithmetic.
  *
- * Use this whenever you have a match-event-shaped object; reach for the
- * primitive `isMatchComplete()` only when the inputs come from somewhere
- * non-event-shaped (e.g. a synthetic test fixture).
+ * Use this whenever you have an already-parsed match (e.g. `MatchResponse`)
+ * with the scoring percentage already on hand. For raw GraphQL event data,
+ * `isMatchCompleteFromRawEvent` does the per-stage `scoring_progress`
+ * aggregation for you.
  */
 export interface MatchCompletionInputs {
-  /** Effective scoring percentage (0-100). Use `effectiveMatchScoringPct(ev)` to derive. */
+  /** Effective scoring percentage (0-100). Use `computeMatchScoringPct(ev)` to derive. */
   scoringPct: number;
   /** Match start date — accepts ISO string, Date, or null/undefined for unknown. */
   startDate: string | Date | null | undefined;
@@ -140,6 +141,60 @@ export function isMatchCompleteFromEvent(input: MatchCompletionInputs): boolean 
   return isMatchComplete(input.scoringPct, daysSince, {
     status: input.status ?? null,
     resultsPublished: input.resultsStatus === "all",
+  });
+}
+
+// ── Match-level scoring percentage ──────────────────────────────────────────
+//
+// SSI exposes scoring progress as integer counts on each `IpscStageNode` via
+// `scoring_progress { scored, total }`. The match-level percentage is the
+// weighted ratio across all stages — i.e. the share of (competitor × stage)
+// pairs that have been scored. This matches SSI's own match-page progress
+// indicator and stays meaningful when stages have unequal squad sizes.
+//
+// (The legacy `IpscMatchNode.scoring_completed` field was deprecated by SSI
+// with the note "Always returns 0. Use scoring_progress / squad_scoring_progress
+// on stages instead.")
+
+interface MatchEventForScoring {
+  stages?: Array<{ scoring_progress?: { scored?: number | null; total?: number | null } | null }> | null;
+}
+
+export function computeMatchScoringPct(event: MatchEventForScoring | null | undefined): number {
+  if (!event?.stages?.length) return 0;
+  let scored = 0;
+  let total = 0;
+  for (const s of event.stages) {
+    const sp = s?.scoring_progress;
+    if (!sp) continue;
+    if (typeof sp.scored === "number") scored += sp.scored;
+    if (typeof sp.total === "number") total += sp.total;
+  }
+  return total > 0 ? (scored / total) * 100 : 0;
+}
+
+/**
+ * Convenience wrapper for callers that hold the raw GraphQL event shape
+ * directly (e.g. `MatchEventForGate` in simulate, the parsed cache blob in
+ * data/results). Aggregates `scoring_progress` across stages internally and
+ * forwards to `isMatchCompleteFromEvent`. Returns `false` for null/undefined
+ * events.
+ */
+export interface RawMatchEventForCompletion extends MatchEventForScoring {
+  starts?: string | null;
+  status?: string | null;
+  results?: string | null;
+}
+
+export function isMatchCompleteFromRawEvent(
+  event: RawMatchEventForCompletion | null | undefined,
+): boolean {
+  if (!event) return false;
+  return isMatchCompleteFromEvent({
+    scoringPct: computeMatchScoringPct(event),
+    startDate: event.starts ?? null,
+    status: event.status,
+    resultsStatus: event.results,
   });
 }
 

--- a/tests/unit/match-ttl.test.ts
+++ b/tests/unit/match-ttl.test.ts
@@ -4,6 +4,7 @@ import {
   computeMatchFreshness,
   isMatchComplete,
   isMatchCompleteFromEvent,
+  isMatchCompleteFromRawEvent,
 } from "@/lib/match-ttl";
 
 const NOW = new Date("2025-06-15T12:00:00Z").getTime();
@@ -179,6 +180,51 @@ describe("isMatchCompleteFromEvent", () => {
         startDate: isoHoursFromNow(-48),
         status: "cp",
         resultsStatus: "all",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isMatchCompleteFromRawEvent", () => {
+  it("returns false for a null/undefined event", () => {
+    expect(isMatchCompleteFromRawEvent(null)).toBe(false);
+    expect(isMatchCompleteFromRawEvent(undefined)).toBe(false);
+  });
+
+  it("aggregates per-stage scoring_progress and treats >=98% past the time gate as complete", () => {
+    // ~4.2 days back (past the 3-day gate, before the 7-day historical fallback)
+    // so the scoringPct=100 signal is what flips the completion bit.
+    expect(
+      isMatchCompleteFromRawEvent({
+        starts: isoHoursFromNow(-100),
+        status: null,
+        results: null,
+        stages: [
+          { scoring_progress: { scored: 100, total: 100 } },
+          { scoring_progress: { scored: 100, total: 100 } },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("respects the time gate even with results=all + 100% scoring", () => {
+    expect(
+      isMatchCompleteFromRawEvent({
+        starts: isoHoursFromNow(-24),
+        status: "cp",
+        results: "all",
+        stages: [{ scoring_progress: { scored: 50, total: 50 } }],
+      }),
+    ).toBe(false);
+  });
+
+  it("treats stages with no progress data as 0% (no flip without other signals)", () => {
+    expect(
+      isMatchCompleteFromRawEvent({
+        starts: isoHoursFromNow(-100),
+        status: null,
+        results: null,
+        stages: [{ scoring_progress: null }, {}],
       }),
     ).toBe(false);
   });


### PR DESCRIPTION
## Summary

Tiny ergonomics pass. Two callers (`simulate/route.ts`, `data/match/.../results/route.ts`) both spelled out the same five-line dance:

\`\`\`ts
isMatchCompleteFromEvent({
  scoringPct: computeMatchScoringPct(matchData.event),
  startDate: matchData.event.starts ?? null,
  status: matchData.event.status,
  resultsStatus: matchData.event.results,
})
\`\`\`

Replaced with `isMatchCompleteFromRawEvent(matchData.event)` — same behavior, raw event in, completion bit out.

The other five callers of `isMatchCompleteFromEvent` either hold a parsed `MatchResponse` (stages route) or use the primitive `isMatchComplete` directly because they reuse `scoringPct` / `daysSince` for nearby `computeMatchSwrTtl` / `computeMatchTtl` calls (compare, coaching, add-match). Those stay as they are.

`computeMatchScoringPct` also moved from `lib/match-data.ts` to `lib/match-ttl.ts` — it belongs alongside the other scoring-state helpers, and the new `isMatchCompleteFromRawEvent` can call it without inlining 10 lines or creating an import cycle. Re-exported from `match-data.ts` so existing imports stay green without a churn pass.

Net diff: `+114 / -49`.

## Test plan

- [x] `pnpm -w run lint` — clean
- [x] `pnpm -w run typecheck` — clean
- [x] `pnpm -w test` — 1712 / 1712 (3 new tests for `isMatchCompleteFromRawEvent` covering null events, time-gate respect, and missing progress data)

## Followup

Discovered while doing this: `EventSummary.scoring_completed` was removed in #432 without bumping v1 → v2 (the snapshot test "passed" because the snapshot was updated to match). Splitsmith and any other v1 consumer pinning to that field will see it disappear. Will address in a separate PR alongside a Zod-validated v1 contract guard so this can't slip through again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)