### PR TITLE
chore(admin): link to /admin/access from the admin top bar

### DIFF
--- a/app/admin/admin-page-client.tsx
+++ b/app/admin/admin-page-client.tsx
@@ -12,6 +12,7 @@ import {
   UserX,
   UserCheck,
   Activity,
+  KeyRound,
   LogOut,
   ExternalLink,
 } from "lucide-react";
@@ -500,7 +501,19 @@ export function AdminPageClient() {
                 aria-label="Open health dashboard in new tab"
               >
                 <Activity className="h-4 w-4 sm:mr-2" />
-                <span className="hidden sm:inline">Dashboard</span>
+                <span className="hidden sm:inline">Health</span>
+                <ExternalLink className="ml-1 hidden h-3 w-3 sm:inline" />
+              </a>
+            </Button>
+            <Button asChild size="sm" variant="ghost" className="min-h-11">
+              <a
+                href={`/admin/access?token=${encodeURIComponent(token)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Open service-account access overview in new tab"
+              >
+                <KeyRound className="h-4 w-4 sm:mr-2" />
+                <span className="hidden sm:inline">Access</span>
                 <ExternalLink className="ml-1 hidden h-3 w-3 sm:inline" />
               </a>
             </Button>


### PR DESCRIPTION
## Summary

Adds an "Access" button to the `/admin` top bar so the new service-account audit page from #442 is discoverable without bookmarking the URL by hand.

- Renames the existing top-bar "Dashboard" label to "Health" -- it links to `/admin/health` so the new label matches both itself and the new sibling.
- Adds a new "Access" button next to it linking to `/admin/access?token=…`, using the `KeyRound` icon and the same new-tab + token-pass-through pattern.

## Test plan

- [x] `pnpm -w run typecheck` -- 0 errors
- [x] `pnpm -w run lint` -- 0 warnings
- [ ] Sign in at `/admin`, confirm both Health and Access buttons appear in the top bar and open the respective dashboards in new tabs with the token forwarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)