### PR TITLE
feat(telemetry): record SSI graphql-error message as error-domain event

### DIFF
--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -10,6 +10,7 @@ import { parseMatchCacheKey, persistActiveMatchToD1 } from "@/lib/match-data-sto
 import { markUpstreamDegraded } from "@/lib/upstream-status";
 import { upstreamTelemetry, hashVariables, type UpstreamOutcome } from "@/lib/upstream-telemetry";
 import { cacheTelemetry } from "@/lib/cache-telemetry";
+import { reportError } from "@/lib/error-telemetry";
 import { isPublicMatchData } from "@/lib/visibility";
 import { getJwt, JWT_EXPIRED_ERROR_PATTERNS } from "@/lib/ssi-auth";
 
@@ -188,6 +189,7 @@ async function executeQueryOnce<T>(
     const msg = result.errors.map((e) => e.message).join("; ");
     console.error(`[ssi-api] ${operationName} GraphQL error | vars=${JSON.stringify(variables ?? {})} | ${msg}`);
     emit("graphql-error", { bytes: bodyText.length });
+    reportError(`ssi-graphql-error:${operationName}`, new Error(msg));
     throw new Error(msg);
   }
 


### PR DESCRIPTION
## Summary
- Investigated red numbers on /admin/health: 14 SSI graphql-errors in 24h (11 GetEvents in a 250ms burst, 3 MatchUpdatedProbe) -- but the actual SSI error text was only console.error'd, never persisted.
- Added a single \`reportError(\`ssi-graphql-error:\${operationName}\`, new Error(msg))\` call at the existing graphql-error site in \`lib/graphql.ts\`. The upstream domain stays a clean metrics stream; the diagnostic payload goes through the error domain that already exists for exactly this.
- Next failure shows up in /admin/health Recent errors card with truncated message + op, and is queryable via \`r2-telemetry --domain error\`.

## Test plan
- [x] \`pnpm -w run typecheck\` clean
- [x] \`pnpm -w run lint\` clean
- [x] \`pnpm -w test\` -- 1740 tests pass
- [ ] After deploy, confirm the next graphql-error surfaces in /admin/health Recent errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)