### PR TITLE
fix(api-v1): restore scoring_completed + Zod-lock the v1 contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,8 +303,14 @@ Endpoints (thin wrappers around the internal routes, see `app/api/v1/`):
 **Contract rules (CRITICAL):**
 - Within v1, only **additive** changes are allowed -- new optional fields, never
   rename/remove/retype existing ones. Breaking changes go to `/api/v2/`.
-- Snapshot tests in `tests/unit/api-v1-routes.test.ts` enforce response shapes;
-  any drift fails CI. Updating a snapshot is a contract change -- review it.
+- The contract is locked by Zod schemas in `lib/api-v1-schemas.ts`. Each happy-path
+  test in `tests/unit/api-v1-routes.test.ts` runs `<schema>.parse(body)` before
+  the snapshot assertion -- removing or retyping a field fails with a named
+  TypeError pointing at the affected path, even when a developer reflexively
+  runs `vitest -u` to bless a snapshot diff. Adding a new field requires
+  extending the schema (an explicit, reviewable change).
+- Snapshot tests preserve the byte shape of each response so reviewers see the
+  impact of any change in the PR diff. Schema validation is the primary guard.
 - Whenever an internal route response shape changes, check whether the v1 wrapper
   for it is affected. If a field is removed or renamed upstream, the v1 wrapper
   must either (a) preserve the old field by reshaping in the wrapper, or

--- a/app/api/v1/events/route.ts
+++ b/app/api/v1/events/route.ts
@@ -18,5 +18,31 @@ export async function GET(req: Request) {
   const innerReq = new Request(innerUrl, { headers: req.headers, method: "GET" });
 
   const inner = await forwardToInternal(() => innerGET(innerReq));
-  return mapInnerToV1(inner);
+  const mapped = await mapInnerToV1(inner);
+
+  // Preserve the v1 contract: each event entry exposes `scoring_completed`.
+  // The internal /api/events stopped emitting it in #432 (the upstream SSI
+  // field was deprecated and always returned 0); the v1 surface keeps it as
+  // a constant 0 so external consumers pinning to the contract don't see a
+  // removed field. Per docs/api-v1.md, removals are not allowed within v1
+  // -- they belong to v2.
+  if (!mapped.ok) return mapped;
+  let body: unknown;
+  try {
+    body = await mapped.clone().json();
+  } catch {
+    return mapped;
+  }
+  if (!Array.isArray(body)) return mapped;
+  const augmented = body.map((entry) =>
+    entry && typeof entry === "object" && !("scoring_completed" in entry)
+      ? { ...entry, scoring_completed: 0 }
+      : entry,
+  );
+  const headers = new Headers(mapped.headers);
+  headers.delete("Content-Length"); // body is reserialized below
+  return new Response(JSON.stringify(augmented), {
+    status: mapped.status,
+    headers,
+  });
 }

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -441,13 +441,19 @@ The shape of every successful 2xx response is locked at v1. Within v1:
 - **Not allowed**: renaming, removing, or changing the type of any existing
   field. Such changes require a `/api/v2/` namespace.
 
-Snapshot tests in `tests/unit/api-v1-routes.test.ts` enforce the shape; CI
-fails on any drift. Fixtures are typed against the production interfaces via
-`satisfies`, so the typechecker also catches divergence between the fixture
-and the real types -- snapshots alone could lock a fictional shape if the
-fixture was hand-written without that constraint. Updating a snapshot is an
-explicit signal that the contract is changing -- review carefully before
-doing so.
+The contract is locked by Zod schemas in `lib/api-v1-schemas.ts`. Each
+happy-path test in `tests/unit/api-v1-routes.test.ts` runs
+`<schema>.parse(body)` before the snapshot assertion -- removing or
+retyping a documented field fails with a named TypeError pointing at the
+affected path, even when a developer reflexively runs `vitest -u` to bless
+a snapshot diff. Adding a new field requires extending the schema (an
+explicit, reviewable change). Snapshot diffs preserve the byte shape so
+reviewers see the impact of every change in the PR.
+
+Fixtures are typed against the production interfaces via `satisfies`, so
+the typechecker also catches divergence between the fixture and the real
+types -- snapshots alone could lock a fictional shape if the fixture was
+hand-written without that constraint.
 
 ---
 

