### PR TITLE
feat(coaching): anchor stage card on shooter dashboard (#465)

### DIFF
--- a/app/api/shooter/[shooterId]/route.ts
+++ b/app/api/shooter/[shooterId]/route.ts
@@ -10,7 +10,8 @@ import type { ShooterProfile } from "@/lib/shooter-index";
 import { parseRawScorecards } from "@/lib/scorecard-data";
 import { extractDivision } from "@/lib/divisions";
 import { computeAggregateStats } from "@/lib/shooter-stats";
-import { computeMatchStats } from "@/lib/match-stats";
+import { computeMatchStats, computeStagePercentages, type StagePercentRecord } from "@/lib/match-stats";
+import { computeAnchorStage, type StagePctRecord } from "@/lib/anchor-stage";
 import { evaluateAchievements } from "@/lib/achievements/evaluate";
 import { maybeTagAsMcp } from "@/lib/telemetry-context";
 import type {
@@ -231,6 +232,7 @@ export async function GET(
   // Load match + scorecard cache entries in parallel (batched to avoid flood)
   const BATCH = 10;
   const matchSummaries: ShooterMatchSummary[] = [];
+  const allStagePctRecords: StagePctRecord[] = [];
 
   for (let i = 0; i < recentRefs.length; i += BATCH) {
     const batch = recentRefs.slice(i, i + BATCH);
@@ -343,6 +345,7 @@ export async function GET(
           let wasDQ = false;
           let perfectStagesCount = 0;
           let consistencyIndexValue: number | null = null;
+          let stagePcts: StagePercentRecord[] = [];
 
           if (scorecardsRaw) {
             try {
@@ -369,6 +372,7 @@ export async function GET(
               wasDQ = mStats.dq;
               perfectStagesCount = mStats.perfectStages;
               consistencyIndexValue = mStats.consistencyIndex;
+              stagePcts = computeStagePercentages(competitorId, division, rawScorecards);
             } catch { /* skip scorecard stats on parse error */ }
           }
 
@@ -399,13 +403,27 @@ export async function GET(
             squadmateShooterIds,
             squadAllSameClub,
           };
-          return summary;
+          return { summary, stagePcts, matchDate: ev.starts ?? null, matchName: ev.name };
         } catch { return null; }
       }),
     );
 
     for (const result of batchResults) {
-      if (result) matchSummaries.push(result);
+      if (result) {
+        matchSummaries.push(result.summary);
+        for (const sp of result.stagePcts) {
+          allStagePctRecords.push({
+            stagePct: sp.stagePct,
+            stageName: sp.stageName,
+            stageNumber: sp.stageNumber,
+            matchName: result.matchName,
+            ct: result.summary.ct,
+            matchId: result.summary.matchId,
+            date: result.matchDate,
+            division: result.summary.division,
+          });
+        }
+      }
     }
   }
 
@@ -494,8 +512,9 @@ export async function GET(
     }
   }
 
-  // ── 4. Compute cross-match aggregates ─────────────────────────────────────
+  // ── 4. Compute cross-match aggregates and anchor stage ───────────────────
   const stats = computeAggregateStats(matchSummaries);
+  const anchorStage = computeAnchorStage(allStagePctRecords);
 
   // ── 5. Evaluate achievements ───────────────────────────────────────────────
   let storedAchievements: import("@/lib/achievements/types").StoredAchievement[] = [];
@@ -522,6 +541,7 @@ export async function GET(
     matches: matchSummaries,
     stats,
     achievements,
+    anchorStage,
     ...(upcomingMatches.length > 0 ? { upcomingMatches } : {}),
   };
 

--- a/app/shooter/[shooterId]/shooter-dashboard-client.tsx
+++ b/app/shooter/[shooterId]/shooter-dashboard-client.tsx
@@ -89,6 +89,7 @@ import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { AnchorStageCard } from "@/components/anchor-stage-card";
 import type {
   ShooterMatchSummary,
   BackfillProgress,
@@ -1906,6 +1907,11 @@ export function ShooterDashboardClient({ shooterId, from }: Props) {
             </div>
           )}
         </section>
