### PR TITLE
refactor: rename MatchResponse.scoring_completed → scoring_pct

### DIFF
--- a/app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts
+++ b/app/api/match/[ct]/[id]/competitor/[competitorId]/stages/route.ts
@@ -71,14 +71,14 @@ export async function GET(
     resultsPublished: match.results_status === "all",
   };
   const dataTtl = computeMatchSwrTtl(
-    match.scoring_completed,
+    match.scoring_pct,
     daysSince,
     match.date,
     signals,
   );
 
   const isComplete = isMatchCompleteFromEvent({
-    scoringPct: match.scoring_completed,
+    scoringPct: match.scoring_pct,
     startDate: match.date,
     status: match.match_status,
     resultsStatus: match.results_status,
@@ -126,7 +126,7 @@ export async function GET(
   const stageRefs = match.stages.map((s) => ({ ct: 24, id: String(s.id) }));
   const matchFreshness = isComplete
     ? null
-    : computeMatchFreshness(match.scoring_completed, daysSince, match.date, signals);
+    : computeMatchFreshness(match.scoring_pct, daysSince, match.date, signals);
   let scorecardsData: RawScorecardsData;
   let scorecardsCachedAt: string | null;
   try {

--- a/app/api/match/[ct]/[id]/route.ts
+++ b/app/api/match/[ct]/[id]/route.ts
@@ -31,7 +31,7 @@ export async function GET(
     cache_hit: cachedAt !== null,
     competitors_count: response.competitors_count,
     stages_count: response.stages_count,
-    scoring_completed: response.scoring_completed,
+    scoring_pct: response.scoring_pct,
     is_complete: isComplete,
     ms_graphql: Math.round(result.msFetch),
     ms_total: Math.round(tDone - t0),

--- a/app/api/popular-matches/route.ts
+++ b/app/api/popular-matches/route.ts
@@ -78,7 +78,7 @@ export async function GET(req: Request) {
           name: ev.name,
           venue: ev.venue ?? null,
           date: ev.starts ?? null,
-          scoring_completed: Math.round(computeMatchScoringPct(ev)),
+          scoring_pct: Math.round(computeMatchScoringPct(ev)),
         });
       } catch {
         // Skip malformed entries.

--- a/app/api/pre-match/brief/[ct]/[id]/route.ts
+++ b/app/api/pre-match/brief/[ct]/[id]/route.ts
@@ -69,7 +69,7 @@ export async function GET(
   // scoring (e.g. multi-day matches, RO squads shooting the day before).
   if (
     !isPreMatchEligible({
-      scoringPct: match.scoring_completed,
+      scoringPct: match.scoring_pct,
       resultsStatus: match.results_status,
       matchStatus: match.match_status,
     })

--- a/app/api/v1/match/[ct]/[id]/route.ts
+++ b/app/api/v1/match/[ct]/[id]/route.ts
@@ -13,5 +13,35 @@ export async function GET(
   if (gate instanceof Response) return gate;
 
   const inner = await forwardToInternal(() => innerGET(req, { params }));
-  return mapInnerToV1(inner, { notFoundMessage: "Match not found" });
+  const mapped = await mapInnerToV1(inner, { notFoundMessage: "Match not found" });
+
+  // Preserve the v1 contract: the v1 surface keeps the legacy
+  // `scoring_completed` field name. Internally the field was renamed to
+  // `scoring_pct` to match its semantic (a percentage, not a boolean) --
+  // see lib/types.ts. The wrapper re-maps so external consumers don't see
+  // the rename. Within v1 only additive changes are allowed; this glue is
+  // what lets internal cleanup happen without bumping to v2.
+  if (!mapped.ok) return mapped;
+  let body: unknown;
+  try {
+    body = await mapped.clone().json();
+  } catch {
+    return mapped;
+  }
+  if (
+    body &&
+    typeof body === "object" &&
+    !Array.isArray(body) &&
+    "scoring_pct" in body
+  ) {
+    const { scoring_pct, ...rest } = body as { scoring_pct: number } & Record<string, unknown>;
+    const remapped = { ...rest, scoring_completed: scoring_pct };
+    const headers = new Headers(mapped.headers);
+    headers.delete("Content-Length");
+    return new Response(JSON.stringify(remapped), {
+      status: mapped.status,
+      headers,
+    });
+  }
+  return mapped;
 }

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -208,12 +208,12 @@ export default function MatchPageClient() {
 
   // Auto view is computed from match-only data first, then refined once the
   // compare response confirms whether any stage already has scores.
-  // (This enables falling back to "live" if `scoring_completed` is still 0
+  // (This enables falling back to "live" if `scoring_pct` is still 0
   // but the API has scores — handles rounding / delayed reporting.)
   const autoMode = useMemo(() => {
     if (!matchQuery.data) return "coaching" as const;
     return detectMatchView({
-      scoringPct: matchQuery.data.scoring_completed,
+      scoringPct: matchQuery.data.scoring_pct,
       daysSinceMatchStart,
       daysSinceMatchEnd,
       resultsStatus: matchQuery.data.results_status,
@@ -229,7 +229,7 @@ export default function MatchPageClient() {
   // available for multi-day matches where some squads still haven't shot.
   const preMatchEligible = matchQuery.data
     ? isPreMatchEligible({
-        scoringPct: matchQuery.data.scoring_completed,
+        scoringPct: matchQuery.data.scoring_pct,
         resultsStatus: matchQuery.data.results_status,
         matchStatus: matchQuery.data.match_status,
       })
@@ -812,8 +812,8 @@ export default function MatchPageClient() {
           <p className="text-sm text-muted-foreground">
             The organizer has not made live scores public for this match.
             Detailed stage results will be available once scoring is complete
-            {match.scoring_completed > 0
-              ? ` (${Math.round(match.scoring_completed)}% scored so far)`
+            {match.scoring_pct > 0
+              ? ` (${Math.round(match.scoring_pct)}% scored so far)`
               : ""}
             .
           </p>
@@ -926,7 +926,7 @@ export default function MatchPageClient() {
                 </div>
                 <ComparisonTable
                   data={compareQuery.data}
-                  scoringCompleted={match.scoring_completed}
+                  scoringCompleted={match.scoring_pct}
                   onRemove={(id) => handleSelectionChange(selectedIds.filter((s) => s !== id))}
                   aiAvailable={aiAvailable}
                   isComplete={isMatchComplete}
@@ -1245,7 +1245,7 @@ export default function MatchPageClient() {
                   </Collapsible>
 
                   {/* Stage Simulator — collapsed by default, only ≥ 80% complete */}
-                  {match.scoring_completed >= 80 && (
+                  {match.scoring_pct >= 80 && (
                     <Collapsible open={showSimulator} onOpenChange={setShowSimulator} className="rounded-lg border p-4">
                       <div className="flex items-start gap-2">
                         <h2 className="flex-1 font-semibold text-base m-0 leading-none">
@@ -1308,7 +1308,7 @@ export default function MatchPageClient() {
                             id={id}
                             data={compareQuery.data}
                             competitors={compareQuery.data.competitors}
-                            scoringCompleted={match.scoring_completed}
+                            scoringCompleted={match.scoring_pct}
                           />
                         </section>
                       </CollapsibleContent>

--- a/app/match/[ct]/[id]/page.tsx
+++ b/app/match/[ct]/[id]/page.tsx
@@ -98,7 +98,7 @@ export default async function MatchPage({ params }: PageProps) {
           ct: ctNum,
           level: result.data.level ?? null,
           region: result.data.region ?? null,
-          scoringBucket: bucketScoring(result.data.scoring_completed ?? 0),
+          scoringBucket: bucketScoring(result.data.scoring_pct ?? 0),
           cacheHit: result.cachedAt !== null,
         });
       }

--- a/components/match-header.tsx
+++ b/components/match-header.tsx
@@ -32,7 +32,7 @@ export function MatchHeader({ match }: MatchHeaderProps) {
       })
     : null;
 
-  const pct = match.scoring_completed ?? 0;
+  const pct = match.scoring_pct ?? 0;
   const isComplete = match.results_status === "all" || pct >= 100;
 
   // For Handgun matches the sub_rule badge (Standard / PCC) is the meaningful

--- a/components/popular-matches.tsx
+++ b/components/popular-matches.tsx
@@ -74,7 +74,15 @@ export function PopularMatches() {
       </h2>
       <div className="grid gap-3 sm:grid-cols-2">
         {visible.map((match) => (
-          <CompetitionCard key={`${match.ct}-${match.id}`} comp={match} />
+          <CompetitionCard
+            key={`${match.ct}-${match.id}`}
+            // Map the API field to the localStorage-shaped `CompetitionCardData`
+            // so the same card component renders both the popular-matches and
+            // recent-competitions sources. The `scoring_completed` name on
+            // CompetitionCardData mirrors `StoredCompetition` (the boundary
+            // type for browser-stored data).
+            comp={{ ...match, scoring_completed: match.scoring_pct }}
+          />
         ))}
       </div>
       {filtered.length > INITIAL_VISIBLE && (

--- a/lib/competition-store.ts
+++ b/lib/competition-store.ts
@@ -46,7 +46,10 @@ export function saveRecentCompetition(
       name: match.name,
       venue: match.venue,
       date: match.date,
-      scoring_completed: match.scoring_completed,
+      // Boundary mapping: MatchResponse uses the renamed `scoring_pct`,
+      // StoredCompetition keeps `scoring_completed` so existing browser
+      // localStorage entries don't lose the field on read.
+      scoring_completed: match.scoring_pct,
       last_visited: Date.now(),
     };
     const updated = [entry, ...existing].slice(0, MAX_RECENT);

--- a/lib/match-data.ts
+++ b/lib/match-data.ts
@@ -354,7 +354,7 @@ export async function fetchMatchData(
     stages_count: ev.stages_count ?? stages.length,
     competitors_count: ev.competitors_count ?? competitors.length,
     max_competitors: ev.max_competitors ?? null,
-    scoring_completed: scoringPct,
+    scoring_pct: scoringPct,
     match_status: ev.status ?? "on",
     results_status: ev.results ?? "org",
     registration_status: ev.registration ?? "cl",

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -41,7 +41,7 @@ export function useMatchQuery(ct: string, id: string) {
       const isComplete =
         data.match_status === "cp" ||
         data.match_status === "cs" ||
-        data.scoring_completed >= 100;
+        data.scoring_pct >= 100;
       return isComplete ? false : 30_000;
     },
     enabled: Boolean(ct && id),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -101,7 +101,12 @@ export interface MatchResponse {
   competitors_count: number;
   /** Maximum number of competitors allowed; null if not set. */
   max_competitors: number | null;
-  scoring_completed: number; // percentage 0-100
+  /** Match-level scoring percentage (0-100), aggregated from per-stage
+   *  `scoring_progress` via `computeMatchScoringPct`. The internal name
+   *  matches the underlying semantic (a percentage, not a boolean). The
+   *  v1 surface keeps the legacy `scoring_completed` name -- the v1 wrapper
+   *  re-maps from this field. */
+  scoring_pct: number;
   /** SSI match lifecycle status: "dr" Draft | "on" Active | "ol" Active/no-self-edit | "pr" Preliminary | "cp" Completed | "cs" Cancelled */
   match_status: string;
   /** SSI results visibility: "org" organizers-only | "stg" scores-public | "cmp" participants-only | "all" publicly published */
@@ -610,7 +615,8 @@ export interface PopularMatch {
   name: string;
   venue: string | null;
   date: string | null;
-  scoring_completed: number;
+  /** Match-level scoring percentage (0-100). Same semantic as `MatchResponse.scoring_pct`. */
+  scoring_pct: number;
 }
 
 export interface EventSummary {

--- a/scripts/release-mock-data.ts
+++ b/scripts/release-mock-data.ts
@@ -27,7 +27,7 @@ export const MOCK_MATCH: MatchResponse = {
   region: "SWE",
   stages_count: 6,
   competitors_count: 48,
-  scoring_completed: 100,
+  scoring_pct: 100,
   match_status: "cp",
   results_status: "all",
   is_live_scores_accessible: true,

--- a/scripts/warm-cache.ts
+++ b/scripts/warm-cache.ts
@@ -166,7 +166,7 @@ interface EventSummary {
 
 interface MatchResponse {
   name: string;
-  scoring_completed: number;
+  scoring_pct: number;
   competitors_count: number;
   stages_count: number;
   date: string | null;
@@ -312,7 +312,7 @@ async function main(): Promise<void> {
     }
 
     const fetchMs = Date.now() - t0;
-    const scoring = matchResponse.scoring_completed;
+    const scoring = matchResponse.scoring_pct;
     const matchDate = matchResponse.date ? new Date(matchResponse.date) : null;
     const daysSince = matchDate ? (Date.now() - matchDate.getTime()) / 86_400_000 : 99;
 

--- a/tests/components/match-header.test.tsx
+++ b/tests/components/match-header.test.tsx
@@ -16,7 +16,7 @@ const baseMatch: MatchResponse = {
   region: "SWE",
   stages_count: 8,
   competitors_count: 105,
-  scoring_completed: 56,
+  scoring_pct: 56,
   match_status: "on",
   results_status: "org",
   is_live_scores_accessible: false,
@@ -57,18 +57,18 @@ describe("MatchHeader", () => {
     expect(screen.getByText("SWE")).toBeInTheDocument();
   });
 
-  it("shows 56% progress for scoring_completed=56", () => {
+  it("shows 56% progress for scoring_pct=56", () => {
     render(<MatchHeader match={baseMatch} />);
     expect(screen.getByText("56%")).toBeInTheDocument();
   });
 
-  it("shows 'Complete' when scoring_completed=100", () => {
-    render(<MatchHeader match={{ ...baseMatch, scoring_completed: 100 }} />);
+  it("shows 'Complete' when scoring_pct=100", () => {
+    render(<MatchHeader match={{ ...baseMatch, scoring_pct: 100 }} />);
     expect(screen.getByText("Complete")).toBeInTheDocument();
   });
 
-  it("shows 0% progress for scoring_completed=0", () => {
-    render(<MatchHeader match={{ ...baseMatch, scoring_completed: 0 }} />);
+  it("shows 0% progress for scoring_pct=0", () => {
+    render(<MatchHeader match={{ ...baseMatch, scoring_pct: 0 }} />);
     expect(screen.getByText("0%")).toBeInTheDocument();
   });
 

--- a/tests/components/popular-matches.test.tsx
+++ b/tests/components/popular-matches.test.tsx
@@ -35,7 +35,7 @@ const sampleMatches: PopularMatch[] = [
     name: "Regional Open 2025",
     venue: "Main Range",
     date: "2025-04-15T09:00:00+00:00",
-    scoring_completed: 100,
+    scoring_pct: 100,
   },
   {
     ct: "22",
@@ -43,7 +43,7 @@ const sampleMatches: PopularMatch[] = [
     name: "Spring Invitational",
     venue: null,
     date: null,
-    scoring_completed: 60,
+    scoring_pct: 60,
   },
 ];
 

--- a/tests/e2e/drawer-collapsible-toggle.spec.ts
+++ b/tests/e2e/drawer-collapsible-toggle.spec.ts
@@ -17,7 +17,7 @@ const MOCK_MATCH: MatchResponse = {
   region: "SWE",
   stages_count: 3,
   competitors_count: 10,
-  scoring_completed: 100,
+  scoring_pct: 100,
   match_status: "cp",
   results_status: "org",
   is_live_scores_accessible: false,

--- a/tests/e2e/scoreboard.spec.ts
+++ b/tests/e2e/scoreboard.spec.ts
@@ -15,7 +15,7 @@ const MOCK_MATCH: MatchResponse = {
   region: "SWE",
   stages_count: 3,
   competitors_count: 10,
-  scoring_completed: 75,
+  scoring_pct: 75,
   match_status: "on",
   results_status: "org",
   is_live_scores_accessible: false,
@@ -162,12 +162,12 @@ const MOCK_COMPARE: CompareResponse = {
 
 // Far-future date keeps daysSinceMatchStart and daysSinceEnd negative, which
 // prevents detectMatchView from ever flipping to "coaching" as time passes.
-// scoring_completed=75 + results_status="org" → effectiveMode === "live".
+// scoring_pct=75 + results_status="org" → effectiveMode === "live".
 const MOCK_LIVE_MATCH: typeof MOCK_MATCH = {
   ...MOCK_MATCH,
   date: "2099-12-30T09:00:00+00:00",
   ends: "2099-12-31T09:00:00+00:00",
-  scoring_completed: 75,
+  scoring_pct: 75,
   results_status: "org",
   match_status: "on",
 };

--- a/tests/unit/api-v1-routes.test.ts
+++ b/tests/unit/api-v1-routes.test.ts
@@ -168,7 +168,7 @@ describe("/api/v1/match/[ct]/[id]", () => {
       stages_count: 12,
       competitors_count: 200,
       max_competitors: 240,
-      scoring_completed: 100,
+      scoring_pct: 100,
       match_status: "cp",
       results_status: "all",
       is_live_scores_accessible: true,


### PR DESCRIPTION
## Summary

Internal-only rename. The field had been carrying a name that suggests a boolean ("completed") for what is actually a percentage 0-100. Aligning the type with its semantic.

## Boundaries kept on the legacy name

To avoid disrupting external state, the following stay on `scoring_completed`:

| Boundary | Why | How |
|---|---|---|
| **v1 API contract** | Locked by Zod schema (`lib/api-v1-schemas.ts`); external consumers (splitsmith) pin to it | `/api/v1/match/{ct}/{id}` wrapper re-maps `scoring_pct → scoring_completed` before returning. Schema unchanged. v1 snapshot unchanged. |
| **Browser localStorage** | `StoredCompetition` is what the user has stored from prior visits | `lib/competition-store.ts` maps `match.scoring_pct → scoring_completed` at write time. Existing entries keep working. |
| **Sync payload** | `SyncPayload.recentCompetitions[].scoring_completed` is `version: 1` and serialized cross-device | Boundary type unchanged. |
| **Database column** | `matches.scoring_completed` (D1 + SQLite) | Renaming the column would force a migration without functional benefit. |
| **GraphQL/SSI comments** | `IpscMatchNode.scoring_completed` is the SSI-side deprecated field | Comments still reference the upstream name verbatim. |

`PopularMatch` (the internal `/api/popular-matches` response shape) IS renamed since it's not on the v1 surface. `components/popular-matches.tsx` maps at the boundary to feed the shared `CompetitionCardData` (which keeps the legacy name to match `StoredCompetition`).

## Strategy

Renamed the type definition first, then let `tsc --noEmit` enumerate every consumer via TS2339 errors. 29 errors across 18 files mapped exactly which sites needed updating. No grep-and-replace blind passes; every change traced by the typechecker.

## Net

`+86 / -39` across 20 files.

## Test plan

- [x] `pnpm -w run lint` — clean
- [x] `pnpm -w run typecheck` — clean
- [x] `pnpm -w test` — 1712 / 1712 (the v1 schema parse confirms the boundary re-mapping works end-to-end)
- [x] No snapshot drift — the v1 wrapper's re-map keeps the externally-observable byte shape identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)