### PR TITLE
feat(db): last_accessed_at on match_data_cache + organizer on matches

### DIFF
--- a/lib/db-d1.ts
+++ b/lib/db-d1.ts
@@ -281,6 +281,14 @@ const db: AppDatabase = {
     return row?.stored_at ?? null;
   },
 
+  async touchMatchDataCache(cacheKey, when) {
+    const db = getDb();
+    await db
+      .prepare(`UPDATE match_data_cache SET last_accessed_at = ? WHERE cache_key = ?`)
+      .bind(when, cacheKey)
+      .run();
+  },
+
   async setMatchDataCache(cacheKey, data, meta) {
     const db = getDb();
     await db
@@ -357,8 +365,8 @@ const db: AppDatabase = {
     const db = getDb();
     await db
       .prepare(
-        `INSERT INTO matches (match_ref, ct, match_id, name, venue, date, level, region, sub_rule, discipline, status, results_status, scoring_completed, competitors_count, stages_count, lat, lng, data, updated_at, registration_starts, registration_closes, registration_status, squadding_starts, squadding_closes, is_registration_possible, is_squadding_possible, max_competitors)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `INSERT INTO matches (match_ref, ct, match_id, name, venue, date, level, region, sub_rule, discipline, status, results_status, scoring_completed, competitors_count, stages_count, lat, lng, data, updated_at, registration_starts, registration_closes, registration_status, squadding_starts, squadding_closes, is_registration_possible, is_squadding_possible, max_competitors, organizer_id, organizer_name)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(match_ref)
          DO UPDATE SET name = excluded.name,
                        venue = excluded.venue,
@@ -383,7 +391,9 @@ const db: AppDatabase = {
                        squadding_closes = excluded.squadding_closes,
                        is_registration_possible = excluded.is_registration_possible,
                        is_squadding_possible = excluded.is_squadding_possible,
-                       max_competitors = excluded.max_competitors`,
+                       max_competitors = excluded.max_competitors,
+                       organizer_id = excluded.organizer_id,
+                       organizer_name = excluded.organizer_name`,
       )
       .bind(
         match.matchRef, match.ct, match.matchId, match.name,
@@ -395,6 +405,7 @@ const db: AppDatabase = {
         match.squaddingStarts, match.squaddingCloses,
         match.isRegistrationPossible ? 1 : 0, match.isSquaddingPossible ? 1 : 0,
         match.maxCompetitors,
+        match.organizerId, match.organizerName,
       )
       .run();
   },
@@ -416,6 +427,7 @@ const db: AppDatabase = {
       squadding_starts: string | null; squadding_closes: string | null;
       is_registration_possible: number | null; is_squadding_possible: number | null;
       max_competitors: number | null;
+      organizer_id: string | null; organizer_name: string | null;
     };
     const result = await db
       .prepare(
@@ -424,7 +436,8 @@ const db: AppDatabase = {
                 lat, lng, data, updated_at,
                 registration_starts, registration_closes, registration_status,
                 squadding_starts, squadding_closes,
-                is_registration_possible, is_squadding_possible, max_competitors
+                is_registration_possible, is_squadding_possible, max_competitors,
+                organizer_id, organizer_name
          FROM matches WHERE match_ref IN (${placeholders})`,
       )
       .bind(...matchRefs)
@@ -444,6 +457,8 @@ const db: AppDatabase = {
         isRegistrationPossible: !!(r.is_registration_possible),
         isSquaddingPossible: !!(r.is_squadding_possible),
         maxCompetitors: r.max_competitors,
+        organizerId: r.organizer_id,
+        organizerName: r.organizer_name,
       });
     }
     return map;

--- a/lib/db-migrations.ts
+++ b/lib/db-migrations.ts
@@ -178,6 +178,37 @@ export const MIGRATIONS: Migration[] = [
       `DELETE FROM shooter_achievements WHERE achievement_id = 'sharpshooter'`,
     ],
   },
+
+  // ── 0009_match_data_cache_last_accessed.sql ────────────────────────────
+  // Tracks when a cached match was most recently *served* to a client,
+  // distinct from `stored_at` (the first cache fill). Powers the admin
+  // access overview's "authorized + cached vs uncached" split: we can
+  // tell which authorized matches have actually been consumed through
+  // the app vs merely sitting in cache. Writes are debounced to one per
+  // ~60s per cache key to keep this near-free even for hot matches.
+  {
+    version: 9,
+    label: "match_data_cache: last_accessed_at column",
+    statements: [
+      `ALTER TABLE match_data_cache ADD COLUMN last_accessed_at TEXT`,
+      `CREATE INDEX IF NOT EXISTS idx_mdc_last_accessed ON match_data_cache(last_accessed_at)`,
+    ],
+  },
+
+  // ── 0010_matches_organizer.sql ─────────────────────────────────────────
+  // Host club / organization for each match, captured from
+  // `IpscMatchNode.organizer` (cache schema v19). Lets the access
+  // overview group cached matches by organizing club without re-parsing
+  // every cached MatchResponse blob.
+  {
+    version: 10,
+    label: "matches: organizer_id + organizer_name columns",
+    statements: [
+      `ALTER TABLE matches ADD COLUMN organizer_id TEXT`,
+      `ALTER TABLE matches ADD COLUMN organizer_name TEXT`,
+      `CREATE INDEX IF NOT EXISTS idx_matches_organizer ON matches(organizer_id)`,
+    ],
+  },
 ];
 
 /** The latest schema version — used by adapters to skip the runner when already current. */

--- a/lib/db-sqlite.ts
+++ b/lib/db-sqlite.ts
@@ -285,6 +285,12 @@ export function createSqliteDatabase(
       return row?.stored_at ?? null;
     },
 
+    async touchMatchDataCache(cacheKey, when) {
+      getDb()
+        .prepare(`UPDATE match_data_cache SET last_accessed_at = ? WHERE cache_key = ?`)
+        .run(when, cacheKey);
+    },
+
     async setMatchDataCache(cacheKey, data, meta) {
       getDb()
         .prepare(
@@ -356,8 +362,8 @@ export function createSqliteDatabase(
     async upsertMatch(match) {
       getDb()
         .prepare(
-          `INSERT INTO matches (match_ref, ct, match_id, name, venue, date, level, region, sub_rule, discipline, status, results_status, scoring_completed, competitors_count, stages_count, lat, lng, data, updated_at, registration_starts, registration_closes, registration_status, squadding_starts, squadding_closes, is_registration_possible, is_squadding_possible, max_competitors)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `INSERT INTO matches (match_ref, ct, match_id, name, venue, date, level, region, sub_rule, discipline, status, results_status, scoring_completed, competitors_count, stages_count, lat, lng, data, updated_at, registration_starts, registration_closes, registration_status, squadding_starts, squadding_closes, is_registration_possible, is_squadding_possible, max_competitors, organizer_id, organizer_name)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(match_ref)
            DO UPDATE SET name = excluded.name,
                          venue = excluded.venue,
@@ -382,7 +388,9 @@ export function createSqliteDatabase(
                          squadding_closes = excluded.squadding_closes,
                          is_registration_possible = excluded.is_registration_possible,
                          is_squadding_possible = excluded.is_squadding_possible,
-                         max_competitors = excluded.max_competitors`,
+                         max_competitors = excluded.max_competitors,
+                         organizer_id = excluded.organizer_id,
+                         organizer_name = excluded.organizer_name`,
         )
         .run(
           match.matchRef, match.ct, match.matchId, match.name,
@@ -394,6 +402,7 @@ export function createSqliteDatabase(
           match.squaddingStarts, match.squaddingCloses,
           match.isRegistrationPossible ? 1 : 0, match.isSquaddingPossible ? 1 : 0,
           match.maxCompetitors,
+          match.organizerId, match.organizerName,
         );
     },
 
@@ -414,6 +423,7 @@ export function createSqliteDatabase(
         squadding_starts: string | null; squadding_closes: string | null;
         is_registration_possible: number | null; is_squadding_possible: number | null;
         max_competitors: number | null;
+        organizer_id: string | null; organizer_name: string | null;
       };
       const rows = d
         .prepare(
@@ -422,7 +432,8 @@ export function createSqliteDatabase(
                   lat, lng, data, updated_at,
                   registration_starts, registration_closes, registration_status,
                   squadding_starts, squadding_closes,
-                  is_registration_possible, is_squadding_possible, max_competitors
+                  is_registration_possible, is_squadding_possible, max_competitors,
+                  organizer_id, organizer_name
            FROM matches WHERE match_ref IN (${placeholders})`,
         )
         .all(...matchRefs) as MatchRow[];
@@ -441,6 +452,8 @@ export function createSqliteDatabase(
           isRegistrationPossible: !!(r.is_registration_possible),
           isSquaddingPossible: !!(r.is_squadding_possible),
           maxCompetitors: r.max_competitors,
+          organizerId: r.organizer_id,
+          organizerName: r.organizer_name,
         });
       }
       return map;

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -84,6 +84,12 @@ export interface AppDatabase {
    *  Used by throttled writers to skip redundant updates. */
   getMatchDataCacheStoredAt(cacheKey: string): Promise<string | null>;
 
+  /** Bump the `last_accessed_at` timestamp on a cache row to mark it as
+   *  recently served. No-op when the row does not exist. Callers are
+   *  expected to debounce in-process (see `lib/match-data-store.ts`) so
+   *  this fires at most ~once per minute per key. */
+  touchMatchDataCache(cacheKey: string, when: string): Promise<void>;
+
   /** Store a match data entry. Upserts on cache_key. */
   setMatchDataCache(
     cacheKey: string,

--- a/lib/match-data-store.ts
+++ b/lib/match-data-store.ts
@@ -20,6 +20,17 @@ const REDIS_DRAIN_TTL = 86_400;
 /** Default minimum age (seconds) before re-writing an active-match D1 row. */
 const ACTIVE_MATCH_D1_THROTTLE_SECONDS = 120;
 
+/** Minimum interval (ms) between `last_accessed_at` bumps for the same cache
+ *  key, debounced in-process. Keeps the audit signal coarsely accurate while
+ *  bounding the D1 UPDATE rate on hot matches. Cold starts re-bump once,
+ *  which is fine — the column tracks "recently served", not exact hit count. */
+const TOUCH_DEBOUNCE_MS = 60_000;
+
+/** In-memory per-cache-key last-touch timestamps. Process-local; not shared
+ *  across CF Worker isolates or Docker replicas. Each isolate independently
+ *  debounces — duplicate writes are harmless since touch is idempotent. */
+const lastTouchedAt = new Map<string, number>();
+
 interface CacheEntryMeta {
   v?: number;
 }
@@ -28,28 +39,49 @@ interface CacheEntryMeta {
  * Read match data from Redis, falling back to D1/SQLite if not in Redis.
  * Returns the raw JSON string or null if not found in either layer.
  * Only returns D1 data if its schema_version matches the current version.
+ *
+ * Side-effect: when we serve a cached entry (from either layer) the D1
+ * row's `last_accessed_at` is bumped, debounced per-process to ~once per
+ * minute per cache key. Errors on the bump are swallowed — the read path
+ * must never fail because of an audit-bookkeeping write.
  */
 export async function getMatchDataWithFallback(
   cacheKey: string,
 ): Promise<string | null> {
+  let raw: string | null = null;
+
   // Try Redis first
   try {
-    const raw = await cache.get(cacheKey);
-    if (raw) return raw;
+    raw = await cache.get(cacheKey);
   } catch (err) {
     reportError("match-data-store.redis-read", err, { matchKey: cacheKey });
   }
 
   // Fall back to D1/SQLite — return whatever is stored; callers are responsible
   // for deciding whether a given schema version is acceptable for their use case.
-  try {
-    const raw = await db.getMatchDataCache(cacheKey);
-    if (raw) return raw;
-  } catch (err) {
-    reportError("match-data-store.d1-read", err, { matchKey: cacheKey });
+  if (!raw) {
+    try {
+      raw = await db.getMatchDataCache(cacheKey);
+    } catch (err) {
+      reportError("match-data-store.d1-read", err, { matchKey: cacheKey });
+    }
   }
 
-  return null;
+  if (raw) maybeTouchMatchDataCache(cacheKey);
+  return raw;
+}
+
+/** Bump `last_accessed_at` on the D1 row, debounced per cache key. */
+function maybeTouchMatchDataCache(cacheKey: string): void {
+  if (!parseMatchCacheKey(cacheKey)) return; // only match-tagged keys get audited
+  const now = Date.now();
+  const last = lastTouchedAt.get(cacheKey);
+  if (last !== undefined && now - last < TOUCH_DEBOUNCE_MS) return;
+  lastTouchedAt.set(cacheKey, now);
+  // Fire-and-forget — never block the read path on the audit write.
+  void db
+    .touchMatchDataCache(cacheKey, new Date(now).toISOString())
+    .catch((err) => reportError("match-data-store.touch", err, { matchKey: cacheKey }));
 }
 
 /**

--- a/lib/match-data.ts
+++ b/lib/match-data.ts
@@ -337,6 +337,8 @@ export async function fetchMatchData(
     isRegistrationPossible: ev.is_registration_possible ?? false,
     isSquaddingPossible: ev.is_squadding_possible ?? false,
     maxCompetitors: ev.max_competitors ?? null,
+    organizerId: ev.organizer?.id ?? null,
+    organizerName: ev.organizer?.name ?? null,
   }));
 
   const visibilityRaw = ev.visibility ?? "";

--- a/lib/shooter-index.ts
+++ b/lib/shooter-index.ts
@@ -74,6 +74,10 @@ export interface MatchMetadata {
   isRegistrationPossible: boolean;
   isSquaddingPossible: boolean;
   maxCompetitors: number | null;
+  /** Host club / organization id (from IpscMatchNode.organizer). Captured in
+   *  cache schema v19; null for older snapshots until they re-fetch. */
+  organizerId: string | null;
+  organizerName: string | null;
 }
 
 /**
@@ -175,6 +179,8 @@ export async function indexMatchShooters(
       isRegistrationPossible: matchMeta.isRegistrationPossible,
       isSquaddingPossible: matchMeta.isSquaddingPossible,
       maxCompetitors: matchMeta.maxCompetitors,
+      organizerId: matchMeta.organizerId,
+      organizerName: matchMeta.organizerName,
     };
     writes.push(db.upsertMatch(record).catch(() => {}));
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -782,6 +782,12 @@ export interface MatchRecord {
   isRegistrationPossible: boolean;
   isSquaddingPossible: boolean;
   maxCompetitors: number | null;
+  /** Host club / organization id (`OrganizationNode.id`). Captured from
+   *  IpscMatchNode.organizer when available; null for matches we haven't
+   *  re-fetched since cache schema v19. Powers the access-overview's
+   *  "matches by club" grouping. */
+  organizerId: string | null;
+  organizerName: string | null;
 }
 
 // ── Upcoming Matches ──────────────────────────────────────────────────────────

--- a/migrations/0009_match_data_cache_last_accessed.sql
+++ b/migrations/0009_match_data_cache_last_accessed.sql
@@ -1,0 +1,6 @@
+-- Tracks when a cached match was most recently served to a client.
+-- Distinct from `stored_at` (first cache fill); powers the access-overview's
+-- "authorized + cached vs uncached" split. Writes are debounced (~60s per key)
+-- so this stays near-free even for hot matches.
+ALTER TABLE match_data_cache ADD COLUMN last_accessed_at TEXT;
+CREATE INDEX IF NOT EXISTS idx_mdc_last_accessed ON match_data_cache(last_accessed_at);

--- a/migrations/0010_matches_organizer.sql
+++ b/migrations/0010_matches_organizer.sql
@@ -1,0 +1,7 @@
+-- Host club / organization columns on the matches domain table.
+-- Captured from IpscMatchNode.organizer (cache schema v19). Lets the
+-- access overview group cached matches by organizing club without
+-- re-parsing the cached MatchResponse blob.
+ALTER TABLE matches ADD COLUMN organizer_id TEXT;
+ALTER TABLE matches ADD COLUMN organizer_name TEXT;
+CREATE INDEX IF NOT EXISTS idx_matches_organizer ON matches(organizer_id);

--- a/tests/unit/db-sqlite.test.ts
+++ b/tests/unit/db-sqlite.test.ts
@@ -205,6 +205,8 @@ describe("AppDatabase (SQLite)", () => {
       isRegistrationPossible: true,
       isSquaddingPossible: false,
       maxCompetitors: 200,
+      organizerId: "2",
+      organizerName: "S:t Eskils Skyttar, Eskilstuna",
     };
 
     it("inserts and retrieves a match", async () => {
@@ -274,6 +276,8 @@ describe("AppDatabase (SQLite)", () => {
         isRegistrationPossible: false,
         isSquaddingPossible: false,
         maxCompetitors: null,
+        organizerId: null,
+        organizerName: null,
       };
       await db.upsertMatch(minimal);
       const result = await db.getMatchesByRefs(["22:2001"]);


### PR DESCRIPTION
## Summary

Second of three PRs in the service-account access overview series. Lays the two schema columns the admin UI in PR 3 will lean on.

- **`match_data_cache.last_accessed_at`** — bumped on every cache read via a new `touchMatchDataCache()` adapter method. Process-local debounce caps writes to ~once per minute per cache key, so even hot matches don't generate write amplification. Distinct from `stored_at` (first cache fill) so the audit overview can split "authorized + actually served" from "authorized + dormant".
- **`matches.organizer_id` + `organizer_name`** — captured from `IpscMatchNode.organizer` (added to the GraphQL response in PR 1 / cache schema v19). Lets the audit view group cached matches by host club without re-parsing the cached `MatchResponse` blobs.

## Migrations

- `0009_match_data_cache_last_accessed.sql` — `ALTER TABLE match_data_cache ADD COLUMN last_accessed_at TEXT` + supporting index.
- `0010_matches_organizer.sql` — two ALTER columns + index on `organizer_id`.

Both columns are nullable; existing rows backfill naturally on next write (or next cache touch for `last_accessed_at`). No data migration step needed.

## What's next

- **PR 3:** `service_account_access` catalog table + sync job + `/admin/access` UI (Clubs / Org Memberships / Authorized Matches with the served-vs-uncached split powered by this PR's columns).

## Test plan

- [x] `pnpm -w run typecheck` -- 0 errors
- [x] `pnpm -w run lint` -- 0 warnings
- [x] `pnpm -w test` -- 1732 passed (fixtures in tests/unit/db-sqlite.test.ts updated for new MatchRecord fields)
- [ ] Verify in dev that opening a cached match populates `last_accessed_at` on the corresponding `match_data_cache` row
- [ ] Verify in dev that re-opening the same match within 60s does NOT trigger a second UPDATE (process-local debounce)
- [ ] Verify in dev that opening a match populates `matches.organizer_id` + `organizer_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)