--- a/lib/api-v1-schemas.ts
+++ b/lib/api-v1-schemas.ts
@@ -1,0 +1,342 @@
+// Public API v1 — Zod-validated response contract.
+//
+// THESE SCHEMAS ARE THE V1 CONTRACT. External consumers (splitsmith and any
+// future ones) pin to the shapes defined here.
+//
+// Rules of engagement:
+//   - Adding an OPTIONAL field: extend the relevant schema, bump no version.
+//     This is the only kind of change allowed within v1.
+//   - Removing, renaming, or retyping a field: not allowed. Bump to /api/v2/.
+//     Do NOT edit these schemas to silence a test — the test is the contract.
+//   - The error-envelope `code` enum is closed; adding a new code requires v2.
+//
+// Schemas use `.strict()` so any unrecognized property is a hard error. That
+// makes the v1 surface impossible to extend by accident — internal type
+// changes (e.g. someone adds a field to MatchResponse) are caught in CI
+// instead of silently leaking into the public surface.
+//
+// See docs/api-v1.md for the prose contract and CLAUDE.md → "Public API v1"
+// for the operational notes.
+
+import { z } from "zod";
+
+// ─── Shared ──────────────────────────────────────────────────────────────────
+
+const cacheInfoSchema = z
+  .object({
+    cachedAt: z.string().nullable(),
+    upstreamDegraded: z.boolean().optional(),
+    lastScorecardAt: z.string().nullable().optional(),
+    scorecardsCachedAt: z.string().nullable().optional(),
+  })
+  .strict();
+
+export const v1ErrorEnvelopeSchema = z
+  .object({
+    error: z
+      .object({
+        code: z.enum([
+          "unauthorized",
+          "rate_limited",
+          "not_found",
+          "upstream_failed",
+          "bad_request",
+        ]),
+        message: z.string(),
+      })
+      .strict(),
+  })
+  .strict();
+export type V1ErrorEnvelope = z.infer<typeof v1ErrorEnvelopeSchema>;
+
+// ─── /api/v1/events ──────────────────────────────────────────────────────────
+
+export const v1EventSchema = z
+  .object({
+    id: z.number(),
+    content_type: z.number(),
+    name: z.string(),
+    venue: z.string().nullable(),
+    date: z.string(),
+    ends: z.string().nullable(),
+    status: z.string(),
+    region: z.string(),
+    discipline: z.string(),
+    level: z.string(),
+    /**
+     * Match-level scoring percentage (0-100). SSI deprecated the upstream
+     * field this comes from with the note "Always returns 0", so this value
+     * is now always 0 — we keep the field on the v1 surface for additive
+     * compatibility. Per-match scoring is available on the
+     * /api/v1/match/{ct}/{id} endpoint.
+     */
+    scoring_completed: z.number(),
+    registration_status: z.string(),
+    registration_starts: z.string().nullable(),
+    registration_closes: z.string().nullable(),
+    is_registration_possible: z.boolean(),
+    squadding_starts: z.string().nullable(),
+    squadding_closes: z.string().nullable(),
+    is_squadding_possible: z.boolean(),
+    max_competitors: z.number().nullable(),
+  })
+  .strict();
+export type V1Event = z.infer<typeof v1EventSchema>;
+
+export const v1EventsResponseSchema = z.array(v1EventSchema);
+export type V1EventsResponse = z.infer<typeof v1EventsResponseSchema>;
+
+// ─── /api/v1/match/{ct}/{id} ─────────────────────────────────────────────────
+
+const v1StageSchema = z
+  .object({
+    id: z.number(),
+    name: z.string(),
+    stage_number: z.number(),
+    max_points: z.number(),
+    min_rounds: z.number().nullable(),
+    paper_targets: z.number().nullable(),
+    steel_targets: z.number().nullable(),
+    ssi_url: z.string().nullable(),
+    course_display: z.string().nullable(),
+    procedure: z.string().nullable(),
+    firearm_condition: z.string().nullable(),
+  })
+  .strict();
+
+const v1CompetitorSchema = z
+  .object({
+    id: z.number(),
+    shooterId: z.number().nullable(),
+    name: z.string(),
+    competitor_number: z.string(),
+    club: z.string().nullable(),
+    division: z.string().nullable(),
+    region: z.string().nullable(),
+    region_display: z.string().nullable(),
+    category: z.string().nullable(),
+    ics_alias: z.string().nullable(),
+    license: z.string().nullable(),
+  })
+  .strict();
+
+const v1SquadSchema = z
+  .object({
+    id: z.number(),
+    number: z.number(),
+    name: z.string(),
+    competitorIds: z.array(z.number()),
+  })
+  .strict();
+
+const v1VisibilitySchema = z
+  .object({
+    class: z.enum(["public", "unlisted", "organizer-published"]),
+    rawCode: z.string(),
+    displayName: z.string(),
+  })
+  .strict();
+
+export const v1MatchResponseSchema = z
+  .object({
+    name: z.string(),
+    venue: z.string().nullable(),
+    lat: z.number().nullable(),
+    lng: z.number().nullable(),
+    date: z.string().nullable(),
+    ends: z.string().nullable(),
+    level: z.string().nullable(),
+    sub_rule: z.string().nullable(),
+    discipline: z.string().nullable(),
+    region: z.string().nullable(),
+    stages_count: z.number(),
+    competitors_count: z.number(),
+    max_competitors: z.number().nullable(),
+    scoring_completed: z.number(),
+    match_status: z.string(),
+    results_status: z.string(),
+    registration_status: z.string(),
+    registration_starts: z.string().nullable(),
+    registration_closes: z.string().nullable(),
+    is_registration_possible: z.boolean(),
+    squadding_starts: z.string().nullable(),
+    squadding_closes: z.string().nullable(),
+    is_squadding_possible: z.boolean(),
+    ssi_url: z.string().nullable(),
+    visibility: v1VisibilitySchema,
+    is_live_scores_accessible: z.boolean(),
+    stages: z.array(v1StageSchema),
+    competitors: z.array(v1CompetitorSchema),
+    squads: z.array(v1SquadSchema),
+    cacheInfo: cacheInfoSchema,
+  })
+  .strict();
+export type V1MatchResponse = z.infer<typeof v1MatchResponseSchema>;
+
+// ─── /api/v1/match/{ct}/{id}/competitor/{competitorId}/stages ────────────────
+
+const v1CompetitorStageResultSchema = z
+  .object({
+    stage_number: z.number(),
+    stage_id: z.number(),
+    time_seconds: z.number().nullable(),
+    scorecard_updated_at: z.string().nullable(),
+    hit_factor: z.number().nullable(),
+    stage_points: z.number().nullable(),
+    stage_pct: z.number().nullable(),
+    alphas: z.number().nullable(),
+    charlies: z.number().nullable(),
+    deltas: z.number().nullable(),
+    misses: z.number().nullable(),
+    no_shoots: z.number().nullable(),
+    procedurals: z.number().nullable(),
+    dq: z.boolean(),
+  })
+  .strict();
+
+export const v1CompetitorStagesResponseSchema = z
+  .object({
+    ct: z.number(),
+    matchId: z.number(),
+    competitorId: z.number(),
+    shooterId: z.number().nullable(),
+    division: z.string().nullable(),
+    stages: z.array(v1CompetitorStageResultSchema),
+    cacheInfo: cacheInfoSchema,
+  })
+  .strict();
+export type V1CompetitorStagesResponse = z.infer<typeof v1CompetitorStagesResponseSchema>;
+
+// ─── /api/v1/shooter/{shooterId} ─────────────────────────────────────────────
+
+const v1ShooterMatchSummarySchema = z
+  .object({
+    ct: z.string(),
+    matchId: z.string(),
+    name: z.string(),
+    date: z.string().nullable(),
+    venue: z.string().nullable(),
+    level: z.string().nullable(),
+    region: z.string().nullable(),
+    division: z.string().nullable(),
+    competitorId: z.number(),
+    competitorsInDivision: z.number().nullable(),
+    stageCount: z.number(),
+    avgHF: z.number().nullable(),
+    matchPct: z.number().nullable(),
+    totalA: z.number(),
+    totalC: z.number(),
+    totalD: z.number(),
+    totalMiss: z.number(),
+    totalNoShoots: z.number(),
+    totalProcedurals: z.number().optional(),
+    dq: z.boolean().optional(),
+    perfectStages: z.number().optional(),
+    consistencyIndex: z.number().nullable().optional(),
+    squadmateShooterIds: z.array(z.number()).optional(),
+    squadAllSameClub: z.boolean().optional(),
+    discipline: z.string().nullable().optional(),
+  })
+  .strict();
+
+const v1ShooterProfileSchema = z
+  .object({
+    name: z.string(),
+    club: z.string().nullable(),
+    division: z.string().nullable(),
+    lastSeen: z.string(),
+    region: z.string().nullable(),
+    region_display: z.string().nullable(),
+    category: z.string().nullable(),
+    ics_alias: z.string().nullable(),
+    license: z.string().nullable(),
+  })
+  .strict();
+
+const v1ShooterStatsSchema = z
+  .object({
+    totalStages: z.number(),
+    dateRange: z
+      .object({
+        from: z.string().nullable(),
+        to: z.string().nullable(),
+      })
+      .strict(),
+    overallAvgHF: z.number().nullable(),
+    overallMatchPct: z.number().nullable(),
+    aPercent: z.number().nullable(),
+    cPercent: z.number().nullable(),
+    dPercent: z.number().nullable(),
+    missPercent: z.number().nullable(),
+    consistencyCV: z.number().nullable(),
+    hfTrendSlope: z.number().nullable(),
+    avgPenaltyRate: z.number().nullable().optional(),
+    avgConsistencyIndex: z.number().nullable().optional(),
+  })
+  .strict();
+
+const v1UpcomingMatchSchema = z
+  .object({
+    ct: z.string(),
+    matchId: z.string(),
+    name: z.string(),
+    date: z.string().nullable(),
+    venue: z.string().nullable(),
+    level: z.string().nullable(),
+    division: z.string().nullable(),
+    competitorId: z.number(),
+    registrationStarts: z.string().nullable(),
+    registrationCloses: z.string().nullable(),
+    isRegistrationPossible: z.boolean(),
+    squaddingStarts: z.string().nullable(),
+    squaddingCloses: z.string().nullable(),
+    isSquaddingPossible: z.boolean(),
+    isRegistered: z.boolean(),
+    isSquadded: z.boolean(),
+  })
+  .strict();
+
+const v1AchievementProgressSchema = z
+  .object({
+    id: z.string(),
+    category: z.string(),
+    title: z.string(),
+    description: z.string(),
+    unlockedTier: z.string().nullable(),
+    nextTier: z.string().nullable(),
+    progress: z.number(),
+    target: z.number(),
+    matchesContributed: z.number().optional(),
+  })
+  .passthrough();
+// `passthrough` here is intentional: the achievement system grows tiers
+// over time and we want new tier metadata to flow through without churning
+// the v1 schema. The fields above are the locked contract.
+
+export const v1ShooterDashboardSchema = z
+  .object({
+    shooterId: z.number(),
+    profile: v1ShooterProfileSchema.nullable(),
+    matchCount: z.number(),
+    matches: z.array(v1ShooterMatchSummarySchema),
+    stats: v1ShooterStatsSchema,
+    upcomingMatches: z.array(v1UpcomingMatchSchema).optional(),
+    achievements: z.array(v1AchievementProgressSchema).optional(),
+  })
+  .strict();
+export type V1ShooterDashboard = z.infer<typeof v1ShooterDashboardSchema>;
+
+// ─── /api/v1/shooter/search ──────────────────────────────────────────────────
+
+const v1ShooterSearchResultSchema = z
+  .object({
+    shooterId: z.number(),
+    name: z.string(),
+    club: z.string().nullable(),
+    division: z.string().nullable(),
+    lastSeen: z.string(),
+  })
+  .strict();
+
+export const v1ShooterSearchResponseSchema = z.array(v1ShooterSearchResultSchema);
+export type V1ShooterSearchResponse = z.infer<typeof v1ShooterSearchResponseSchema>;

