### PR TITLE
feat(telemetry): include match identity on swallowed graphql errors

### DIFF
--- a/lib/error-telemetry.ts
+++ b/lib/error-telemetry.ts
@@ -27,6 +27,8 @@ export interface ErrorEvent {
   /** Content-type discriminator. Stored as-is — callers pass either number or string. */
   ct?: number | string | null;
   matchId?: string | null;
+  /** Same hash used by upstream-domain events; lets you correlate an error with the failing request. */
+  varsHash?: string | null;
 }
 
 export function reportError(

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -196,7 +196,9 @@ async function executeQueryOnce<T>(
     // `graphql-error` outcome above still records the first-attempt failure
     // for operational debugging.
     if (!JWT_EXPIRED_ERROR_PATTERNS.some((p) => msg.includes(p))) {
-      reportError(`ssi-graphql-error:${operationName}`, new Error(msg));
+      const ct = typeof variables?.ct === "number" || typeof variables?.ct === "string" ? variables.ct : null;
+      const matchId = typeof variables?.id === "string" ? variables.id : null;
+      reportError(`ssi-graphql-error:${operationName}`, new Error(msg), { ct, matchId, varsHash });
     }
     throw new Error(msg);
   }

--- a/tests/unit/error-telemetry.test.ts
+++ b/tests/unit/error-telemetry.test.ts
@@ -46,12 +46,14 @@ describe("reportError", () => {
       shooterId: 12345,
       ct: 22,
       matchId: "67890",
+      varsHash: "abc12345",
     });
     const line = JSON.parse(infoSpy.mock.calls[0][0] as string);
     expect(line.matchKey).toBe("gql:GetMatch:foo");
     expect(line.shooterId).toBe(12345);
     expect(line.ct).toBe(22);
     expect(line.matchId).toBe("67890");
+    expect(line.varsHash).toBe("abc12345");
   });
 
   it("does not include a stack trace", () => {


### PR DESCRIPTION
## Summary
- Error-domain events from `ssi-graphql-error:*` carried only `site`/`errorClass`/`errorMsg`. A burst of "not allowed to view event" (observed today: 8 events in 17s) was unactionable -- no way to know if it was one private match or eight, or to correlate with the matching `upstream`-domain rows.
- Forward `ct` + `matchId` from `variables`, plus the `varsHash` we already compute for upstream telemetry, so `--group-by ct,matchId` and `--where varsHash=...` now work against the error feed.

## Test plan
- [x] `pnpm -w run typecheck` clean
- [x] `pnpm -w run lint` clean
- [x] Extended `tests/unit/error-telemetry.test.ts` to assert `varsHash` is forwarded; all 5 cases pass
- [ ] After deploy: trigger a `GetMatch` against a private match and confirm the error event carries `ct`, `matchId`, `varsHash` in R2

🤖 Generated with [Claude Code](https://claude.com/claude-code)