### PR TITLE
feat(admin): refresh button on /admin/access dashboard

### DIFF
--- a/app/admin/access/page.tsx
+++ b/app/admin/access/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import type { ServiceAccountAccessRow } from "@/lib/types";
+import { RefreshButton } from "./refresh-button";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -96,6 +97,7 @@ export default async function AdminAccessPage({ searchParams }: PageProps) {
     <main className="mx-auto flex max-w-md flex-col gap-3 p-3 pb-24">
       <header className="flex items-center justify-between gap-2 px-1">
         <h1 className="text-xl font-semibold">Service account access</h1>
+        <RefreshButton token={provided as string} />
       </header>
 
       <Card>

--- a/app/admin/access/refresh-button.tsx
+++ b/app/admin/access/refresh-button.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  token: string;
+}
+
+export function RefreshButton({ token }: Props) {
+  const router = useRouter();
+  const [isFetching, setIsFetching] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const busy = isFetching || isPending;
+
+  async function handleClick() {
+    setError(null);
+    setIsFetching(true);
+    try {
+      const res = await fetch("/api/admin/access/refresh", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(body?.error || `HTTP ${res.status}`);
+      }
+      startTransition(() => router.refresh());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsFetching(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={handleClick}
+        disabled={busy}
+        aria-label="Refresh access catalog from SSI"
+      >
+        {busy ? "refreshing..." : "refresh"}
+      </Button>
+      {error ? (
+        <div role="alert" className="text-xs text-destructive">
+          {error}
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- The `/admin/access` dashboard reads from the `service_account_access` D1 table, which is only populated by `POST /api/admin/access/refresh`. The daily cron was deferred when #442 landed, so on a fresh deploy the dashboard renders empty with no obvious way to fix it from the UI.
- Adds a header-level refresh button that POSTs to the existing endpoint using the token already in the URL, shows a pending state, surfaces errors inline (`role="alert"`), and re-renders the server component via `router.refresh()` on success.
- Footer curl hint is kept -- still useful for ops scripts and the deferred cron.

## Test plan
- [ ] Load `/admin/access?token=<CACHE_PURGE_SECRET>` on a fresh DB and confirm dashboard starts empty.
- [ ] Click `refresh`, observe `refreshing...` state, then dashboard populates with clubs / org memberships / matches.
- [ ] Pass a wrong token (e.g. truncate one char) and confirm the inline error renders with the upstream message.
- [ ] Confirm `pnpm -w run typecheck` and `pnpm -w run lint` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)