--- a/tests/unit/__snapshots__/api-v1-routes.test.ts.snap
+++ b/tests/unit/__snapshots__/api-v1-routes.test.ts.snap
@@ -17,6 +17,7 @@ exports[`/api/v1/events > forwards query params and returns the inner payload un
     "registration_closes": null,
     "registration_starts": null,
     "registration_status": "cl",
+    "scoring_completed": 0,
     "squadding_closes": null,
     "squadding_starts": null,
     "status": "on",

--- a/tests/unit/api-v1-routes.test.ts
+++ b/tests/unit/api-v1-routes.test.ts
@@ -1,14 +1,22 @@
-// Snapshot tests for /api/v1/* response shapes.
+// Snapshot + schema tests for /api/v1/* response shapes.
 //
-// The whole point of the v1 contract is that splitsmith (and any future
-// consumer) can pin to it. These snapshots fail CI if the shape drifts --
-// any field rename or removal is a breaking change that requires v2.
-// Additive changes (new optional fields) need an intentional snapshot update.
+// The v1 contract has two layers of CI guard:
+//
+// 1. **Schema validation** (`lib/api-v1-schemas.ts`). Strict Zod schemas
+//    define the v1 surface field-by-field. Each happy-path test below runs
+//    `<schema>.parse(body)` -- removing or retyping a documented field
+//    fails with a named TypeError pointing at the affected path, even if
+//    a developer reflexively runs `vitest -u` to bless a snapshot diff.
+//    This is the primary guard.
+//
+// 2. **Snapshot diffs**. The `toMatchSnapshot()` calls below preserve the
+//    "exact byte shape" of each response so a reviewer sees the impact of
+//    any change in the PR diff, even when the schema-passable change is
+//    intentional (e.g. a new optional field being added to the schema).
 //
 // Fixtures are typed against the real interfaces in lib/types.ts via
-// `satisfies`, so the typechecker also catches drift between the fixture and
-// the production type -- the snapshot alone could lock a fictional shape if
-// the fixture was hand-written without that constraint.
+// `satisfies`, so the typechecker also catches drift between the fixture
+// and the production type.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
@@ -18,6 +26,14 @@ import type {
   ShooterDashboardResponse,
   ShooterSearchResult,
 } from "@/lib/types";
+import {
+  v1CompetitorStagesResponseSchema,
+  v1ErrorEnvelopeSchema,
+  v1EventsResponseSchema,
+  v1MatchResponseSchema,
+  v1ShooterDashboardSchema,
+  v1ShooterSearchResponseSchema,
+} from "@/lib/api-v1-schemas";
 
 const cacheMock = vi.hoisted(() => ({
   get: vi.fn<(k: string) => Promise<string | null>>(),
@@ -115,7 +131,9 @@ describe("/api/v1/events", () => {
       new Request("http://x/api/v1/events?q=SPSK&minLevel=l2plus&country=SWE", { headers: auth }),
     );
     expect(res.status).toBe(200);
-    expect(await res.json()).toMatchSnapshot();
+    const body = await res.json();
+    v1EventsResponseSchema.parse(body); // contract guard
+    expect(body).toMatchSnapshot();
 
     const innerReq = innerEvents.mock.calls[0]![0];
     expect(innerReq.url).toBe("http://x/api/events?q=SPSK&minLevel=l2plus&country=SWE");
@@ -128,7 +146,9 @@ describe("/api/v1/events", () => {
     const { GET } = await import("@/app/api/v1/events/route");
     const res = await GET(new Request("http://x/api/v1/events", { headers: auth }));
     expect(res.status).toBe(502);
-    expect(await res.json()).toMatchSnapshot();
+    const body = await res.json();
+    v1ErrorEnvelopeSchema.parse(body);
+    expect(body).toMatchSnapshot();
   });
 });
 
@@ -212,7 +232,9 @@ describe("/api/v1/match/[ct]/[id]", () => {
     expect(res.status).toBe(200);
     // Server-Timing should be stripped from the v1 envelope.
     expect(res.headers.get("Server-Timing")).toBeNull();
-    expect(await res.json()).toMatchSnapshot();
+    const body = await res.json();
+    v1MatchResponseSchema.parse(body);
+    expect(body).toMatchSnapshot();
   });
 
   it("maps a 404 from the inner route to not_found", async () => {
@@ -225,7 +247,9 @@ describe("/api/v1/match/[ct]/[id]", () => {
       { params: Promise.resolve({ ct: "22", id: "99999" }) },
     );
     expect(res.status).toBe(404);
-    expect(await res.json()).toMatchSnapshot();
+    const body = await res.json();
+    v1ErrorEnvelopeSchema.parse(body);
+    expect(body).toMatchSnapshot();
   });
 
   it("maps a 400 from the inner route to bad_request", async () => {
@@ -238,7 +262,9 @@ describe("/api/v1/match/[ct]/[id]", () => {
       { params: Promise.resolve({ ct: "abc", id: "27190" }) },
     );
     expect(res.status).toBe(400);
-    expect(await res.json()).toMatchSnapshot();
+    const body = await res.json();
+    v1ErrorEnvelopeSchema.parse(body);
+    expect(body).toMatchSnapshot();
   });
 });
 
@@ -268,7 +294,9 @@ describe("/api/v1/shooter/search", () => {
       new Request("http://x/api/v1/shooter/search?q=doe&limit=10", { headers: auth }),
     );
     expect(res.status).toBe(200);
-    expect(await res.json()).toMatchSnapshot();
+    const body = await res.json();
+    v1ShooterSearchResponseSchema.parse(body);
+    expect(body).toMatchSnapshot();
   });
 });
 
@@ -333,7 +361,9 @@ describe("/api/v1/shooter/[shooterId]", () => {
       { params: Promise.resolve({ shooterId: "12345" }) },
     );
     expect(res.status).toBe(200);
-    expect(await res.json()).toMatchSnapshot();
+    const body = await res.json();
+    v1ShooterDashboardSchema.parse(body);
+    expect(body).toMatchSnapshot();
   });
 
   it("maps GDPR 410 to not_found preserving the 410 status code", async () => {
@@ -348,7 +378,9 @@ describe("/api/v1/shooter/[shooterId]", () => {
       { params: Promise.resolve({ shooterId: "12345" }) },
     );
     expect(res.status).toBe(410);
-    expect(await res.json()).toMatchSnapshot();
+    const body = await res.json();
+    v1ErrorEnvelopeSchema.parse(body);
+    expect(body).toMatchSnapshot();
   });
 });
 
@@ -415,7 +447,9 @@ describe("/api/v1/match/[ct]/[id]/competitor/[competitorId]/stages", () => {
       },
     );
     expect(res.status).toBe(200);
-    expect(await res.json()).toMatchSnapshot();
+    const body = await res.json();
+    v1CompetitorStagesResponseSchema.parse(body);
+    expect(body).toMatchSnapshot();
   });
 
   it("maps a 404 from the inner route to not_found", async () => {
@@ -436,7 +470,9 @@ describe("/api/v1/match/[ct]/[id]/competitor/[competitorId]/stages", () => {
       },
     );
     expect(res.status).toBe(404);
-    expect(await res.json()).toMatchSnapshot();
+    const body = await res.json();
+    v1ErrorEnvelopeSchema.parse(body);
+    expect(body).toMatchSnapshot();
   });
 
   it("maps a 400 from the inner route to bad_request", async () => {
@@ -457,6 +493,8 @@ describe("/api/v1/match/[ct]/[id]/competitor/[competitorId]/stages", () => {
       },
     );
     expect(res.status).toBe(400);
-    expect(await res.json()).toMatchSnapshot();
+    const body = await res.json();
+    v1ErrorEnvelopeSchema.parse(body);
+    expect(body).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary

Two-part fix for the v1 contract regression introduced in #432.

### The breach

#432 dropped `EventSummary.scoring_completed` in the internal `/api/events` route. The v1 wrapper passes the body through unchanged, so external consumers (splitsmith, future ones) pinning to `/api/v1/events` lost the field. This violated the documented "additive only within v1" rule.

The snapshot test in `tests/unit/api-v1-routes.test.ts` fired loudly during that PR -- and I reflexively ran `vitest -u` to bless the diff. The contract change went through with no friction. CI guards that rely on humans reviewing snapshot diffs are guards in name only when "make CI green" muscle memory takes over.

### Part 1: restore the field

`app/api/v1/events/route.ts` now reshapes the inner body to inject `scoring_completed: 0` per event entry after the v1 envelope mapping. Always-0 matches what SSI itself returned upstream (the deprecated field is permanently broken per the SSI deprecation notice), and the field stays present so external consumers don't see a removal.

Internal `/api/events` stays clean -- no `scoring_completed` field, no zombie GraphQL call. The compatibility shim is local to the v1 wrapper.

### Part 2: Zod-lock the contract

`lib/api-v1-schemas.ts` defines strict Zod schemas for every documented v1 endpoint:

- `v1EventsResponseSchema` -- array of v1 events
- `v1MatchResponseSchema` -- match overview
- `v1CompetitorStagesResponseSchema` -- per-competitor stage results
- `v1ShooterDashboardSchema` -- shooter dashboard
- `v1ShooterSearchResponseSchema` -- name search results
- `v1ErrorEnvelopeSchema` -- the documented error envelope

Each happy-path test in `tests/unit/api-v1-routes.test.ts` now runs `<schema>.parse(body)` **before** `toMatchSnapshot()`. Schema validation is the primary guard; the snapshot preserves the byte shape so reviewers see the impact of every change in the PR diff.

Schemas use `.strict()` so internal type changes can't accidentally extend the v1 surface. Adding a v1 field requires extending the schema -- an explicit, reviewable change.

### Probe results

Confirmed the schema fires on all three breach modes against `v1EventsResponseSchema`:

\`\`\`
Missing scoring_completed         -> FAILED: 0.scoring_completed -- Required
Extra 'internal_debug_field'      -> FAILED: 0 -- Unrecognized key(s) in object: 'internal_debug_field'
Retyped scoring_completed -> str  -> FAILED: 0.scoring_completed -- Expected number, received string
\`\`\`

The error path makes the breach immediately diagnosable, unlike a snapshot diff where the reader has to spot the missing line.

### Docs

`CLAUDE.md` (Public API v1 section) and `docs/api-v1.md` updated to reflect that schema validation is now the primary guard.

## Test plan

- [x] `pnpm -w run lint` -- clean
- [x] `pnpm -w run typecheck` -- clean
- [x] `pnpm -w test` -- 1712 / 1712
- [x] Schema parses sample payload from current snapshot for every endpoint
- [x] Probed three breach modes; all caught with named errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)