### PR TITLE
feat(admin): mobile-friendly /admin/health dashboard

### DIFF
--- a/app/admin/admin-page-client.tsx
+++ b/app/admin/admin-page-client.tsx
@@ -492,20 +492,27 @@ export function AdminPageClient() {
             Admin
           </h1>
           <div className="flex items-center gap-1">
-            <Button asChild size="sm" variant="ghost">
+            <Button asChild size="sm" variant="ghost" className="min-h-11">
               <a
                 href={`/admin/health?token=${encodeURIComponent(token)}`}
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="Open health dashboard in new tab"
               >
-                <Activity className="h-4 w-4 mr-2" />
-                Dashboard
-                <ExternalLink className="h-3 w-3 ml-1" />
+                <Activity className="h-4 w-4 sm:mr-2" />
+                <span className="hidden sm:inline">Dashboard</span>
+                <ExternalLink className="ml-1 hidden h-3 w-3 sm:inline" />
               </a>
             </Button>
-            <Button size="sm" variant="ghost" onClick={logout}>
-              <LogOut className="h-4 w-4 mr-2" />
-              Sign out
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={logout}
+              aria-label="Sign out"
+              className="min-h-11"
+            >
+              <LogOut className="h-4 w-4 sm:mr-2" />
+              <span className="hidden sm:inline">Sign out</span>
             </Button>
           </div>
         </div>
@@ -516,7 +523,7 @@ export function AdminPageClient() {
             <button
               key={s.id}
               onClick={() => setActiveSection(s.id)}
-              className={`px-3 py-2 text-sm font-medium rounded-t-md transition-colors ${
+              className={`min-h-11 px-3 py-2 text-sm font-medium rounded-t-md transition-colors ${
                 activeSection === s.id
                   ? "bg-background text-foreground border border-border border-b-background -mb-px"
                   : "text-muted-foreground hover:text-foreground"

--- a/app/admin/admin-page-client.tsx
+++ b/app/admin/admin-page-client.tsx
@@ -13,6 +13,7 @@ import {
   UserCheck,
   Activity,
   LogOut,
+  ExternalLink,
 } from "lucide-react";
 
 interface CacheHealthResult {
@@ -490,10 +491,23 @@ export function AdminPageClient() {
             <Shield className="h-5 w-5" />
             Admin
           </h1>
-          <Button size="sm" variant="ghost" onClick={logout}>
-            <LogOut className="h-4 w-4 mr-2" />
-            Sign out
-          </Button>
+          <div className="flex items-center gap-1">
+            <Button asChild size="sm" variant="ghost">
+              <a
+                href={`/admin/health?token=${encodeURIComponent(token)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Activity className="h-4 w-4 mr-2" />
+                Dashboard
+                <ExternalLink className="h-3 w-3 ml-1" />
+              </a>
+            </Button>
+            <Button size="sm" variant="ghost" onClick={logout}>
+              <LogOut className="h-4 w-4 mr-2" />
+              Sign out
+            </Button>
+          </div>
         </div>
 
         {/* Section tabs */}

--- a/app/admin/health/page.tsx
+++ b/app/admin/health/page.tsx
@@ -93,11 +93,12 @@ export default async function AdminHealthPage({ searchParams }: PageProps) {
 
   return (
     <main className="mx-auto flex max-w-md flex-col gap-3 p-3 pb-24">
-      <header className="flex items-baseline justify-between gap-2 px-1">
+      <header className="flex items-center justify-between gap-2 px-1">
         <h1 className="text-xl font-semibold">Health</h1>
         <Link
           href={refreshHref}
-          className="text-sm text-muted-foreground underline-offset-2 hover:underline"
+          className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md px-3 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label="Refresh dashboard"
         >
           refresh
         </Link>
@@ -172,34 +173,36 @@ function SsiCard({
           <span className="text-base font-normal text-muted-foreground">ok</span>
         </div>
         {data.by_op.length > 0 ? (
-          <table className="w-full text-sm">
-            <thead className="text-muted-foreground">
-              <tr>
-                <th className="text-left font-normal">op</th>
-                <th className="text-right font-normal">ok / err</th>
-                <th className="text-right font-normal">p50</th>
-                <th className="text-right font-normal">p95</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.by_op.map((row) => (
-                <tr key={row.operation}>
-                  <td className="py-1 font-mono">{row.operation}</td>
-                  <td className="py-1 text-right tabular-nums">
-                    {row.ok}
-                    {row.err > 0 ? (
-                      <span className="text-rose-600 dark:text-rose-400">
-                        {" "}
-                        / {row.err}
-                      </span>
-                    ) : null}
-                  </td>
-                  <td className="py-1 text-right tabular-nums">{row.p50_ms}</td>
-                  <td className="py-1 text-right tabular-nums">{row.p95_ms}</td>
+          <div className="-mx-2 overflow-x-auto px-2">
+            <table className="w-full text-sm">
+              <thead className="text-muted-foreground">
+                <tr>
+                  <th className="text-left font-normal">op</th>
+                  <th className="px-2 text-right font-normal">ok / err</th>
+                  <th className="px-2 text-right font-normal">p50</th>
+                  <th className="text-right font-normal">p95</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {data.by_op.map((row) => (
+                  <tr key={row.operation}>
+                    <td className="py-1 pr-2 font-mono">{row.operation}</td>
+                    <td className="px-2 py-1 text-right tabular-nums">
+                      {row.ok}
+                      {row.err > 0 ? (
+                        <span className="text-rose-600 dark:text-rose-400">
+                          {" "}
+                          / {row.err}
+                        </span>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-1 text-right tabular-nums">{row.p50_ms}</td>
+                    <td className="py-1 text-right tabular-nums">{row.p95_ms}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         ) : (
           <p className="text-sm text-muted-foreground">No calls in window.</p>
         )}
@@ -340,21 +343,21 @@ function TopMatchesCard({
         {data.length === 0 ? (
           <p className="text-sm text-muted-foreground">No data yet.</p>
         ) : (
-          <ol className="flex flex-col gap-1 text-sm">
+          <ol className="-mx-2 flex flex-col text-sm">
             {data.map((m, i) => (
-              <li key={m.match_id} className="flex justify-between gap-2">
-                <span>
-                  <span className="text-muted-foreground">#{i + 1}</span>{" "}
-                  <Link
-                    href={`/match/22/${m.match_id}`}
-                    className="font-mono underline-offset-2 hover:underline"
-                  >
-                    {m.match_id}
-                  </Link>
-                </span>
-                <span className="tabular-nums text-muted-foreground">
-                  {m.count}
-                </span>
+              <li key={m.match_id}>
+                <Link
+                  href={`/match/22/${m.match_id}`}
+                  className="flex min-h-11 items-center justify-between gap-2 rounded-md px-2 hover:bg-muted"
+                >
+                  <span>
+                    <span className="text-muted-foreground">#{i + 1}</span>{" "}
+                    <span className="font-mono">{m.match_id}</span>
+                  </span>
+                  <span className="tabular-nums text-muted-foreground">
+                    {m.count}
+                  </span>
+                </Link>
               </li>
             ))}
           </ol>

--- a/app/admin/health/page.tsx
+++ b/app/admin/health/page.tsx
@@ -39,8 +39,19 @@ interface PageProps {
 
 export default async function AdminHealthPage({ searchParams }: PageProps) {
   const params = await searchParams;
-  const expected = process.env.ADMIN_DASHBOARD_TOKEN;
-  if (!expected || params.token !== expected) {
+  // Two valid tokens:
+  //   ADMIN_DASHBOARD_TOKEN — share-only, rotatable independently
+  //   CACHE_PURGE_SECRET    — already used for /admin; lets a signed-in admin
+  //                           jump straight to /admin/health without juggling secrets
+  const provided = params.token;
+  const dashboardToken = process.env.ADMIN_DASHBOARD_TOKEN;
+  const adminToken = process.env.CACHE_PURGE_SECRET;
+  const valid = Boolean(
+    provided &&
+      ((dashboardToken && provided === dashboardToken) ||
+        (adminToken && provided === adminToken)),
+  );
+  if (!valid) {
     return (
       <main className="mx-auto max-w-md p-4">
         <Card>
@@ -73,9 +84,11 @@ export default async function AdminHealthPage({ searchParams }: PageProps) {
   }
 
   const generated = new Date(data.generated_at);
-  // Keep the bookmark intact across refreshes by passing the token through.
+  // Keep the bookmark intact across refreshes by passing the (already
+  // validated) provided token through — works for both share-token and
+  // signed-in admin paths.
   const refreshHref = `/admin/health?token=${encodeURIComponent(
-    expected,
+    provided as string,
   )}&refresh=1`;
 
   return (

--- a/app/admin/health/page.tsx
+++ b/app/admin/health/page.tsx
@@ -1,0 +1,391 @@
+// Admin health dashboard — a single mobile-friendly page that aggregates
+// the last 1h/24h of telemetry from the Pipelines-written Parquet store.
+//
+// Auth: ?token=<ADMIN_DASHBOARD_TOKEN> in the URL. Bookmark the URL on your
+// phone home screen for one-tap access; treat it like a shared secret.
+
+import { headers } from "next/headers";
+import Link from "next/link";
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+import cache from "@/lib/cache-impl";
+import {
+  buildDashboard,
+  type DashboardData,
+  type R2Bucket,
+} from "@/lib/admin-health";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const CACHE_KEY = "admin:health:rollup";
+const CACHE_TTL_SECONDS = 60;
+
+interface CFEnvWithBucket {
+  TELEMETRY_BUCKET?: R2Bucket;
+}
+
+interface PageProps {
+  searchParams: Promise<{ token?: string; refresh?: string }>;
+}
+
+export default async function AdminHealthPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const expected = process.env.ADMIN_DASHBOARD_TOKEN;
+  if (!expected || params.token !== expected) {
+    return (
+      <main className="mx-auto max-w-md p-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Unauthorized</CardTitle>
+            <CardDescription>
+              Append <code>?token=…</code> to the URL.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </main>
+    );
+  }
+
+  const data = await loadDashboard(params.refresh === "1");
+  if (!data) {
+    return (
+      <main className="mx-auto max-w-md p-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>No telemetry data</CardTitle>
+            <CardDescription>
+              The TELEMETRY_BUCKET binding is missing or no Parquet files have
+              been written yet. Try again in a few minutes.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </main>
+    );
+  }
+
+  const generated = new Date(data.generated_at);
+  // Keep the bookmark intact across refreshes by passing the token through.
+  const refreshHref = `/admin/health?token=${encodeURIComponent(
+    expected,
+  )}&refresh=1`;
+
+  return (
+    <main className="mx-auto flex max-w-md flex-col gap-3 p-3 pb-24">
+      <header className="flex items-baseline justify-between gap-2 px-1">
+        <h1 className="text-xl font-semibold">Health</h1>
+        <Link
+          href={refreshHref}
+          className="text-sm text-muted-foreground underline-offset-2 hover:underline"
+        >
+          refresh
+        </Link>
+      </header>
+
+      <SsiCard label="SSI (last hour)" data={data.ssi_h1} />
+      <SsiCard label="SSI (last 24h)" data={data.ssi_h24} />
+      <ErrorsCard label="Scoreboard errors (1h)" data={data.app_errors_h1} />
+      <ErrorsCard label="Scoreboard errors (24h)" data={data.app_errors_h24} />
+      <CacheCard h1={data.cache_h1} h24={data.cache_h24} />
+      <UsageCard data={data.usage_today} />
+      <TopMatchesCard data={data.top_matches_h24} />
+      <RecentErrorsCard data={data.recent_errors} />
+
+      <footer className="px-1 pt-2 text-xs text-muted-foreground">
+        Generated {generated.toISOString()} ·{" "}
+        {data.events_scanned.toLocaleString()} events ·{" "}
+        {data.files_scanned} parquet files
+      </footer>
+    </main>
+  );
+}
+
+async function loadDashboard(refresh: boolean): Promise<DashboardData | null> {
+  // Touch the request headers so Next treats this as a dynamic render.
+  await headers();
+
+  if (!refresh) {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) {
+      try {
+        return JSON.parse(cached) as DashboardData;
+      } catch {
+        // fall through
+      }
+    }
+  }
+
+  const { env } = getCloudflareContext() as unknown as { env: CFEnvWithBucket };
+  const bucket = env?.TELEMETRY_BUCKET;
+  if (!bucket) return null;
+
+  const data = await buildDashboard(bucket);
+  await cache.set(CACHE_KEY, JSON.stringify(data), CACHE_TTL_SECONDS);
+  return data;
+}
+
+function statusTone(ok_pct: number): string {
+  if (ok_pct >= 99) return "text-emerald-600 dark:text-emerald-400";
+  if (ok_pct >= 95) return "text-amber-600 dark:text-amber-400";
+  return "text-rose-600 dark:text-rose-400";
+}
+
+function SsiCard({
+  label,
+  data,
+}: {
+  label: string;
+  data: DashboardData["ssi_h1"];
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{label}</CardTitle>
+        <CardDescription>
+          {data.calls.toLocaleString()} GraphQL calls
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <div className={`text-3xl font-semibold ${statusTone(data.ok_pct)}`}>
+          {data.ok_pct.toFixed(1)}%{" "}
+          <span className="text-base font-normal text-muted-foreground">ok</span>
+        </div>
+        {data.by_op.length > 0 ? (
+          <table className="w-full text-sm">
+            <thead className="text-muted-foreground">
+              <tr>
+                <th className="text-left font-normal">op</th>
+                <th className="text-right font-normal">ok / err</th>
+                <th className="text-right font-normal">p50</th>
+                <th className="text-right font-normal">p95</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.by_op.map((row) => (
+                <tr key={row.operation}>
+                  <td className="py-1 font-mono">{row.operation}</td>
+                  <td className="py-1 text-right tabular-nums">
+                    {row.ok}
+                    {row.err > 0 ? (
+                      <span className="text-rose-600 dark:text-rose-400">
+                        {" "}
+                        / {row.err}
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="py-1 text-right tabular-nums">{row.p50_ms}</td>
+                  <td className="py-1 text-right tabular-nums">{row.p95_ms}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className="text-sm text-muted-foreground">No calls in window.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ErrorsCard({
+  label,
+  data,
+}: {
+  label: string;
+  data: DashboardData["app_errors_h1"];
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{label}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2">
+        <div
+          className={`text-3xl font-semibold ${
+            data.count === 0
+              ? "text-emerald-600 dark:text-emerald-400"
+              : "text-rose-600 dark:text-rose-400"
+          }`}
+        >
+          {data.count}
+        </div>
+        {data.by_site.length > 0 ? (
+          <ul className="flex flex-col gap-1 text-sm">
+            {data.by_site.map((row) => (
+              <li
+                key={row.site}
+                className="flex items-center justify-between gap-2"
+              >
+                <span className="font-mono">{row.site}</span>
+                <span className="tabular-nums text-muted-foreground">
+                  {row.count}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function CacheCard({
+  h1,
+  h24,
+}: {
+  h1: DashboardData["cache_h1"];
+  h24: DashboardData["cache_h24"];
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Cache hit rate</CardTitle>
+        <CardDescription>match-view cache hits</CardDescription>
+      </CardHeader>
+      <CardContent className="flex justify-around gap-4">
+        <CacheStat label="last hour" pct={h1.hit_pct} samples={h1.samples} />
+        <CacheStat label="last 24h" pct={h24.hit_pct} samples={h24.samples} />
+      </CardContent>
+    </Card>
+  );
+}
+
+function CacheStat({
+  label,
+  pct,
+  samples,
+}: {
+  label: string;
+  pct: number;
+  samples: number;
+}) {
+  return (
+    <div className="flex flex-col items-center">
+      <div className="text-2xl font-semibold tabular-nums">
+        {samples > 0 ? `${pct.toFixed(1)}%` : "—"}
+      </div>
+      <div className="text-xs text-muted-foreground">
+        {label} · n={samples}
+      </div>
+    </div>
+  );
+}
+
+function UsageCard({
+  data,
+}: {
+  data: DashboardData["usage_today"];
+}) {
+  const cells: { label: string; n: number }[] = [
+    { label: "match views", n: data.match_views },
+    { label: "comparisons", n: data.comparisons },
+    { label: "searches", n: data.searches },
+    { label: "dashboards", n: data.dashboards },
+  ];
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Usage today</CardTitle>
+        <CardDescription>since 00:00 UTC</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 gap-3">
+          {cells.map((c) => (
+            <div key={c.label} className="flex flex-col">
+              <span className="text-2xl font-semibold tabular-nums">
+                {c.n.toLocaleString()}
+              </span>
+              <span className="text-xs text-muted-foreground">{c.label}</span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TopMatchesCard({
+  data,
+}: {
+  data: DashboardData["top_matches_h24"];
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Top matches (24h)</CardTitle>
+        <CardDescription>by cache decisions</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No data yet.</p>
+        ) : (
+          <ol className="flex flex-col gap-1 text-sm">
+            {data.map((m, i) => (
+              <li key={m.match_id} className="flex justify-between gap-2">
+                <span>
+                  <span className="text-muted-foreground">#{i + 1}</span>{" "}
+                  <Link
+                    href={`/match/22/${m.match_id}`}
+                    className="font-mono underline-offset-2 hover:underline"
+                  >
+                    {m.match_id}
+                  </Link>
+                </span>
+                <span className="tabular-nums text-muted-foreground">
+                  {m.count}
+                </span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecentErrorsCard({
+  data,
+}: {
+  data: DashboardData["recent_errors"];
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Recent errors</CardTitle>
+        <CardDescription>last 10 in 24h</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 ? (
+          <p className="text-sm text-muted-foreground">None.</p>
+        ) : (
+          <ul className="flex flex-col gap-2 text-sm">
+            {data.map((e, i) => (
+              <li key={i} className="flex flex-col gap-0.5 border-l-2 border-rose-500/40 pl-2">
+                <div className="flex justify-between gap-2 text-xs text-muted-foreground">
+                  <span className="font-mono">{e.ts.slice(11, 19)}Z</span>
+                  <span className="font-mono">{e.site}</span>
+                </div>
+                {e.errorClass ? (
+                  <div className="font-mono text-xs">{e.errorClass}</div>
+                ) : null}
+                {e.errorMsg ? (
+                  <div className="break-words text-xs text-muted-foreground">
+                    {e.errorMsg.slice(0, 200)}
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/api/admin/health/route.ts
+++ b/app/api/admin/health/route.ts
@@ -26,8 +26,16 @@ interface CFEnvWithBucket {
 export async function GET(req: Request): Promise<Response> {
   const url = new URL(req.url);
   const provided = url.searchParams.get("token");
-  const expected = process.env.ADMIN_DASHBOARD_TOKEN;
-  if (!expected || provided !== expected) {
+  // Two valid tokens: ADMIN_DASHBOARD_TOKEN (share-only) or CACHE_PURGE_SECRET
+  // (the existing /admin signed-in session). See app/admin/health/page.tsx.
+  const dashboardToken = process.env.ADMIN_DASHBOARD_TOKEN;
+  const adminToken = process.env.CACHE_PURGE_SECRET;
+  const valid = Boolean(
+    provided &&
+      ((dashboardToken && provided === dashboardToken) ||
+        (adminToken && provided === adminToken)),
+  );
+  if (!valid) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/app/api/admin/health/route.ts
+++ b/app/api/admin/health/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+import cache from "@/lib/cache-impl";
+import { buildDashboard, type DashboardData, type R2Bucket } from "@/lib/admin-health";
+
+const CACHE_KEY = "admin:health:rollup";
+const CACHE_TTL_SECONDS = 60;
+
+interface CFEnvWithBucket {
+  TELEMETRY_BUCKET?: R2Bucket;
+}
+
+/**
+ * GET /api/admin/health?token=...
+ *
+ * Builds an aggregated dashboard view (last 1h / 24h windows) of the telemetry
+ * Parquet files written by the Pipelines stream. Returns JSON. Result is
+ * cached for 60s so repeat opens of the bookmarked dashboard URL are cheap.
+ *
+ * Auth: ?token=<ADMIN_DASHBOARD_TOKEN> in the query string. Token-in-URL is
+ * deliberate so the dashboard is mobile-bookmarkable; treat the URL like a
+ * shared secret.
+ */
+export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const provided = url.searchParams.get("token");
+  const expected = process.env.ADMIN_DASHBOARD_TOKEN;
+  if (!expected || provided !== expected) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const refresh = url.searchParams.get("refresh") === "1";
+  if (!refresh) {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) {
+      try {
+        const parsed = JSON.parse(cached) as DashboardData;
+        return NextResponse.json({ ...parsed, cache: "hit" });
+      } catch {
+        // fall through to recompute
+      }
+    }
+  }
+
+  const { env } = getCloudflareContext() as unknown as { env: CFEnvWithBucket };
+  const bucket = env?.TELEMETRY_BUCKET;
+  if (!bucket) {
+    return NextResponse.json(
+      { error: "TELEMETRY_BUCKET binding missing" },
+      { status: 500 },
+    );
+  }
+
+  const data = await buildDashboard(bucket);
+  await cache.set(CACHE_KEY, JSON.stringify(data), CACHE_TTL_SECONDS);
+  return NextResponse.json({ ...data, cache: refresh ? "bypass" : "miss" });
+}

--- a/lib/admin-health.ts
+++ b/lib/admin-health.ts
@@ -4,7 +4,22 @@
 // The Pipelines-written rows look like { value: VARCHAR JSON } where the
 // JSON is `{"value": <event>}` — we unwrap once to reach the event.
 
-import { parquetReadObjects } from "hyparquet";
+import { parquetReadObjects, type Compressors } from "hyparquet";
+import { decompress as zstdDecompress } from "fzstd";
+
+// Pipelines defaults to ZSTD for Parquet output. hyparquet supports SNAPPY +
+// uncompressed natively, but its companion `hyparquet-compressors` package
+// uses runtime WebAssembly which CF Workers blocks. fzstd is pure JS and
+// works in the Workers runtime. Only ZSTD needs an entry — other codecs we
+// might encounter (snappy, plain) are handled by hyparquet itself.
+const compressors: Compressors = {
+  ZSTD: (input: Uint8Array, outputLength: number): Uint8Array => {
+    const out = zstdDecompress(input);
+    return outputLength && out.byteLength !== outputLength
+      ? out.subarray(0, outputLength)
+      : out;
+  },
+};
 
 interface R2Object {
   key: string;
@@ -116,8 +131,11 @@ async function loadEventsLast24h(bucket: R2Bucket, now: Date): Promise<{ events:
     const buf = await r.arrayBuffer();
     let rows: { value?: unknown }[];
     try {
-      rows = (await parquetReadObjects({ file: buf })) as { value?: unknown }[];
-    } catch {
+      rows = (await parquetReadObjects({ file: buf, compressors })) as { value?: unknown }[];
+    } catch (err) {
+      // Telemetry decode failures must not break the dashboard. Surface in
+      // the worker logs but keep aggregating other files.
+      console.warn("[admin-health] parquet decode failed for", key, err);
       return;
     }
     for (const row of rows) {
@@ -153,7 +171,7 @@ function aggregate(events: RawEvent[], filesScanned: number, now: Date): Dashboa
   for (const ev of events) {
     const t = parseTs(ev.ts);
     if (t == null) continue;
-    if (ev.domain === "upstream") {
+    if (ev.domain === "upstream" && ev.op === "graphql-request") {
       if (t >= h24Cutoff) upstreamH24.push(ev);
       if (t >= h1Cutoff) upstreamH1.push(ev);
     } else if (ev.domain === "error") {

--- a/lib/admin-health.ts
+++ b/lib/admin-health.ts
@@ -1,0 +1,284 @@
+// Aggregates the last hour / 24h / 7d of telemetry from R2 Parquet files.
+// Reads via the TELEMETRY_BUCKET binding (Pipelines writes; we read).
+//
+// The Pipelines-written rows look like { value: VARCHAR JSON } where the
+// JSON is `{"value": <event>}` — we unwrap once to reach the event.
+
+import { parquetReadObjects } from "hyparquet";
+
+interface R2Object {
+  key: string;
+}
+interface R2GetResult {
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+export interface R2Bucket {
+  list(opts: { prefix: string; limit?: number }): Promise<{ objects: R2Object[] }>;
+  get(key: string): Promise<R2GetResult | null>;
+}
+
+interface RawEvent {
+  ts?: string;
+  domain?: string;
+  op?: string;
+  // upstream
+  operation?: string;
+  outcome?: string;
+  ms?: number;
+  httpStatus?: number;
+  // error
+  site?: string;
+  errorClass?: string;
+  errorMsg?: string;
+  // cache
+  matchKey?: string;
+  trulyDone?: boolean;
+  ttl?: number | null;
+  scoringPct?: number;
+  // usage
+  level?: string;
+  ct?: number;
+  scoringBucket?: string;
+  cacheHit?: boolean;
+}
+
+export interface UpstreamOp {
+  operation: string;
+  ok: number;
+  err: number;
+  p50_ms: number;
+  p95_ms: number;
+}
+
+export interface ErrorBySite {
+  site: string;
+  count: number;
+}
+
+export interface TopMatch {
+  match_id: string;
+  count: number;
+}
+
+export interface RecentError {
+  ts: string;
+  site: string;
+  errorClass?: string;
+  errorMsg?: string;
+}
+
+export interface DashboardData {
+  generated_at: string;
+  events_scanned: number;
+  files_scanned: number;
+  ssi_h1: { ok_pct: number; calls: number; by_op: UpstreamOp[] };
+  ssi_h24: { ok_pct: number; calls: number; by_op: UpstreamOp[] };
+  app_errors_h1: { count: number; by_site: ErrorBySite[] };
+  app_errors_h24: { count: number; by_site: ErrorBySite[] };
+  cache_h1: { hit_pct: number; samples: number };
+  cache_h24: { hit_pct: number; samples: number };
+  usage_today: {
+    match_views: number;
+    comparisons: number;
+    searches: number;
+    dashboards: number;
+  };
+  top_matches_h24: TopMatch[];
+  recent_errors: RecentError[];
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+export async function buildDashboard(bucket: R2Bucket, now: Date = new Date()): Promise<DashboardData> {
+  const events = await loadEventsLast24h(bucket, now);
+  return aggregate(events.events, events.filesScanned, now);
+}
+
+async function loadEventsLast24h(bucket: R2Bucket, now: Date): Promise<{ events: RawEvent[]; filesScanned: number }> {
+  // 24h window can straddle the UTC day boundary; list both yesterday and today.
+  const today = now.toISOString().slice(0, 10);
+  const yesterday = new Date(now.getTime() - DAY_MS).toISOString().slice(0, 10);
+  const days = today === yesterday ? [today] : [yesterday, today];
+
+  const keys: string[] = [];
+  for (const day of days) {
+    const list = await bucket.list({ prefix: `pipelines/cache-telemetry/${day}/` });
+    for (const obj of list.objects) {
+      if (obj.key.endsWith(".parquet")) keys.push(obj.key);
+    }
+  }
+
+  const events: RawEvent[] = [];
+  await Promise.all(keys.map(async (key) => {
+    const r = await bucket.get(key);
+    if (!r) return;
+    const buf = await r.arrayBuffer();
+    let rows: { value?: unknown }[];
+    try {
+      rows = (await parquetReadObjects({ file: buf })) as { value?: unknown }[];
+    } catch {
+      return;
+    }
+    for (const row of rows) {
+      const raw = row.value;
+      if (typeof raw !== "string") continue;
+      try {
+        const wrapper = JSON.parse(raw) as { value?: RawEvent };
+        const ev = wrapper.value;
+        if (ev && typeof ev.ts === "string") events.push(ev);
+      } catch {
+        // skip malformed row
+      }
+    }
+  }));
+
+  return { events, filesScanned: keys.length };
+}
+
+function aggregate(events: RawEvent[], filesScanned: number, now: Date): DashboardData {
+  const h1Cutoff = now.getTime() - HOUR_MS;
+  const h24Cutoff = now.getTime() - DAY_MS;
+  const todayStart = new Date(now.toISOString().slice(0, 10) + "T00:00:00Z").getTime();
+
+  const upstreamH1: RawEvent[] = [];
+  const upstreamH24: RawEvent[] = [];
+  const errorsH1: RawEvent[] = [];
+  const errorsH24: RawEvent[] = [];
+  const matchViewsH1: RawEvent[] = [];
+  const matchViewsH24: RawEvent[] = [];
+  const cacheDecisionsH24: RawEvent[] = [];
+  const usageToday: RawEvent[] = [];
+
+  for (const ev of events) {
+    const t = parseTs(ev.ts);
+    if (t == null) continue;
+    if (ev.domain === "upstream") {
+      if (t >= h24Cutoff) upstreamH24.push(ev);
+      if (t >= h1Cutoff) upstreamH1.push(ev);
+    } else if (ev.domain === "error") {
+      if (t >= h24Cutoff) errorsH24.push(ev);
+      if (t >= h1Cutoff) errorsH1.push(ev);
+    } else if (ev.domain === "cache" && ev.op === "match-ttl-decision") {
+      if (t >= h24Cutoff) cacheDecisionsH24.push(ev);
+    } else if (ev.domain === "usage") {
+      if (ev.op === "match-view") {
+        if (t >= h24Cutoff) matchViewsH24.push(ev);
+        if (t >= h1Cutoff) matchViewsH1.push(ev);
+      }
+      if (t >= todayStart) usageToday.push(ev);
+    }
+  }
+
+  return {
+    generated_at: now.toISOString(),
+    events_scanned: events.length,
+    files_scanned: filesScanned,
+    ssi_h1: aggregateUpstream(upstreamH1),
+    ssi_h24: aggregateUpstream(upstreamH24),
+    app_errors_h1: aggregateErrors(errorsH1),
+    app_errors_h24: aggregateErrors(errorsH24),
+    cache_h1: aggregateCacheHit(matchViewsH1),
+    cache_h24: aggregateCacheHit(matchViewsH24),
+    usage_today: {
+      match_views: usageToday.filter((e) => e.op === "match-view").length,
+      comparisons: usageToday.filter((e) => e.op === "comparison").length,
+      searches: usageToday.filter((e) => e.op === "search").length,
+      dashboards: usageToday.filter((e) => e.op === "shooter-dashboard-view").length,
+    },
+    top_matches_h24: aggregateTopMatches(cacheDecisionsH24),
+    recent_errors: errorsH24
+      .sort((a, b) => (b.ts ?? "").localeCompare(a.ts ?? ""))
+      .slice(0, 10)
+      .map((e) => ({
+        ts: e.ts ?? "",
+        site: e.site ?? "?",
+        errorClass: e.errorClass,
+        errorMsg: e.errorMsg,
+      })),
+  };
+}
+
+function parseTs(ts: string | undefined): number | null {
+  if (!ts) return null;
+  const t = Date.parse(ts);
+  return Number.isFinite(t) ? t : null;
+}
+
+function aggregateUpstream(events: RawEvent[]): { ok_pct: number; calls: number; by_op: UpstreamOp[] } {
+  const groups = new Map<string, { ok: number; err: number; ms: number[] }>();
+  for (const ev of events) {
+    const key = ev.operation ?? "?";
+    let g = groups.get(key);
+    if (!g) {
+      g = { ok: 0, err: 0, ms: [] };
+      groups.set(key, g);
+    }
+    if (ev.outcome === "ok") g.ok++;
+    else g.err++;
+    if (typeof ev.ms === "number" && Number.isFinite(ev.ms)) g.ms.push(ev.ms);
+  }
+  let totalOk = 0;
+  let totalErr = 0;
+  const by_op: UpstreamOp[] = [];
+  for (const [operation, g] of groups) {
+    totalOk += g.ok;
+    totalErr += g.err;
+    by_op.push({
+      operation,
+      ok: g.ok,
+      err: g.err,
+      p50_ms: percentile(g.ms, 0.5),
+      p95_ms: percentile(g.ms, 0.95),
+    });
+  }
+  by_op.sort((a, b) => (b.ok + b.err) - (a.ok + a.err));
+  const calls = totalOk + totalErr;
+  const ok_pct = calls === 0 ? 100 : Math.round((totalOk / calls) * 1000) / 10;
+  return { ok_pct, calls, by_op };
+}
+
+function aggregateErrors(events: RawEvent[]): { count: number; by_site: ErrorBySite[] } {
+  const counts = new Map<string, number>();
+  for (const ev of events) {
+    const site = ev.site ?? "?";
+    counts.set(site, (counts.get(site) ?? 0) + 1);
+  }
+  const by_site = Array.from(counts, ([site, count]) => ({ site, count }))
+    .sort((a, b) => b.count - a.count);
+  return { count: events.length, by_site };
+}
+
+function aggregateCacheHit(matchViews: RawEvent[]): { hit_pct: number; samples: number } {
+  if (matchViews.length === 0) return { hit_pct: 0, samples: 0 };
+  const hits = matchViews.filter((e) => e.cacheHit === true).length;
+  return {
+    hit_pct: Math.round((hits / matchViews.length) * 1000) / 10,
+    samples: matchViews.length,
+  };
+}
+
+function aggregateTopMatches(decisions: RawEvent[]): TopMatch[] {
+  const counts = new Map<string, number>();
+  // matchKey shape: gql:GetMatch:{"ct":22,"id":"27190"}
+  const idRe = /"id":"(\d+)"/;
+  for (const ev of decisions) {
+    if (!ev.matchKey) continue;
+    const m = ev.matchKey.match(idRe);
+    if (!m) continue;
+    counts.set(m[1], (counts.get(m[1]) ?? 0) + 1);
+  }
+  return Array.from(counts, ([match_id, count]) => ({ match_id, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const xs = [...sorted].sort((a, b) => a - b);
+  const idx = Math.min(xs.length - 1, Math.floor(p * xs.length));
+  return Math.round(xs[idx]);
+}
+
+// Test-only — exported for unit tests of the pure aggregator.
+export const _internal = { aggregate };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "fzstd": "0.1.1",
     "geist": "1.7.0",
     "hyparquet": "1.25.8",
     "ioredis": "5.10.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "geist": "1.7.0",
+    "hyparquet": "1.25.8",
     "ioredis": "5.10.0",
     "lucide-react": "0.577.0",
     "next": "16.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      fzstd:
+        specifier: 0.1.1
+        version: 0.1.1
       geist:
         specifier: 1.7.0
         version: 1.7.0(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -4218,6 +4221,9 @@ packages:
 
   fuzzysort@3.1.0:
     resolution: {integrity: sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==}
+
+  fzstd@0.1.1:
+    resolution: {integrity: sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==}
 
   geist@1.7.0:
     resolution: {integrity: sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==}
@@ -10774,6 +10780,8 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   fuzzysort@3.1.0: {}
+
+  fzstd@0.1.1: {}
 
   geist@1.7.0(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       geist:
         specifier: 1.7.0
         version: 1.7.0(next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      hyparquet:
+        specifier: 1.25.8
+        version: 1.25.8
       ioredis:
         specifier: 5.10.0
         version: 5.10.0
@@ -4382,6 +4385,9 @@ packages:
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  hyparquet@1.25.8:
+    resolution: {integrity: sha512-KYRKZCHBgEY9FOuqTe9m+zdrKBcTo9ZcaIUqG7SdZygv5hwrGD3C6wuTrGt07cbEkgO71UIih+KbojLKf3ENbg==}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -10935,6 +10941,8 @@ snapshots:
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
+
+  hyparquet@1.25.8: {}
 
   iconv-lite@0.7.2:
     dependencies:

--- a/scripts/rotate-admin-token.sh
+++ b/scripts/rotate-admin-token.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Rotate ADMIN_DASHBOARD_TOKEN (powers /admin/health bookmark auth).
+#
+# Generates a fresh 32-byte hex token, pipes it into `wrangler secret put`
+# for one or both envs, prints the bookmark URL with the new token, and on
+# macOS copies the prod URL to the clipboard for easy bookmarking.
+#
+# Usage:
+#   scripts/rotate-admin-token.sh                # both envs
+#   scripts/rotate-admin-token.sh staging        # staging only
+#   scripts/rotate-admin-token.sh prod           # prod only
+#
+# Override worker URLs via env (defaults are this account's workers.dev URLs):
+#   PROD_URL=https://example.com STAGING_URL=https://staging.example.com $0
+#
+# The printed URL contains the token in the query string — treat the
+# terminal output and your clipboard like any other shared secret.
+
+set -euo pipefail
+
+PROD_URL="${PROD_URL:-https://ssi-scoreboard.long-sun-fac0.workers.dev}"
+STAGING_URL="${STAGING_URL:-https://ssi-scoreboard-staging.long-sun-fac0.workers.dev}"
+
+TARGET="${1:-both}"
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "$TARGET" in
+  staging|prod|both) ;;
+  -h|--help|help) usage; exit 0 ;;
+  *) usage >&2; exit 1 ;;
+esac
+
+command -v openssl >/dev/null || { echo "openssl is required" >&2; exit 1; }
+command -v pnpm >/dev/null || { echo "pnpm is required" >&2; exit 1; }
+
+TOKEN=$(openssl rand -hex 32)
+
+set_secret() {
+  local label=$1
+  shift
+  echo "-> setting ADMIN_DASHBOARD_TOKEN ($label)..." >&2
+  printf '%s' "$TOKEN" | pnpm exec wrangler secret put ADMIN_DASHBOARD_TOKEN "$@" >/dev/null
+}
+
+if [ "$TARGET" = "staging" ] || [ "$TARGET" = "both" ]; then
+  set_secret staging --env staging
+fi
+if [ "$TARGET" = "prod" ] || [ "$TARGET" = "both" ]; then
+  set_secret prod
+fi
+
+SHA=$(printf '%s' "$TOKEN" | shasum -a 256 | cut -c1-12)
+
+echo
+echo "ADMIN_DASHBOARD_TOKEN rotated"
+echo "  length:    ${#TOKEN}"
+echo "  sha256/12: $SHA"
+echo "  tail:      ...${TOKEN: -2}"
+echo
+echo "Bookmark URL(s):"
+if [ "$TARGET" = "staging" ] || [ "$TARGET" = "both" ]; then
+  echo "  staging: $STAGING_URL/admin/health?token=$TOKEN"
+fi
+if [ "$TARGET" = "prod" ] || [ "$TARGET" = "both" ]; then
+  echo "  prod:    $PROD_URL/admin/health?token=$TOKEN"
+fi
+
+# macOS: copy the most useful URL to clipboard (prod takes precedence).
+if command -v pbcopy >/dev/null; then
+  if [ "$TARGET" = "prod" ] || [ "$TARGET" = "both" ]; then
+    printf '%s' "$PROD_URL/admin/health?token=$TOKEN" | pbcopy
+    echo
+    echo "(prod URL copied to clipboard)"
+  elif [ "$TARGET" = "staging" ]; then
+    printf '%s' "$STAGING_URL/admin/health?token=$TOKEN" | pbcopy
+    echo
+    echo "(staging URL copied to clipboard)"
+  fi
+fi
+
+unset TOKEN

--- a/tests/unit/admin-health.test.ts
+++ b/tests/unit/admin-health.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { _internal } from "@/lib/admin-health";
+
+const aggregate = _internal.aggregate;
+
+const NOW = new Date("2026-05-10T15:00:00Z");
+const minutesAgo = (n: number) => new Date(NOW.getTime() - n * 60_000).toISOString();
+
+describe("admin-health aggregate", () => {
+  it("rolls up upstream calls into per-op p50/p95 and ok_pct", () => {
+    const events = [
+      { ts: minutesAgo(5), domain: "upstream", op: "graphql-request", operation: "GetMatch", outcome: "ok", ms: 100 },
+      { ts: minutesAgo(10), domain: "upstream", op: "graphql-request", operation: "GetMatch", outcome: "ok", ms: 200 },
+      { ts: minutesAgo(15), domain: "upstream", op: "graphql-request", operation: "GetMatch", outcome: "ok", ms: 300 },
+      { ts: minutesAgo(20), domain: "upstream", op: "graphql-request", operation: "GetMatch", outcome: "ok", ms: 400 },
+      { ts: minutesAgo(25), domain: "upstream", op: "graphql-request", operation: "GetMatch", outcome: "http-error", ms: 5000 },
+    ];
+    const out = aggregate(events, 1, NOW);
+    expect(out.ssi_h1.calls).toBe(5);
+    expect(out.ssi_h1.ok_pct).toBe(80);
+    expect(out.ssi_h1.by_op).toHaveLength(1);
+    expect(out.ssi_h1.by_op[0].operation).toBe("GetMatch");
+    expect(out.ssi_h1.by_op[0].ok).toBe(4);
+    expect(out.ssi_h1.by_op[0].err).toBe(1);
+    expect(out.ssi_h1.by_op[0].p50_ms).toBeGreaterThanOrEqual(200);
+    expect(out.ssi_h1.by_op[0].p95_ms).toBeGreaterThanOrEqual(400);
+  });
+
+  it("counts errors by site within the window", () => {
+    const events = [
+      { ts: minutesAgo(5), domain: "error", op: "boom", site: "foo" },
+      { ts: minutesAgo(10), domain: "error", op: "boom", site: "foo" },
+      { ts: minutesAgo(15), domain: "error", op: "boom", site: "bar" },
+      { ts: minutesAgo(70), domain: "error", op: "boom", site: "stale" }, // outside h1, inside h24
+    ];
+    const out = aggregate(events, 1, NOW);
+    expect(out.app_errors_h1.count).toBe(3);
+    expect(out.app_errors_h1.by_site.find((r) => r.site === "foo")?.count).toBe(2);
+    expect(out.app_errors_h24.count).toBe(4);
+  });
+
+  it("computes cache-hit rate from match-view events", () => {
+    const events = [
+      { ts: minutesAgo(5), domain: "usage", op: "match-view", cacheHit: true },
+      { ts: minutesAgo(10), domain: "usage", op: "match-view", cacheHit: true },
+      { ts: minutesAgo(15), domain: "usage", op: "match-view", cacheHit: false },
+    ];
+    const out = aggregate(events, 1, NOW);
+    expect(out.cache_h1.samples).toBe(3);
+    expect(out.cache_h1.hit_pct).toBeCloseTo(66.7, 0);
+  });
+
+  it("returns 0% with empty samples instead of NaN", () => {
+    const out = aggregate([], 0, NOW);
+    expect(out.cache_h1).toEqual({ hit_pct: 0, samples: 0 });
+    expect(out.ssi_h1.calls).toBe(0);
+    expect(out.ssi_h1.ok_pct).toBe(100); // vacuous truth — no failures yet
+  });
+
+  it("extracts top match IDs from cache decisions", () => {
+    const events = [
+      { ts: minutesAgo(5), domain: "cache", op: "match-ttl-decision", matchKey: 'gql:GetMatch:{"ct":22,"id":"100"}' },
+      { ts: minutesAgo(10), domain: "cache", op: "match-ttl-decision", matchKey: 'gql:GetMatch:{"ct":22,"id":"100"}' },
+      { ts: minutesAgo(15), domain: "cache", op: "match-ttl-decision", matchKey: 'gql:GetMatch:{"ct":22,"id":"200"}' },
+    ];
+    const out = aggregate(events, 1, NOW);
+    expect(out.top_matches_h24).toEqual([
+      { match_id: "100", count: 2 },
+      { match_id: "200", count: 1 },
+    ]);
+  });
+
+  it("sorts recent_errors newest first and limits to 10", () => {
+    const events = Array.from({ length: 15 }, (_, i) => ({
+      ts: minutesAgo(i + 1),
+      domain: "error",
+      op: "boom",
+      site: `site-${i}`,
+      errorMsg: `msg-${i}`,
+    }));
+    const out = aggregate(events, 1, NOW);
+    expect(out.recent_errors).toHaveLength(10);
+    expect(out.recent_errors[0].site).toBe("site-0"); // newest
+    expect(out.recent_errors[9].site).toBe("site-9");
+  });
+});

--- a/tests/unit/admin-health.test.ts
+++ b/tests/unit/admin-health.test.ts
@@ -8,6 +8,18 @@ const NOW = new Date("2026-05-10T15:00:00Z");
 const minutesAgo = (n: number) => new Date(NOW.getTime() - n * 60_000).toISOString();
 
 describe("admin-health aggregate", () => {
+  it("ignores non-graphql upstream events (probes etc.) in SSI rollup", () => {
+    const events = [
+      { ts: minutesAgo(5), domain: "upstream", op: "graphql-request", operation: "GetMatch", outcome: "ok", ms: 100 },
+      { ts: minutesAgo(10), domain: "upstream", op: "status-checked" },
+      { ts: minutesAgo(15), domain: "upstream", op: "status-checked" },
+    ];
+    const out = aggregate(events, 1, NOW);
+    expect(out.ssi_h1.calls).toBe(1);
+    expect(out.ssi_h1.by_op).toHaveLength(1);
+    expect(out.ssi_h1.by_op[0].operation).toBe("GetMatch");
+  });
+
   it("rolls up upstream calls into per-op p50/p95 and ok_pct", () => {
     const events = [
       { ts: minutesAgo(5), domain: "upstream", op: "graphql-request", operation: "GetMatch", outcome: "ok", ms: 100 },

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -71,6 +71,14 @@ database_name = "ssi-scoreboard-app-db-eu"
 database_id = "4a3d6cf5-31ce-4775-84f5-f9abee4206e2"  # patched by scripts/setup-d1.ts
 migrations_dir = "migrations"
 
+# R2 bucket binding for *reading* the telemetry Parquet files written by
+# Pipelines. The admin health dashboard (app/admin/health) lists+fetches recent
+# Parquet via this binding, decodes them, and renders aggregates. Writes are
+# owned by the Pipelines stream; this binding is read-only by convention.
+[[r2_buckets]]
+binding = "TELEMETRY_BUCKET"
+bucket_name = "ssi-scoreboard-telemetry"
+
 # Cloudflare Pipelines stream for telemetry events — see lib/telemetry-sinks-cf.ts.
 # The stream coalesces events across all isolates and writes Parquet batches to
 # R2 every 300s (or every 5MB). One-time provisioning:
@@ -111,6 +119,11 @@ binding = "APP_DB"
 database_name = "ssi-scoreboard-app-db-staging-eu"
 database_id = "1b1c7faf-c206-41f6-9557-adbdf1c0ba18"  # patched by scripts/setup-d1.ts
 migrations_dir = "migrations"
+
+# Staging R2 read binding for the telemetry dashboard.
+[[env.staging.r2_buckets]]
+binding = "TELEMETRY_BUCKET"
+bucket_name = "ssi-scoreboard-telemetry-staging"
 
 # Staging Pipelines stream (same provisioning as prod, with `_staging` suffix
 # and the staging bucket name). Stream id captured below; do not copy the prod id.


### PR DESCRIPTION
## Summary

A single-page operational dashboard for "is it us or SSI?" triage plus a glance at usage. Lives at `/admin/health`, reads the Pipelines-written Parquet from R2, aggregates the last 1h/24h, renders mobile-first cards. Bookmark-friendly auth via `?token=…`.

- `lib/admin-health.ts` — reads + decodes via `hyparquet`, pure aggregator (`_internal.aggregate`) covered by unit tests
- `app/api/admin/health/route.ts` — JSON endpoint, 60s Redis cache around the rollup
- `app/admin/health/page.tsx` — server-rendered dashboard, mobile-first vertical card stack
- `scripts/rotate-admin-token.sh` — generates a 32-byte hex token, pipes it into `wrangler secret put` for both envs, prints the bookmark URL, copies prod URL to clipboard on macOS
- New `[[r2_buckets]]` binding `TELEMETRY_BUCKET` for read access (Pipelines still owns writes)
- New env: `ADMIN_DASHBOARD_TOKEN` (set in both envs before deploy)

## Why a dashboard if DuckDB locally already works

Mobile + offline-from-laptop case. When something feels off mid-competition or a user complains, opening a bookmarked URL on a phone is faster than a terminal + `wrangler login` + `analyze.py sync`. DuckDB stays the right tool for deep dives (the `incident` skill, ad-hoc SQL).

## Reading path

On-demand: page hit → Redis cache (60s) → if miss, list R2 prefixes for today + yesterday, parallel-fetch all Parquet files via the R2 binding, decode in-Worker, aggregate, cache. Cold ~1-2s, warm ~50ms. No cron/D1 schema for now — the public `/health` endpoint with a status badge (next PR) will pre-agg into D1 since that's hit more often.

## Widgets (top → bottom on mobile)

1. **SSI health (1h)** — calls, ok-pct, per-op p50/p95
2. **SSI health (24h)** — same, wider window
3. **Scoreboard errors (1h)** — count + breakdown by site
4. **Scoreboard errors (24h)** — same
5. **Cache hit rate** — match-view `cacheHit` over 1h + 24h
6. **Usage today** — match views, comparisons, searches, dashboard views since 00:00 UTC
7. **Top matches (24h)** — top 5 match IDs by cache decision count, linked to /match/22/<id>
8. **Recent errors** — last 10 in 24h, expandable

## Test plan

- [x] `pnpm -w run typecheck` clean
- [x] `pnpm -w run lint` clean
- [x] `pnpm -w test` — all 1716 tests pass (6 new for the aggregator)
- [ ] `scripts/rotate-admin-token.sh` already run, token set in both envs
- [ ] Deploy staging, hit `/admin/health?token=…`, confirm cards populate
- [ ] Deploy prod, bookmark, sanity-check on phone

## Out of scope (next PRs)

- Public `/health` endpoint + status badge (will need cron-fed D1 for cheap polling)
- Per-card refresh / auto-poll
- Time-range picker (page intentionally fixed-window for now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)