### PR TITLE
refactor(telemetry): write via Pipelines instead of raw R2 PUTs

### DIFF
--- a/.claude/skills/r2-telemetry/scripts/fetch.py
+++ b/.claude/skills/r2-telemetry/scripts/fetch.py
@@ -1,11 +1,22 @@
 #!/usr/bin/env python3
 """
-Fetch + filter telemetry events from the R2 NDJSON store.
+Fetch + filter telemetry events from the R2 Parquet store.
 
-Auth: reads the wrangler-cached OAuth token and account ID. Run
-`wrangler login` first if the token has expired.
+Backed by Cloudflare Pipelines (since 2026-05): a Workers stream
+coalesces events across isolates and writes Parquet batches to R2 every
+5 min, partitioned by UTC day:
 
-Usage examples (see argparse below for the full set):
+    pipelines/cache-telemetry/YYYY-MM-DD/{uuid}.parquet
+
+This script downloads any new Parquet files in the requested window to
+~/.cache/ssi-scoreboard-telemetry/{env}/ (shared with the usage-analysis
+skill) and runs the filter as a DuckDB query. No more line-by-line
+NDJSON parsing.
+
+Auth: reads the wrangler-cached OAuth token. Run `wrangler login` first
+if the token has expired.
+
+Usage examples:
 
     # last 2 hours, all domains
     fetch.py --since 2h
@@ -26,13 +37,14 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
+import random
 import re
+import subprocess
 import sys
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
@@ -45,15 +57,20 @@ WRANGLER_CONFIG_CANDIDATES = [
     Path.home() / ".wrangler/config/default.toml",                      # legacy
 ]
 
-# This account ID is specific to this repo's CF account. Run
-# `wrangler whoami` to verify if you're hitting auth errors after
-# switching accounts.
 ACCOUNT_ID = "e1854db8e2a989281305b1b229319c31"
 
 BUCKETS = {
     "prod": "ssi-scoreboard-telemetry",
     "staging": "ssi-scoreboard-telemetry-staging",
 }
+
+# Shared with the usage-analysis skill. Each Parquet file is immutable
+# (Pipelines writes once with a UUID name), so on-disk hits are safe.
+CACHE_ROOT = Path.home() / ".cache" / "ssi-scoreboard-telemetry"
+
+MAX_RETRIES = 5
+INITIAL_BACKOFF_SECONDS = 1.0
+MAX_BACKOFF_SECONDS = 30.0
 
 
 def read_oauth_token() -> str:
@@ -63,10 +80,7 @@ def read_oauth_token() -> str:
                 m = re.match(r'^oauth_token\s*=\s*"([^"]+)"', line)
                 if m:
                     return m.group(1)
-    sys.exit(
-        "Could not find oauth_token in wrangler config. "
-        "Run `wrangler login` first."
-    )
+    sys.exit("Could not find oauth_token. Run `wrangler login` first.")
 
 
 # ── Time-range expansion ────────────────────────────────────────────
@@ -100,19 +114,48 @@ def day_prefixes(since: datetime, until: datetime) -> list[str]:
 # ── R2 REST API ─────────────────────────────────────────────────────
 
 
-def cf_get(path: str, token: str, accept_404: bool = False) -> bytes | None:
+def cf_get(path: str, token: str) -> bytes:
     url = f"https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}{path}"
-    req = Request(url, headers={"Authorization": f"Bearer {token}"})
-    try:
-        with urlopen(req, timeout=30) as r:
-            return r.read()
-    except HTTPError as e:
-        if accept_404 and e.code == 404:
-            return None
-        msg = e.read().decode("utf-8", errors="replace")[:300]
-        sys.exit(f"HTTP {e.code} on {path}: {msg}")
-    except URLError as e:
-        sys.exit(f"Network error on {path}: {e}")
+    backoff = INITIAL_BACKOFF_SECONDS
+    last_err: str | None = None
+    for attempt in range(MAX_RETRIES + 1):
+        req = Request(url, headers={"Authorization": f"Bearer {token}"})
+        try:
+            with urlopen(req, timeout=30) as r:
+                return r.read()
+        except HTTPError as e:
+            if e.code == 429 or e.code >= 500:
+                if attempt >= MAX_RETRIES:
+                    last_err = f"HTTP {e.code} after {MAX_RETRIES} retries"
+                    break
+                retry_after = e.headers.get("Retry-After") if e.headers else None
+                if retry_after and retry_after.isdigit():
+                    sleep_for = float(retry_after)
+                else:
+                    sleep_for = backoff + random.uniform(0, backoff * 0.5)
+                sleep_for = min(sleep_for, MAX_BACKOFF_SECONDS)
+                print(
+                    f"# {e.code} on {path[:80]} -- retry {attempt + 1}/{MAX_RETRIES} in {sleep_for:.1f}s",
+                    file=sys.stderr,
+                )
+                time.sleep(sleep_for)
+                backoff = min(backoff * 2, MAX_BACKOFF_SECONDS)
+                continue
+            msg = e.read().decode("utf-8", errors="replace")[:300]
+            sys.exit(f"HTTP {e.code} on {path}: {msg}")
+        except URLError as e:
+            if attempt >= MAX_RETRIES:
+                last_err = f"network error: {e}"
+                break
+            sleep_for = min(backoff + random.uniform(0, backoff * 0.5), MAX_BACKOFF_SECONDS)
+            print(
+                f"# network error on {path[:80]} -- retry {attempt + 1}/{MAX_RETRIES} in {sleep_for:.1f}s",
+                file=sys.stderr,
+            )
+            time.sleep(sleep_for)
+            backoff = min(backoff * 2, MAX_BACKOFF_SECONDS)
+            continue
+    sys.exit(f"Exhausted retries on {path}: {last_err}")
 
 
 def list_objects(bucket: str, prefix: str, token: str) -> list[str]:
@@ -124,8 +167,6 @@ def list_objects(bucket: str, prefix: str, token: str) -> list[str]:
         if cursor:
             path += f"&cursor={quote(cursor)}"
         body = cf_get(path, token)
-        if body is None:
-            break
         data = json.loads(body)
         result = data.get("result") or []
         for obj in result:
@@ -136,23 +177,66 @@ def list_objects(bucket: str, prefix: str, token: str) -> list[str]:
     return keys
 
 
-def fetch_object(bucket: str, key: str, token: str) -> str:
-    """Return the NDJSON body of one object."""
-    body = cf_get(
-        f"/r2/buckets/{bucket}/objects/{quote(key, safe='/')}", token
-    )
-    return body.decode("utf-8") if body else ""
+def sync_window(env: str, since_ts: datetime, until_ts: datetime, token: str) -> Path:
+    """Download any Parquet files in [since, until] we don't already have."""
+    bucket = BUCKETS[env]
+    root = CACHE_ROOT / env
+    root.mkdir(parents=True, exist_ok=True)
+    days = day_prefixes(since_ts, until_ts)
+    print(f"# scanning {len(days)} day prefix(es) in bucket {bucket}", file=sys.stderr)
+    keys: list[str] = []
+    for d in days:
+        keys.extend(list_objects(bucket, f"pipelines/cache-telemetry/{d}/", token))
+    print(f"# {len(keys)} R2 object(s)", file=sys.stderr)
+
+    def fetch_one(key: str) -> bool:
+        dest = root / key
+        if dest.exists():
+            return False
+        body = cf_get(f"/r2/buckets/{bucket}/objects/{quote(key, safe='/')}", token)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        tmp = dest.with_name(dest.name + ".tmp")
+        tmp.write_bytes(body)
+        tmp.replace(dest)
+        return True
+
+    new_count = 0
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        for downloaded in pool.map(fetch_one, keys):
+            if downloaded:
+                new_count += 1
+    print(f"# downloaded {new_count} new file(s) ({len(keys) - new_count} cached)", file=sys.stderr)
+    return root
 
 
-# ── Filtering ───────────────────────────────────────────────────────
+# ── Filtering: SQL builder ─────────────────────────────────────────
 
 WHERE_RE = re.compile(r"^([^=!]+)(==|=|!=)(.*)$")
 
 