+      )}
+
+      {/* ── Anchor stage (peak stage card) ────────────────────────── */}
+      {data.anchorStage && (
+        <AnchorStageCard anchorStage={data.anchorStage} />
       )}
 
       {/* ── Trend charts (collapsed by default) ────────────────────── */}

--- a/components/anchor-stage-card.tsx
+++ b/components/anchor-stage-card.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { HelpCircle, ExternalLink } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+} from "@/components/ui/popover";
+import type { AnchorStage } from "@/lib/types";
+
+interface AnchorStageCardProps {
+  anchorStage: AnchorStage;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("en-GB", { year: "numeric", month: "short" });
+}
+
+export function AnchorStageCard({ anchorStage }: AnchorStageCardProps) {
+  const matchPath = `/match/${anchorStage.ct}/${anchorStage.matchId}#stage-${anchorStage.stageNumber}`;
+  const stagePctDisplay = anchorStage.stagePct.toFixed(1);
+  const dateStr = formatDate(anchorStage.date);
+  const metaParts = [
+    anchorStage.division,
+    dateStr,
+  ].filter(Boolean);
+
+  return (
+    <section aria-labelledby="anchor-stage-heading">
+      <div className="flex items-center gap-1 mb-2">
+        <h2
+          id="anchor-stage-heading"
+          className="text-sm font-semibold text-muted-foreground uppercase tracking-wide"
+        >
+          Your peak stage
+        </h2>
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+              aria-label="About your peak stage"
+            >
+              <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-80" side="bottom" align="start">
+            <PopoverHeader>
+              <PopoverTitle>Your peak stage</PopoverTitle>
+              <PopoverDescription>
+                The single best stage in your match history -- highest hit factor as a percentage of the division stage winner.
+              </PopoverDescription>
+            </PopoverHeader>
+            <div className="text-xs text-muted-foreground space-y-1.5 mt-2">
+              <p>The percentage shown is your hit factor divided by the division stage winner&apos;s hit factor. 100% means you won the stage outright.</p>
+              <p>Shown when you have at least 10 valid stages on record. Use it as a confidence cue before your next match -- this is your ceiling.</p>
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      <a
+        href={matchPath}
+        className="group block rounded-lg border bg-muted/30 p-4 hover:bg-muted/50 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+        aria-label={`Your best stage: ${stagePctDisplay}% of stage winner on Stage ${anchorStage.stageNumber}, ${anchorStage.stageName}, at ${anchorStage.matchName}. Open match page.`}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div
+              className="text-3xl font-bold tabular-nums leading-none mb-1"
+              aria-hidden="true"
+            >
+              {stagePctDisplay}%
+            </div>
+            <div className="text-xs text-muted-foreground mb-0.5">
+              of stage winner
+            </div>
+            <div className="font-medium text-sm truncate">
+              Stage {anchorStage.stageNumber}: {anchorStage.stageName}
+            </div>
+            <div className="text-xs text-muted-foreground truncate">
+              {anchorStage.matchName}
+            </div>
+            {metaParts.length > 0 && (
+              <div className="text-xs text-muted-foreground/70 mt-0.5">
+                {metaParts.join(" · ")}
+              </div>
+            )}
+          </div>
+          <ExternalLink
+            className="w-4 h-4 text-muted-foreground shrink-0 mt-1 group-hover:text-foreground transition-colors"
+            aria-hidden="true"
+          />
+        </div>
+      </a>
+    </section>
+  );
+}

