### PR TITLE
fix(telemetry): skip error-domain log for JWT-expiry graphql errors

### DIFF
--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -189,7 +189,15 @@ async function executeQueryOnce<T>(
     const msg = result.errors.map((e) => e.message).join("; ");
     console.error(`[ssi-api] ${operationName} GraphQL error | vars=${JSON.stringify(variables ?? {})} | ${msg}`);
     emit("graphql-error", { bytes: bodyText.length });
-    reportError(`ssi-graphql-error:${operationName}`, new Error(msg));
+    // Skip error-domain telemetry for JWT-expiry messages: the outer
+    // `executeQuery` wrapper force-refreshes the JWT and retries once, and
+    // the retry almost always succeeds. Surfacing these in the error feed
+    // produces false-alarm noise in the admin dashboard. The upstream
+    // `graphql-error` outcome above still records the first-attempt failure
+    // for operational debugging.
+    if (!JWT_EXPIRED_ERROR_PATTERNS.some((p) => msg.includes(p))) {
+      reportError(`ssi-graphql-error:${operationName}`, new Error(msg));
+    }
     throw new Error(msg);
   }
 


### PR DESCRIPTION
## Summary
- The admin dashboard's error feed was filling with "User must be authenticated" entries that are routine JWT-refresh retries, not real errors.
- `executeQuery` already catches JWT-expiry messages, force-refreshes via `getJwt({force:true})`, and retries once -- the retry succeeds within ~0.3-2s for every burst seen in R2 telemetry over the last 24h.
- Skip `reportError()` for messages matching `JWT_EXPIRED_ERROR_PATTERNS` so the error-domain feed only surfaces errors that actually propagate.
- Upstream-domain `graphql-error` outcome is unchanged, so the retry pattern remains visible for operational debugging.

## Test plan
- [x] `pnpm -w run typecheck` -- clean
- [x] `pnpm -w test` -- 1740 passed
- [ ] After merge: confirm admin dashboard stops showing JWT-expiry entries while real graphql-errors still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)