-def parse_where(raw: list[str]) -> list[tuple[str, str, str]]:
-    """Parse `--where key=value,key=value` into (key, op, value) tuples."""
-    out: list[tuple[str, str, str]] = []
-    for chunk in raw:
+def sql_str(s: str) -> str:
+    """Single-quote a string for embedding in DuckDB SQL."""
+    return "'" + s.replace("'", "''") + "'"
+
+
+def field(key: str) -> str:
+    """SQL fragment to extract a field from the doubly-wrapped value column."""
+    return f"json_extract_string(value, '$.value.{key}')"
+
+
+def build_query(args: argparse.Namespace, since_iso: str, until_iso: str, glob: str) -> str:
+    where: list[str] = [
+        f"{field('ts')} >= {sql_str(since_iso)}",
+        f"{field('ts')} <= {sql_str(until_iso)}",
+    ]
+    if args.domain:
+        where.append(f"{field('domain')} = {sql_str(args.domain)}")
+    if args.op:
+        where.append(f"{field('op')} = {sql_str(args.op)}")
+    if args.shooter is not None:
+        where.append(f"cast({field('shooterId')} as bigint) = {int(args.shooter)}")
+
+    for chunk in args.where:
         for clause in chunk.split(","):
             clause = clause.strip()
             if not clause:
@@ -160,69 +244,61 @@ def parse_where(raw: list[str]) -> list[tuple[str, str, str]]:
             m = WHERE_RE.match(clause)
             if not m:
                 sys.exit(f"--where clause must be key=value, got {clause!r}")
