### PR TITLE
feat(api): public /api/health liveness endpoint

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+// Public liveness endpoint. Intentionally lightweight: no Redis / D1 / GraphQL
+// calls, no auth. Used by uptime probes, load balancers, and CI smoke checks.
+//
+// Deep readiness checks (cache round-trip, env-var presence) live behind auth
+// at /api/admin/cache/health -- exposing them publicly would amplify load on
+// our backends and leak operational detail.
+//
+// Response shape follows the IETF "Health Check Response Format for HTTP APIs"
+// draft (draft-inadarei-api-health-check): status / version / releaseId /
+// serviceId / description, served as application/health+json.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const SERVICE_ID = "ssi-scoreboard";
+const DESCRIPTION = "SSI Scoreboard liveness probe";
+const API_VERSION = "1";
+
+function buildPayload() {
+  return {
+    status: "pass" as const,
+    version: API_VERSION,
+    releaseId: process.env.NEXT_PUBLIC_BUILD_ID ?? null,
+    serviceId: SERVICE_ID,
+    description: DESCRIPTION,
+  };
+}
+
+const HEALTH_HEADERS = {
+  "Content-Type": "application/health+json",
+  "Cache-Control": "no-store",
+} as const;
+
+export async function GET(): Promise<Response> {
+  return NextResponse.json(buildPayload(), { headers: HEALTH_HEADERS });
+}
+
+export async function HEAD(): Promise<Response> {
+  return new Response(null, { status: 200, headers: HEALTH_HEADERS });
+}

--- a/tests/unit/health-route.test.ts
+++ b/tests/unit/health-route.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { GET, HEAD } from "@/app/api/health/route";
+
+describe("GET /api/health -- public liveness probe", () => {
+  const originalBuildId = process.env.NEXT_PUBLIC_BUILD_ID;
+
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_BUILD_ID;
+  });
+
+  afterEach(() => {
+    if (originalBuildId === undefined) {
+      delete process.env.NEXT_PUBLIC_BUILD_ID;
+    } else {
+      process.env.NEXT_PUBLIC_BUILD_ID = originalBuildId;
+    }
+  });
+
+  it("returns 200 with status=pass and the IETF health+json shape", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/health+json");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      status: "pass",
+      version: "1",
+      serviceId: "ssi-scoreboard",
+      description: expect.any(String),
+      releaseId: null,
+    });
+  });
+
+  it("includes releaseId when NEXT_PUBLIC_BUILD_ID is set", async () => {
+    process.env.NEXT_PUBLIC_BUILD_ID = "abc123";
+    const res = await GET();
+    const body = (await res.json()) as { releaseId: string | null };
+    expect(body.releaseId).toBe("abc123");
+  });
+
+  it("HEAD returns 200 with no body and the same headers", async () => {
+    const res = await HEAD();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/health+json");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(await res.text()).toBe("");
+  });
+});


### PR DESCRIPTION
Lightweight, unauthenticated liveness probe for uptime monitors and load
balancers. Follows the IETF "Health Check Response Format for HTTP APIs"
draft (application/health+json) and intentionally performs no I/O so it
can't be used to amplify load on Redis/D1/GraphQL. Deep readiness checks
remain behind auth at /api/admin/cache/health.