--- a/components/comparison-table.tsx
+++ b/components/comparison-table.tsx
@@ -1479,7 +1479,7 @@ export function ComparisonTable({ data, scoringCompleted, onRemove, aiAvailable,
           </thead>
           <tbody>
             {sortedStages.map((stage) => (
-              <tr key={stage.stage_id} className="border-b hover:bg-muted/30">
+              <tr key={stage.stage_id} id={`stage-${stage.stage_num}`} className="border-b hover:bg-muted/30 target:bg-amber-500/10">
                 <td className="sticky left-0 z-10 bg-background py-2 pr-2 font-medium shadow-[2px_0_4px_-2px_rgba(0,0,0,0.08)] dark:shadow-[2px_0_4px_-2px_rgba(0,0,0,0.4)]">
                   {/* Mobile: compact "S{n}" label + info popover; icons stacked below */}
                   <div className="flex flex-col items-start gap-0.5 sm:hidden">

--- a/lib/anchor-stage.ts
+++ b/lib/anchor-stage.ts
@@ -1,0 +1,48 @@
+// Pure function for selecting the shooter's best-ever stage. No I/O, fully unit-tested.
+
+import type { AnchorStage } from "@/lib/types";
+
+export interface StagePctRecord {
+  stagePct: number;
+  stageName: string;
+  stageNumber: number;
+  matchName: string;
+  ct: string;
+  matchId: string;
+  date: string | null;
+  division: string | null;
+}
+
+const MIN_STAGES = 10;
+
+/**
+ * Pick the shooter's single best stage from their match history.
+ * Returns null when fewer than MIN_STAGES valid stage records are provided.
+ * Tiebreak: most recent date wins (ISO date string comparison, desc).
+ */
+export function computeAnchorStage(stages: StagePctRecord[]): AnchorStage | null {
+  if (stages.length < MIN_STAGES) return null;
+
+  let best = stages[0];
+  for (let i = 1; i < stages.length; i++) {
+    const s = stages[i];
+    if (s.stagePct > best.stagePct) {
+      best = s;
+    } else if (s.stagePct === best.stagePct) {
+      const db = best.date ?? "";
+      const ds = s.date ?? "";
+      if (ds > db) best = s;
+    }
+  }
+
+  return {
+    stageName: best.stageName,
+    stageNumber: best.stageNumber,
+    matchName: best.matchName,
+    ct: best.ct,
+    matchId: best.matchId,
+    date: best.date,
+    division: best.division,
+    stagePct: best.stagePct,
+  };
+}

--- a/lib/match-stats.ts
+++ b/lib/match-stats.ts
@@ -2,6 +2,60 @@
 
 import type { RawScorecard } from "@/app/api/compare/logic";
 
+export interface StagePercentRecord {
+  stageId: number;
+  stageName: string;
+  stageNumber: number;
+  /** HF as a percentage of the division stage winner's HF (0-100). */
+  stagePct: number;
+}
+
+/**
+ * Returns per-stage division percentages for one competitor.
+ * Excludes DNF / DQ / zeroed stages and stages where the division winner HF is unknown.
+ * Returns [] when division is null or no valid stages exist.
+ */
+export function computeStagePercentages(
+  competitorId: number,
+  division: string | null,
+  rawScorecards: RawScorecard[],
+): StagePercentRecord[] {
+  if (!division) return [];
+
+  const myCards = rawScorecards.filter(
+    (sc) =>
+      sc.competitor_id === competitorId &&
+      !sc.dnf &&
+      !sc.dq &&
+      !sc.zeroed &&
+      sc.hit_factor != null &&
+      sc.hit_factor > 0,
+  );
+  if (myCards.length === 0) return [];
+
+  const stageWinnerHF = new Map<number, number>();
+  for (const sc of rawScorecards) {
+    if (sc.competitor_division !== division) continue;
+    if (sc.dnf || sc.dq || sc.zeroed) continue;
+    if (sc.hit_factor == null || sc.hit_factor <= 0) continue;
+    const cur = stageWinnerHF.get(sc.stage_id) ?? 0;
+    if (sc.hit_factor > cur) stageWinnerHF.set(sc.stage_id, sc.hit_factor);
+  }
+
+  const result: StagePercentRecord[] = [];
+  for (const sc of myCards) {
+    const winnerHF = stageWinnerHF.get(sc.stage_id) ?? 0;
+    if (winnerHF <= 0 || sc.hit_factor == null) continue;
+    result.push({
+      stageId: sc.stage_id,
+      stageName: sc.stage_name,
+      stageNumber: sc.stage_number,
+      stagePct: (sc.hit_factor / winnerHF) * 100,
+    });
+  }
+  return result;
+}
+
 export interface MatchStats {
   stageCount: number;
   avgHF: number | null;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -956,6 +956,19 @@ export interface ShooterAggregateStats {
   avgConsistencyIndex?: number | null;
 }
 
+/** The shooter's single best-ever stage, by division HF% of stage winner. */
+export interface AnchorStage {
+  stageName: string;
+  stageNumber: number;
+  matchName: string;
+  ct: string;
+  matchId: string;
+  date: string | null;
+  division: string | null;
+  /** HF as a percentage of the division stage winner's HF (0-100). */
+  stagePct: number;
+}
+
 // Response from GET /api/shooter/{shooterId}.
 export interface ShooterDashboardResponse {
   shooterId: number;
@@ -980,6 +993,8 @@ export interface ShooterDashboardResponse {
   upcomingMatches?: UpcomingMatch[];
   /** Achievement progress (preview feature). */
   achievements?: _AchievementProgress[];
+  /** The shooter's best-ever stage (N >= 10 valid stages required). Null when not enough data. */
+  anchorStage?: AnchorStage | null;
 }
 
 // Response from GET /api/shooter/search.

--- a/tests/unit/anchor-stage.test.ts
+++ b/tests/unit/anchor-stage.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { computeAnchorStage, type StagePctRecord } from "@/lib/anchor-stage";
+
+function makeRecord(overrides: Partial<StagePctRecord> = {}): StagePctRecord {
+  return {
+    stagePct: 80,
+    stageName: "Stage 1",
+    stageNumber: 1,
+    matchName: "Test Match",
+    ct: "22",
+    matchId: "100",
+    date: "2025-01-01",
+    division: "Production Optics",
+    ...overrides,
+  };
+}
+
+function makeRecords(count: number, basePct = 80): StagePctRecord[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeRecord({ stageNumber: i + 1, stageName: `Stage ${i + 1}`, stagePct: basePct }),
+  );
+}
+
+describe("computeAnchorStage", () => {
+  it("returns null when fewer than 10 stages", () => {
+    expect(computeAnchorStage(makeRecords(9))).toBeNull();
+  });
+
+  it("returns null for empty input", () => {
+    expect(computeAnchorStage([])).toBeNull();
+  });
+
+  it("returns null for exactly 9 stages (boundary)", () => {
+    expect(computeAnchorStage(makeRecords(9))).toBeNull();
+  });
+
+  it("returns a result for exactly 10 stages", () => {
+    const result = computeAnchorStage(makeRecords(10));
+    expect(result).not.toBeNull();
+  });
+
+  it("picks the stage with highest stagePct", () => {
+    const stages = makeRecords(10, 70);
+    stages[4] = makeRecord({ stageNumber: 5, stageName: "Best", stagePct: 98.5 });
+    const result = computeAnchorStage(stages);
+    expect(result?.stageName).toBe("Best");
+    expect(result?.stagePct).toBe(98.5);
+  });
+
+  it("returns correct metadata on the best stage", () => {
+    const stages = makeRecords(10, 70);
+    stages[2] = makeRecord({
+      stageNumber: 3,
+      stageName: "Stage 3",
+      stagePct: 97.0,
+      matchName: "SPSK Open 2025",
+      ct: "22",
+      matchId: "12345",
+      date: "2025-06-01",
+      division: "Standard",
+    });
+    const result = computeAnchorStage(stages);
+    expect(result).toEqual({
+      stageName: "Stage 3",
+      stageNumber: 3,
+      matchName: "SPSK Open 2025",
+      ct: "22",
+      matchId: "12345",
+      date: "2025-06-01",
+      division: "Standard",
+      stagePct: 97.0,
+    });
+  });
+
+  it("tiebreaks by most recent date when stagePct is equal", () => {
+    const stages = makeRecords(10, 80);
+    stages[0] = makeRecord({ stagePct: 95, date: "2024-01-01", stageName: "Old" });
+    stages[1] = makeRecord({ stagePct: 95, date: "2025-06-15", stageName: "Recent" });
+    const result = computeAnchorStage(stages);
+    expect(result?.stageName).toBe("Recent");
+  });
+
+  it("tiebreaks: null date loses to any real date", () => {
+    const stages = makeRecords(10, 80);
+    stages[0] = makeRecord({ stagePct: 95, date: null, stageName: "NoDate" });
+    stages[1] = makeRecord({ stagePct: 95, date: "2025-01-01", stageName: "Dated" });
+    const result = computeAnchorStage(stages);
+    expect(result?.stageName).toBe("Dated");
+  });
+
+  it("works when all stages are from different matches", () => {
+    const stages = Array.from({ length: 10 }, (_, i) =>
+      makeRecord({
+        stageNumber: 1,
+        matchId: String(i + 1),
+        matchName: `Match ${i + 1}`,
+        stagePct: 50 + i * 5,
+      }),
+    );
+    const result = computeAnchorStage(stages);
+    expect(result?.matchId).toBe("10");
+    expect(result?.stagePct).toBe(95);
+  });
+
+  it("handles 100% stages (stage winner)", () => {
+    const stages = makeRecords(10, 80);
+    stages[5] = makeRecord({ stagePct: 100, stageName: "Perfect" });
+    const result = computeAnchorStage(stages);
+    expect(result?.stagePct).toBe(100);
+    expect(result?.stageName).toBe("Perfect");
+  });
+
+  it("processes large history without error", () => {
+    const stages = makeRecords(200, 75);
+    stages[150] = makeRecord({ stagePct: 99.9, stageName: "Peak" });
+    const result = computeAnchorStage(stages);
+    expect(result?.stageName).toBe("Peak");
+  });
+});


### PR DESCRIPTION
## Summary

- New pure helper `lib/anchor-stage.ts` with `computeAnchorStage()` -- picks the best stage by division HF% of stage winner across all cached matches; N >= 10 guard
- `computeStagePercentages()` added to `lib/match-stats.ts` -- computes per-stage division percentages in the same scorecard pass as `computeMatchStats` (no extra I/O)
- Shooter dashboard API (`app/api/shooter/[shooterId]/route.ts`) now accumulates stage records and computes `anchorStage` during the existing batch, included in the cached response
- New `components/anchor-stage-card.tsx` -- full-width `<a>` card, `text-3xl` hero number, `<section aria-labelledby>` wrapper, `?` info popover per CLAUDE.md convention
- Stage rows in the comparison table get `id="stage-{n}"` + `target:bg-amber-500/10` so the deep link from the card scrolls and highlights the right row
- Dashboard client inserts the card between aggregate stats and performance trends per the IA doc §4a order
- 11 unit tests covering: sample-size guard, best-stage selection, tiebreak (most recent date), metadata passthrough, edge cases

## IA checklist (docs/coaching-features-ia.md §6)

- [x] Not identity-gated -- renders for the subject of any dashboard with N >= 10 stages (§4b: "Anchor stage always renders when the underlying shooter has N >= 10 stages; it's not about who is viewing")
- [x] Section order matches §4a: identity -> aggregates -> anchor stage -> trends -> upcoming -> history -> achievements
- [x] `<section aria-labelledby="anchor-stage-heading">` with unique label
- [x] Heading is h2 (next level after h1 identity heading)
- [x] `?` info popover follows existing pattern
- [x] Card is a single semantic `<a>` with descriptive `aria-label`
- [x] `ExternalLink` icon is `aria-hidden="true"`
- [x] Hero number `text-3xl` -- readable at 390px
- [x] Full-width card, no horizontal overflow at 390px
- [x] Deep link `#stage-{n}` with `:target` highlight on the comparison table row
- [x] No schema change, no migration, no new GraphQL call
- [x] `pnpm -w run lint && pnpm -w run typecheck && pnpm -w test` all clean

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)