-            out.append((m.group(1).strip(), m.group(2), m.group(3).strip()))
-    return out
+            key, op_, val = m.group(1).strip(), m.group(2), m.group(3).strip()
+            if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+                sys.exit(f"--where key must be a simple identifier, got {key!r}")
+            sql_op = "!=" if op_ == "!=" else "="
+            where.append(f"lower({field(key)}) {sql_op} lower({sql_str(val)})")
+
+    if args.match:
+        # substring match anywhere in the value JSON
+        where.append(f"value ILIKE {sql_str('%' + args.match + '%')}")
+
+    where_sql = " AND ".join(where)
+    src = f"read_parquet({sql_str(glob)}, union_by_name = true)"
+
+    if args.group_by:
+        keys = [k.strip() for k in args.group_by.split(",") if k.strip()]
+        for k in keys:
+            if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", k):
+                sys.exit(f"--group-by key must be a simple identifier, got {k!r}")
+        cols = ", ".join(f"{field(k)} AS {k}" for k in keys)
+        group = ", ".join(field(k) for k in keys)
+        return (
+            f"SELECT {cols}, count(*) AS count "
+            f"FROM {src} "
+            f"WHERE {where_sql} "
+            f"GROUP BY {group} "
+            f"ORDER BY count DESC;"
+        )
+
+    # SELECT all common fields + the inner event JSON for the timeline renderer.
+    return (
+        f"SELECT "
+        f"  {field('ts')} AS ts, "
+        f"  {field('domain')} AS domain, "
+        f"  {field('op')} AS op, "
+        f"  json_extract(value, '$.value') AS j "
+        f"FROM {src} "
+        f"WHERE {where_sql} "
+        f"ORDER BY ts DESC "
+        f"LIMIT {int(args.limit)};"
+    )
 
 
-def matches_clause(ev: dict[str, Any], key: str, op: str, value: str) -> bool:
-    raw = ev.get(key)
-    raw_str = str(raw).lower() if raw is not None else ""
-    target = value.lower()
-    if op == "!=":
-        return raw_str != target
-    # treat = and == identically — common typo proofing
-    return raw_str == target
+# ── DuckDB invocation + output ─────────────────────────────────────
 
 
-def passes_filters(
-    ev: dict[str, Any],
-    domain: str | None,
-    op: str | None,
-    where: list[tuple[str, str, str]],
-    match_substr: str | None,
-    shooter_id: int | None,
-    since_ts: datetime,
-    until_ts: datetime,
-) -> bool:
-    if domain and ev.get("domain") != domain:
-        return False
-    if op and ev.get("op") != op:
-        return False
-    if match_substr is not None:
-        # match anywhere across any string-valued field
-        joined = " ".join(str(v) for v in ev.values() if isinstance(v, (str, int, float)))
-        if match_substr not in joined:
-            return False
-    if shooter_id is not None and ev.get("shooterId") != shooter_id:
-        return False
-    if where:
-        for k, o, v in where:
-            if not matches_clause(ev, k, o, v):
-                return False
-    ts = ev.get("ts")
-    if isinstance(ts, str):
-        try:
-            ev_ts = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-            if ev_ts < since_ts or ev_ts > until_ts:
-                return False
-        except ValueError:
-            pass
-    return True
-
-
-# ── Output ──────────────────────────────────────────────────────────
-
-
-def render_timeline(events: list[dict[str, Any]]) -> None:
-    events.sort(key=lambda e: e.get("ts", ""))
-    for ev in events:
-        ts = ev.get("ts", "")[:19]  # YYYY-MM-DDTHH:MM:SS
-        dom = ev.get("domain", "?")
-        op = ev.get("op", "?")
-        # Compact summary of the most useful 2-3 fields per domain
-        summary_keys = SUMMARY_KEYS.get(dom, [])
-        bits = [f"{k}={ev.get(k)!s}" for k in summary_keys if k in ev]
-        print(f"{ts}Z  {dom:9}  {op:30}  {' '.join(bits)}")
+def run_duckdb(sql: str, fmt: str) -> str:
+    flag = {"json": "-json", "timeline": "-csv"}.get(fmt, "-csv")
+    proc = subprocess.run(
+        ["duckdb", flag, "-c", sql],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        sys.exit(f"duckdb query failed:\n{proc.stderr}")
+    return proc.stdout
 
 
 SUMMARY_KEYS = {
@@ -233,20 +309,26 @@ SUMMARY_KEYS = {
 }
 
 
-def render_group(events: list[dict[str, Any]], keys: list[str]) -> None:
-    counts: dict[tuple[str, ...], int] = {}
-    for ev in events:
-        k = tuple(str(ev.get(key, "<none>")) for key in keys)
-        counts[k] = counts.get(k, 0) + 1
-    rows = sorted(counts.items(), key=lambda kv: -kv[1])
-    widths = [max(len(keys[i]), max((len(k[i]) for k, _ in rows), default=0)) for i in range(len(keys))]
-    header = "  ".join(k.ljust(w) for k, w in zip(keys, widths)) + "  count"
-    print(header)
-    print("-" * len(header))
-    for k, c in rows:
-        line = "  ".join(v.ljust(w) for v, w in zip(k, widths)) + f"  {c}"
-        print(line)
-    print(f"\n{sum(c for _, c in rows)} events across {len(rows)} groups")
+def render_timeline_csv(csv: str) -> None:
+    import csv as _csv
+    from io import StringIO
+
+    reader = _csv.DictReader(StringIO(csv))
+    for row in reader:
+        ts = (row.get("ts") or "")[:19]
+        dom = row.get("domain", "?") or "?"
+        op = row.get("op", "?") or "?"
+        # j is the inner event JSON; parse it for the summary fields.
+        try:
+            j = json.loads(row.get("j") or "{}")
+        except (TypeError, ValueError):
+            j = {}
+        bits = []
+        for k in SUMMARY_KEYS.get(dom, []):
+            v = j.get(k)
+            if v not in (None, ""):
+                bits.append(f"{k}={v}")
+        print(f"{ts}Z  {dom:9}  {op:30}  {' '.join(bits)}")
 
 
 # ── Main ────────────────────────────────────────────────────────────
@@ -269,7 +351,6 @@ def main() -> None:
 
     if args.env not in BUCKETS:
         sys.exit(f"--env must be one of: {', '.join(BUCKETS)}")
-    bucket = BUCKETS[args.env]
 
     now = datetime.now(timezone.utc)
     since_ts = parse_since(args.since, now)
@@ -282,47 +363,31 @@ def main() -> None:
         sys.exit("--since is after --until")
 
     token = read_oauth_token()
-    where = parse_where(args.where)
+    cache_root = sync_window(args.env, since_ts, until_ts, token)
 
-    # Discover objects across the relevant day prefixes.
-    days = day_prefixes(since_ts, until_ts)
-    print(f"# scanning {len(days)} day prefix(es) in bucket {bucket}", file=sys.stderr)
-    keys: list[str] = []
-    for d in days:
-        keys.extend(list_objects(bucket, f"cache-telemetry/{d}/", token))
-    print(f"# {len(keys)} R2 object(s)", file=sys.stderr)
+    glob = str(cache_root / "pipelines" / "cache-telemetry" / "**" / "*.parquet")
+    sql = build_query(args, since_ts.isoformat().replace("+00:00", "Z"),
+                      until_ts.isoformat().replace("+00:00", "Z"), glob)
 
-    # Fetch in parallel.
-    events: list[dict[str, Any]] = []
-    with ThreadPoolExecutor(max_workers=8) as pool:
-        for body in pool.map(lambda k: fetch_object(bucket, k, token), keys):
-            for line in body.splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    ev = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if passes_filters(ev, args.domain, args.op, where, args.match, args.shooter, since_ts, until_ts):
-                    events.append(ev)
-
-    print(f"# {len(events)} event(s) after filtering", file=sys.stderr)
-
-    if args.group_by:
-        keys = [k.strip() for k in args.group_by.split(",") if k.strip()]
-        render_group(events, keys)
-        return
-
-    # Apply limit (most recent first when applicable)
-    events.sort(key=lambda e: e.get("ts", ""), reverse=True)
-    events = events[: args.limit]
-
-    if args.format == "timeline":
-        render_timeline(events)
+    if args.format == "json":
+        out = run_duckdb(sql, "json")
+        sys.stdout.write(out)
+    elif args.group_by:
+        # CSV with header — print as a simple aligned table.
+        import csv as _csv
+        from io import StringIO
+        out = run_duckdb(sql, "timeline")
+        reader = _csv.reader(StringIO(out))
+        rows = list(reader)
+        if not rows:
+            return
+        widths = [max(len(c) for c in col) for col in zip(*rows)]
+        for r in rows:
+            print("  ".join(c.ljust(w) for c, w in zip(r, widths)))
+        print(f"\n{len(rows) - 1} groups")
     else:
-        for ev in events:
-            print(json.dumps(ev))
+        out = run_duckdb(sql, "timeline")
+        render_timeline_csv(out)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/usage-analysis/scripts/analyze.py
+++ b/.claude/skills/usage-analysis/scripts/analyze.py
@@ -5,8 +5,8 @@ and run canned or ad-hoc SQL against it.
 
 Layout:
     ~/.cache/ssi-scoreboard-telemetry/
-        prod/cache-telemetry/YYYY-MM-DD/*.ndjson
-        staging/cache-telemetry/YYYY-MM-DD/*.ndjson
+        prod/pipelines/cache-telemetry/YYYY-MM-DD/*.parquet
+        staging/pipelines/cache-telemetry/YYYY-MM-DD/*.parquet
         prod.duckdb
         staging.duckdb
 
@@ -29,9 +29,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import random
 import re
 import subprocess
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -55,6 +57,10 @@ BUCKETS = {
 CACHE_ROOT = Path.home() / ".cache" / "ssi-scoreboard-telemetry"
 SETUP_SQL = Path(__file__).resolve().parent / "setup.sql"
 
+MAX_RETRIES = 5
+INITIAL_BACKOFF_SECONDS = 1.0
+MAX_BACKOFF_SECONDS = 30.0
+
 
 def read_oauth_token() -> str:
     for path in WRANGLER_CONFIG_CANDIDATES:
@@ -68,15 +74,46 @@ def read_oauth_token() -> str:
 
 def cf_get(path: str, token: str) -> bytes:
     url = f"https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}{path}"
-    req = Request(url, headers={"Authorization": f"Bearer {token}"})
-    try:
-        with urlopen(req, timeout=30) as r:
-            return r.read()
-    except HTTPError as e:
-        body = e.read().decode("utf-8", errors="replace")[:300]
-        sys.exit(f"HTTP {e.code} on {path}: {body}")
-    except URLError as e:
-        sys.exit(f"Network error on {path}: {e}")
+    backoff = INITIAL_BACKOFF_SECONDS
+    last_err: str | None = None
+    for attempt in range(MAX_RETRIES + 1):
+        req = Request(url, headers={"Authorization": f"Bearer {token}"})
+        try:
+            with urlopen(req, timeout=30) as r:
+                return r.read()
+        except HTTPError as e:
+            if e.code == 429 or e.code >= 500:
+                if attempt >= MAX_RETRIES:
+                    last_err = f"HTTP {e.code} after {MAX_RETRIES} retries"
+                    break
+                retry_after = e.headers.get("Retry-After") if e.headers else None
+                if retry_after and retry_after.isdigit():
+                    sleep_for = float(retry_after)
+                else:
+                    sleep_for = backoff + random.uniform(0, backoff * 0.5)
+                sleep_for = min(sleep_for, MAX_BACKOFF_SECONDS)
+                print(
+                    f"# {e.code} on {path[:80]} -- retry {attempt + 1}/{MAX_RETRIES} in {sleep_for:.1f}s",
+                    file=sys.stderr,
+                )
+                time.sleep(sleep_for)
+                backoff = min(backoff * 2, MAX_BACKOFF_SECONDS)
+                continue
+            body = e.read().decode("utf-8", errors="replace")[:300]
+            sys.exit(f"HTTP {e.code} on {path}: {body}")
+        except URLError as e:
+            if attempt >= MAX_RETRIES:
+                last_err = f"network error: {e}"
+                break
+            sleep_for = min(backoff + random.uniform(0, backoff * 0.5), MAX_BACKOFF_SECONDS)
+            print(
+                f"# network error on {path[:80]} -- retry {attempt + 1}/{MAX_RETRIES} in {sleep_for:.1f}s",
+                file=sys.stderr,
+            )
+            time.sleep(sleep_for)
+            backoff = min(backoff * 2, MAX_BACKOFF_SECONDS)
+            continue
+    sys.exit(f"Exhausted retries on {path}: {last_err}")
 
 
 # ── Sync ────────────────────────────────────────────────────────────
@@ -143,7 +180,7 @@ def cmd_sync(args: argparse.Namespace) -> None:
     print(f"# scanning {len(days)} day(s) in {bucket}", file=sys.stderr)
     all_objects: list[dict] = []
     for day in days:
-        all_objects.extend(list_objects(bucket, f"cache-telemetry/{day}/", token))
+        all_objects.extend(list_objects(bucket, f"pipelines/cache-telemetry/{day}/", token))
     print(f"# {len(all_objects)} object(s) on R2", file=sys.stderr)
 
     new_count = 0

--- a/.claude/skills/usage-analysis/scripts/setup.sql
+++ b/.claude/skills/usage-analysis/scripts/setup.sql
@@ -3,25 +3,44 @@
 -- Run automatically by analyze.py whenever the .duckdb file is opened.
 -- Idempotent — safe to re-run after schema changes.
 --
+-- Pipelines (since 2026-05) writes Parquet partitioned by UTC day under
+-- pipelines/cache-telemetry/YYYY-MM-DD/{uuid}.parquet. The schemaless
+-- stream stores every row as a single VARCHAR `value` column whose
+-- content is the JSON-serialised input record `{"value": <event>}` —
+-- so the actual event lives at JSON path `$.value` inside that string.
+-- We promote common fields to columns here and expose `j` (the full
+-- event as JSON) for ad-hoc field access.
+--
 -- Usage from the CLI (after analyze.py sync):
 --   duckdb ~/.cache/ssi-scoreboard-telemetry/prod.duckdb
 --   D> SELECT count(*) FROM events;
 --   D> SELECT op, count(*) FROM usage_events GROUP BY op ORDER BY 2 DESC;
+--   D> SELECT j->>'$.matchKey' FROM cache_events LIMIT 5;
 
 INSTALL json;
 LOAD json;
 
 -- The CACHE_DIR placeholder is replaced by analyze.py before execution.
--- We point the view at a glob so newly-synced files appear automatically.
-
-CREATE OR REPLACE VIEW events AS
+CREATE OR REPLACE VIEW raw_events AS
 SELECT *
-FROM read_ndjson(
-  'CACHE_DIR/cache-telemetry/**/*.ndjson',
+FROM read_parquet(
+  'CACHE_DIR/pipelines/cache-telemetry/**/*.parquet',
   filename = true,
   union_by_name = true,
-  ignore_errors = true
+  hive_partitioning = false
 );
+
+-- Promote common fields to columns; keep the rest in `j` for queries
+-- that need domain-specific shapes (matchKey, ttl, scoringPct, etc.).
+CREATE OR REPLACE VIEW events AS
+SELECT
+  json_extract_string(value, '$.value.ts')        AS ts,
+  json_extract_string(value, '$.value.domain')    AS domain,
+  json_extract_string(value, '$.value.op')        AS op,
+  json_extract_string(value, '$.value.via')       AS via,
+  json_extract(value, '$.value')                  AS j,
+  filename
+FROM raw_events;
 
 CREATE OR REPLACE VIEW cache_events    AS SELECT * FROM events WHERE domain = 'cache';
 CREATE OR REPLACE VIEW upstream_events AS SELECT * FROM events WHERE domain = 'upstream';

--- a/lib/telemetry-sinks-cf.ts
+++ b/lib/telemetry-sinks-cf.ts
@@ -1,30 +1,32 @@
-// Cloudflare-target extra sinks — registers an R2 NDJSON sink when the
-// `TELEMETRY` binding is present.
+// Cloudflare-target extra sinks — registers a Pipelines sink when the
+// `TELEMETRY_PIPELINE` binding is present.
 //
-// ── Why R2 ───────────────────────────────────────────────────────────
-// Cloudflare Workers Logs retains for 3 days only. Diagnosing a "data
-// stuck" report often requires looking back further. R2 free tier:
-//   - 10 GB storage
-//   - 1M Class A ops/month (PUT/LIST)
-//   - 10M Class B ops/month (GET)
-// Plenty of headroom for decision-level telemetry with a 30-day lifecycle.
+// ── Why Pipelines (not raw R2 PUTs) ──────────────────────────────────
+// Workers isolates are short-lived and uncoordinated. Writing one R2
+// object per isolate flush ("small-files problem") produces thousands
+// of tiny .ndjson files per day, which makes the read side painful:
+// listing pages slowly, and Cloudflare's REST API rate-limits LIST/GET
+// long before we hit any byte budget.
 //
-// ── How writes work ──────────────────────────────────────────────────
-// R2 has no native append. Concurrent read-modify-write would race, so
-// instead each flush writes a *unique-keyed* NDJSON object:
+// Pipelines coalesces events across isolates and writes one Parquet
+// batch to R2 every 300s (or every 5MB), partitioned by UTC day:
 //
-//   cache-telemetry/YYYY-MM-DD/HHmmss-NNNN.ndjson
+//   pipelines/cache-telemetry/YYYY-MM-DD/{uuid}.parquet
 //
-// The day prefix groups objects for easy listing; the nonce avoids
-// collisions across concurrent isolates. Lifecycle rules on the bucket
-// (set once via `wrangler r2 bucket lifecycle set`) auto-delete after
-// 30 days so this never grows unbounded.
+// At our volume this collapses ~2500 files/day → ~288 files/day
+// (24h / 5min) and turns NDJSON-line-by-line scans into Parquet with
+// predicate pushdown for free. Provisioning lives in wrangler.toml.
+//
+// ── Wire format ──────────────────────────────────────────────────────
+// The stream was created without a schema, so each record is wrapped
+// as `{value: <event json>}` — DuckDB then queries fields via
+// `value->>'$.<key>'` (see the read scripts).
 //
 // ── Batching ─────────────────────────────────────────────────────────
 // Per-isolate in-memory buffer. The first event in a burst schedules a
 // flush via afterResponse() (ctx.waitUntil); subsequent events join the
-// buffer. The flush splices the whole buffer atomically, so concurrent
-// requests in the same isolate share a single PUT.
+// buffer. The flush sends the whole buffer in one .send() call so a
+// burst becomes a single ingest call to the Pipelines stream.
 //
 // ── Sampling ─────────────────────────────────────────────────────────
 // Per-domain sample rate, controlled by env vars TELEMETRY_SAMPLE_<DOMAIN>
@@ -39,21 +41,20 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { afterResponse } from "@/lib/background-impl";
 import type { TelemetrySink, EnrichedEvent } from "@/lib/telemetry";
 
-interface R2Bucket {
-  put(key: string, body: string): Promise<unknown>;
+interface PipelineBinding {
+  send(records: { value: EnrichedEvent }[]): Promise<unknown>;
 }
 interface CFEnvWithTelemetry {
-  TELEMETRY?: R2Bucket;
+  TELEMETRY_PIPELINE?: PipelineBinding;
 }
 
 // Default sample rates per domain. 1 = keep all; 0 = drop all; 0.1 = 10%.
 // Override per domain via TELEMETRY_SAMPLE_<DOMAIN>=<number>.
 //
-// As of Apr 2026: production sees ~3-6k requests/day. Even at 100% sampling
-// the usage domain produces ~600 R2 PUTs/day with per-isolate batching —
-// well under 2% of the 1M Class A free-tier monthly cap. With this user
-// base it pays to keep everything; tighten the usage rate later only if
-// traffic grows ~10x or the volume mix shifts.
+// At the volume this product runs (a few thousand requests/day) Pipelines
+// keeps full-fidelity ingest comfortably inside the R2 free tier even
+// without sampling — defaults stay at "keep all". Tighten only if a
+// specific domain proves too noisy.
 const DEFAULT_RATES: Record<string, number> = {
   cache: 1,
   upstream: 1,
@@ -81,48 +82,37 @@ function getDomainRate(domain: string): number {
 const buffer: EnrichedEvent[] = [];
 let flushScheduled = false;
 
-const r2Sink: TelemetrySink = (ev) => {
+const pipelineSink: TelemetrySink = (ev) => {
   if (!keepEvent(ev)) return;
-  const bucket = getR2Binding();
-  if (!bucket) return;
+  const pipeline = getPipelineBinding();
+  if (!pipeline) return;
 
   buffer.push(ev);
   if (flushScheduled) return;
   flushScheduled = true;
-  afterResponse(flushBuffer(bucket));
+  afterResponse(flushBuffer(pipeline));
 };
 
-function getR2Binding(): R2Bucket | null {
+function getPipelineBinding(): PipelineBinding | null {
   try {
     const { env } = getCloudflareContext() as unknown as { env: CFEnvWithTelemetry };
-    return env?.TELEMETRY ?? null;
+    return env?.TELEMETRY_PIPELINE ?? null;
   } catch {
     return null;
   }
 }
 
-async function flushBuffer(bucket: R2Bucket): Promise<void> {
+async function flushBuffer(pipeline: PipelineBinding): Promise<void> {
   const events = buffer.splice(0);
   flushScheduled = false;
   if (events.length === 0) return;
-  const body = events.map((e) => JSON.stringify(e)).join("\n") + "\n";
-  const key = makeObjectKey(new Date());
+  const records = events.map((ev) => ({ value: ev }));
   try {
-    await bucket.put(key, body);
+    await pipeline.send(records);
   } catch (err) {
     // One warning per flush — telemetry must never break the request path.
-    console.warn("[telemetry] R2 PUT failed:", err);
+    console.warn("[telemetry] Pipelines send failed:", err);
   }
-}
-
-function makeObjectKey(now: Date): string {
-  const iso = now.toISOString(); // 2026-04-28T13:24:05.123Z
-  const day = iso.slice(0, 10); // 2026-04-28
-  const time = iso.slice(11, 19).replace(/:/g, ""); // 132405
-  // 6-hex nonce — collision odds across concurrent isolates within the
-  // same second are ~0 for our request volume.
-  const nonce = Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, "0");
-  return `cache-telemetry/${day}/${time}-${nonce}.ndjson`;
 }
 
 function keepEvent(ev: EnrichedEvent): boolean {
@@ -132,7 +122,7 @@ function keepEvent(ev: EnrichedEvent): boolean {
   return Math.random() < rate;
 }
 
-export const extraSinks: TelemetrySink[] = [r2Sink];
+export const extraSinks: TelemetrySink[] = [pipelineSink];
 
 // Test-only — exported for unit tests of the sampler.
-export const _internal = { keepEvent, getDomainRate, makeObjectKey, DEFAULT_RATES };
+export const _internal = { keepEvent, getDomainRate, DEFAULT_RATES };

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -129,17 +129,3 @@ describe("per-domain sampling", () => {
   });
 });
 
-describe("R2 object key shape", () => {
-  it("produces day-prefixed keys with a nonce", () => {
-    const key = _internal.makeObjectKey(new Date("2026-04-28T13:24:05.123Z"));
-    expect(key).toMatch(/^cache-telemetry\/2026-04-28\/132405-[0-9a-f]{6}\.ndjson$/);
-  });
-
-  it("two consecutive keys differ (nonce)", () => {
-    const now = new Date("2026-04-28T13:24:05.123Z");
-    const a = _internal.makeObjectKey(now);
-    const b = _internal.makeObjectKey(now);
-    // Statistical: collisions are 1/16M.
-    expect(a).not.toBe(b);
-  });
-});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -71,14 +71,22 @@ database_name = "ssi-scoreboard-app-db-eu"
 database_id = "4a3d6cf5-31ce-4775-84f5-f9abee4206e2"  # patched by scripts/setup-d1.ts
 migrations_dir = "migrations"
 
-# R2 bucket for long-retention telemetry (cache decisions, etc.) — see
-# lib/telemetry-sinks-cf.ts. Free-tier friendly. One-time setup:
-#   wrangler r2 bucket create ssi-scoreboard-telemetry
-#   wrangler r2 bucket lifecycle add ssi-scoreboard-telemetry expire-30d "" \
-#     --expire-days 30 --force
-[[r2_buckets]]
-binding = "TELEMETRY"
-bucket_name = "ssi-scoreboard-telemetry"
+# Cloudflare Pipelines stream for telemetry events — see lib/telemetry-sinks-cf.ts.
+# The stream coalesces events across all isolates and writes Parquet batches to
+# R2 every 300s (or every 5MB). One-time provisioning:
+#   wrangler pipelines streams create ssi_telemetry --http-enabled false
+#   wrangler pipelines sinks create ssi_telemetry_r2 \
+#     --type r2 --bucket ssi-scoreboard-telemetry \
+#     --format parquet --compression zstd \
+#     --path 'pipelines/cache-telemetry/' --partitioning '%Y-%m-%d' \
+#     --roll-size 5 --roll-interval 300
+#   wrangler pipelines create ssi_telemetry \
+#     --sql 'INSERT INTO ssi_telemetry_r2 SELECT * FROM ssi_telemetry'
+# The `pipeline` field below is the *stream* id (CF's wrangler.toml field name
+# is historical — confusing but correct). Get it from `wrangler pipelines streams list`.
+[[pipelines]]
+binding = "TELEMETRY_PIPELINE"
+pipeline = "506f6888c6c9478e99ef925d50ce9aa5"
 
 [assets]
 directory = ".open-next/assets"
@@ -104,8 +112,8 @@ database_name = "ssi-scoreboard-app-db-staging-eu"
 database_id = "1b1c7faf-c206-41f6-9557-adbdf1c0ba18"  # patched by scripts/setup-d1.ts
 migrations_dir = "migrations"
 
-# Staging R2 bucket — same setup commands as prod, with --env staging:
-#   wrangler r2 bucket create ssi-scoreboard-telemetry-staging
-[[env.staging.r2_buckets]]
-binding = "TELEMETRY"
-bucket_name = "ssi-scoreboard-telemetry-staging"
+# Staging Pipelines stream (same provisioning as prod, with `_staging` suffix
+# and the staging bucket name). Stream id captured below; do not copy the prod id.
+[[env.staging.pipelines]]
+binding = "TELEMETRY_PIPELINE"
+pipeline = "d2fa22626af04c48bd9914574f9014a8"


### PR DESCRIPTION
## Summary

Replaces the per-isolate raw R2 PUT path in `lib/telemetry-sinks-cf.ts`
with a Cloudflare Pipelines binding. Pipelines coalesces events across
isolates and rolls Parquet batches into R2 every 5 min, partitioned
by UTC day:

```
pipelines/cache-telemetry/YYYY-MM-DD/{uuid}.parquet
```

At our volume that collapses ~2500 small NDJSON files/day to ~288
Parquet files/day. The CF REST API slowness + rate-limiting that made
the read scripts effectively unusable goes away.

- New: `[[pipelines]]` binding `TELEMETRY_PIPELINE` (top-level + staging)
- Removed: `[[r2_buckets]]` `TELEMETRY` binding (Pipelines owns the bucket now)
- `lib/telemetry-sinks-cf.ts`: per-isolate buffer + `ctx.waitUntil` preserved;
  flush calls `env.TELEMETRY_PIPELINE.send([{value: ev}, ...])` instead of
  constructing R2 keys
- Sampling stays Worker-side (`TELEMETRY_SAMPLE_<DOMAIN>` env vars unchanged)
- Read scripts (`fetch.py`, `analyze.py`, `setup.sql`) now read Parquet via
  DuckDB; `fetch.py` is a thin wrapper that builds a SQL query and prints
  the result, no more line-by-line NDJSON parsing in Python

The schemaless stream stores each row as a VARCHAR JSON `value` column
that wraps the input record, so the event sits at `$.value.<field>`.
`setup.sql` projects `ts`, `domain`, `op`, `via` as columns and exposes
`j` (the parsed inner JSON) for ad-hoc access.

Old `cache-telemetry/*.ndjson` files keep aging out under the existing
30-day R2 lifecycle; nothing is migrated.

## Provisioning (already done in both envs)

```bash
wrangler pipelines streams create ssi_telemetry --http-enabled false
wrangler pipelines sinks create ssi_telemetry_r2 \
  --type r2 --bucket ssi-scoreboard-telemetry \
  --format parquet --compression zstd \
  --path 'pipelines/cache-telemetry/' --partitioning '%Y-%m-%d' \
  --roll-size 5 --roll-interval 300
wrangler pipelines create ssi_telemetry \
  --sql 'INSERT INTO ssi_telemetry_r2 SELECT * FROM ssi_telemetry'
# repeat with `_staging` suffix and the staging bucket
```

## Test plan

- [x] `pnpm -w run typecheck` clean
- [x] `pnpm -w run lint` clean
- [x] `pnpm -w test` — all 1710 tests pass
- [x] Staging deploy: traffic exercised, first Parquet file landed in
      `pipelines/cache-telemetry/2026-05-10/`, schema verified, fetch.py
      and analyze.py query end-to-end against it
- [x] Prod deploy: binding wired, traffic generated, awaiting first
      roll to confirm prod-side write path
- [ ] After 24h: spot-check `analyze.py --env=prod report` against a
      day's worth of organic traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)