### PR TITLE
fix(costs): opt update-costs workflow into Node 24

### DIFF
--- a/.github/workflows/update-costs.yml
+++ b/.github/workflows/update-costs.yml
@@ -27,6 +27,11 @@ jobs:
     # the account, so staging usage is included automatically.
     environment: production
     timeout-minutes: 10
+    env:
+      # Opt JavaScript actions (e.g. peter-evans/create-pull-request) into
+      # Node 24 ahead of the June 2026 default switch — silences the Node 20
+      # deprecation warning until the action ships a Node 24 release.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
The first successful run of \`Update Running Costs\` (after #449 + #450) emitted a Node 20 deprecation warning because \`peter-evans/create-pull-request@v7\` still bundles Node 20. Setting \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true\` at the job level forces JS actions onto Node 24 ahead of the June 2026 default switch.

## Test plan
- [ ] Re-run the workflow and confirm the deprecation warning is gone, the action still completes, and the refresh PR is updated/created

🤖 Generated with [Claude Code](https://claude.com/claude-code)