### PR TITLE
feat(coaching): near-achievement nudges on shooter dashboard

### DIFF
--- a/app/shooter/[shooterId]/shooter-dashboard-client.tsx
+++ b/app/shooter/[shooterId]/shooter-dashboard-client.tsx
@@ -90,6 +90,7 @@ import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { AnchorStageCard } from "@/components/anchor-stage-card";
+import { computeNearAchievements } from "@/lib/achievements/near";
 import type {
   ShooterMatchSummary,
   BackfillProgress,
@@ -1491,6 +1492,143 @@ function AchievementCard({ achievement }: { achievement: AchievementProgress }) 
   );
 }
 
+// ─── Near-achievement nudge section ──────────────────────────────────────────
+
+function NearAchievementsSection({
+  achievements,
+}: {
+  achievements: AchievementProgress[];
+}) {
+  const near = computeNearAchievements(achievements);
+  if (near.length === 0) return null;
+
+  return (
+    <section aria-labelledby="near-achievements-heading">
+      <div className="flex items-center gap-1 mb-3">
+        <h2
+          id="near-achievements-heading"
+          className="text-sm font-semibold text-muted-foreground uppercase tracking-wide"
+        >
+          Close to unlocking
+        </h2>
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label="About close to unlocking"
+              className="ml-1 text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="max-w-xs text-sm space-y-2" side="top">
+            <p className="font-medium">Close to unlocking</p>
+            <p className="text-muted-foreground">
+              These are the achievement tiers you are closest to earning right
+              now, sorted by how far through the current step you are. Tap a
+              card to see the full ladder.
+            </p>
+            <p className="text-muted-foreground">
+              Only achievements where you have covered at least a quarter of the
+              way toward the next tier are shown here.
+            </p>
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+        {near.map(({ progress, remaining, nudge }) => {
+          const { definition, nextTier, progressToNext, unlockedTiers } = progress;
+          const Icon = ACHIEVEMENT_ICONS[definition.icon] ?? HelpCircle;
+          const highestTier =
+            unlockedTiers.length > 0 ? unlockedTiers[unlockedTiers.length - 1] : null;
+          const colorClass = highestTier
+            ? (TIER_COLORS[highestTier.level] ?? TIER_COLORS[1])
+            : "bg-muted/40 text-muted-foreground";
+
+          return (
+            <Popover key={definition.id}>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  className="flex items-start gap-3 rounded-lg border bg-muted/30 p-3 text-left w-full transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  aria-label={`${definition.name}: ${nudge} until ${nextTier?.name ?? "next tier"}. ${Math.round(progressToNext * 100)}% complete. Tap to see full ladder.`}
+                >
+                  <span
+                    className={cn(
+                      "mt-0.5 w-8 h-8 rounded-full flex-none flex items-center justify-center",
+                      colorClass,
+                    )}
+                    aria-hidden="true"
+                  >
+                    <Icon className="w-4 h-4" aria-hidden="true" />
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-xs font-semibold truncate">
+                      {definition.name}
+                      <span className="ml-1.5 font-normal text-muted-foreground">
+                        {nextTier?.name}
+                      </span>
+                    </span>
+                    <span className="block text-xs text-muted-foreground mt-0.5 truncate">
+                      {nudge}
+                    </span>
+                    <Progress
+                      value={progressToNext * 100}
+                      className="h-1 mt-1.5"
+                      aria-label={`${Math.round(progressToNext * 100)}% to ${nextTier?.name}`}
+                    />
+                  </span>
+                </button>
+              </PopoverTrigger>
+              <PopoverContent className="max-w-xs text-sm space-y-2" side="top">
+                <p className="font-medium flex items-center gap-1.5">
+                  <Icon className="w-4 h-4 shrink-0" aria-hidden="true" />
+                  {definition.name}
+                </p>
+                <p className="text-muted-foreground">{definition.description}</p>
+                <div className="space-y-1">
+                  {definition.tiers.map((tier) => {
+                    const unlocked = unlockedTiers.some((u) => u.level === tier.level);
+                    return (
+                      <div
+                        key={tier.level}
+                        className={cn(
+                          "flex items-center gap-2 text-xs",
+                          unlocked ? "text-foreground" : "text-muted-foreground",
+                        )}
+                      >
+                        <span aria-hidden="true">{unlocked ? "✓" : "○"}</span>
+                        <span className="font-medium">{tier.name}</span>
+                        <span className="text-muted-foreground">{tier.label}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+                {nextTier && (
+                  <div className="pt-1">
+                    <Progress
+                      value={progressToNext * 100}
+                      className="h-1.5"
+                      aria-label={`${Math.round(progressToNext * 100)}% to ${nextTier.name}`}
+                    />
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      {Math.round(progressToNext * 100)}% to {nextTier.name} —{" "}
+                      {remaining} more {nextTier.label.replace(/^\d+\s*/, "").trim()}
+                    </p>
+                  </div>
+                )}
+              </PopoverContent>
+            </Popover>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+// ─── Achievements section ────────────────────────────────────────────────────
+
 function AchievementsSection({
   achievements,
 }: {
@@ -1912,6 +2050,11 @@ export function ShooterDashboardClient({ shooterId, from }: Props) {
       {/* ── Anchor stage (peak stage card) ────────────────────────── */}
       {data.anchorStage && (
         <AnchorStageCard anchorStage={data.anchorStage} />
+      )}
+
+      {/* ── Near achievements (close-to-unlock nudges) ────────────── */}
+      {data.achievements && data.achievements.length > 0 && (
+        <NearAchievementsSection achievements={data.achievements} />
       )}
 
       {/* ── Trend charts (collapsed by default) ────────────────────── */}

--- a/lib/achievements/near.ts
+++ b/lib/achievements/near.ts
@@ -1,0 +1,59 @@
+// Pure function for near-achievement nudges. No I/O, fully unit-tested.
+
+import type { AchievementProgress } from "./types";
+
+export interface NearAchievement {
+  /** Full progress object — used by the UI to render the tier popover. */
+  progress: AchievementProgress;
+  remaining: number;
+  /** Human-readable nudge: "{N} more {unit}" e.g. "3 more matches" */
+  nudge: string;
+}
+
+const MAX_NEAR = 3;
+
+/**
+ * At least 25% of the way through the step toward the next tier is
+ * the threshold for "near". Anything below is not actionable today.
+ */
+const MIN_PROGRESS_TO_NEXT = 0.25;
+
+/**
+ * Extract the unit word(s) from a tier label like "5 matches" → "matches".
+ * Labels follow the format "{threshold} {unit}", e.g. "25 matches",
+ * "3 divisions", "100 stages".
+ */
+function unitFromLabel(label: string): string {
+  return label.replace(/^\d+\s*/, "").trim();
+}
+
+/**
+ * Return up to MAX_NEAR near-achievement nudges sorted by closest first
+ * (highest progressToNext = smallest remaining proportion).
+ *
+ * Excludes: already-maxed achievements (nextTier === null) and achievements
+ * where the shooter has covered less than MIN_PROGRESS_TO_NEXT of the
+ * current step toward the next tier.
+ */
+export function computeNearAchievements(
+  achievements: AchievementProgress[],
+): NearAchievement[] {
+  const candidates: NearAchievement[] = [];
+
+  for (const a of achievements) {
+    if (!a.nextTier) continue;
+    if (a.progressToNext < MIN_PROGRESS_TO_NEXT) continue;
+
+    const remaining = a.nextTier.threshold - a.currentValue;
+    const unit = unitFromLabel(a.nextTier.label);
+
+    candidates.push({
+      progress: a,
+      remaining,
+      nudge: `${remaining} more ${unit}`,
+    });
+  }
+
+  candidates.sort((a, b) => b.progress.progressToNext - a.progress.progressToNext);
+  return candidates.slice(0, MAX_NEAR);
+}

--- a/tests/unit/near-achievements.test.ts
+++ b/tests/unit/near-achievements.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { computeNearAchievements } from "@/lib/achievements/near";
+import type { AchievementProgress } from "@/lib/achievements/types";
+
+function makeProgress(overrides: Partial<AchievementProgress> = {}): AchievementProgress {
+  return {
+    definition: {
+      id: "match-count",
+      name: "Competitor",
+      description: "Test achievement",
+      category: "milestone",
+      icon: "trophy",
+      tiers: [
+        { level: 1, name: "First", threshold: 1, label: "1 match" },
+        { level: 2, name: "Regular", threshold: 5, label: "5 matches" },
+        { level: 3, name: "Veteran", threshold: 10, label: "10 matches" },
+      ],
+    },
+    currentValue: 7,
+    unlockedTiers: [
+      { level: 1, unlockedAt: "2024-01-01", matchRef: null, value: 1 },
+      { level: 2, unlockedAt: "2024-06-01", matchRef: null, value: 5 },
+    ],
+    nextTier: { level: 3, name: "Veteran", threshold: 10, label: "10 matches" },
+    progressToNext: 0.4,
+    ...overrides,
+  };
+}
+
+function makeMaxed(): AchievementProgress {
+  return makeProgress({
+    currentValue: 10,
+    nextTier: null,
+    progressToNext: 1,
+    unlockedTiers: [
+      { level: 1, unlockedAt: "2024-01-01", matchRef: null, value: 1 },
+      { level: 2, unlockedAt: "2024-06-01", matchRef: null, value: 5 },
+      { level: 3, unlockedAt: "2025-01-01", matchRef: null, value: 10 },
+    ],
+  });
+}
+
+describe("computeNearAchievements", () => {
+  it("returns empty for empty input", () => {
+    expect(computeNearAchievements([])).toEqual([]);
+  });
+
+  it("returns empty when all achievements are maxed", () => {
+    expect(computeNearAchievements([makeMaxed(), makeMaxed()])).toEqual([]);
+  });
+
+  it("returns empty when all have progressToNext below threshold (< 0.25)", () => {
+    const far = makeProgress({ progressToNext: 0.1 });
+    expect(computeNearAchievements([far])).toEqual([]);
+  });
+
+  it("includes achievements with progressToNext exactly at threshold (0.25)", () => {
+    const borderline = makeProgress({ progressToNext: 0.25 });
+    const result = computeNearAchievements([borderline]);
+    expect(result).toHaveLength(1);
+  });
+
+  it("excludes achievements with progressToNext just below threshold (0.249)", () => {
+    const nearMiss = makeProgress({ progressToNext: 0.249 });
+    expect(computeNearAchievements([nearMiss])).toHaveLength(0);
+  });
+
+  it("caps at 3 results", () => {
+    const many = Array.from({ length: 8 }, (_, i) =>
+      makeProgress({
+        definition: {
+          id: `achievement-${i}`,
+          name: `Achievement ${i}`,
+          description: "",
+          category: "milestone",
+          icon: "trophy",
+          tiers: [{ level: 1, name: "Tier", threshold: 10, label: "10 matches" }],
+        },
+        progressToNext: 0.3 + i * 0.05,
+      }),
+    );
+    expect(computeNearAchievements(many)).toHaveLength(3);
+  });
+
+  it("sorts by highest progressToNext first (closest first)", () => {
+    const a = makeProgress({
+      definition: { id: "a", name: "A", description: "", category: "milestone", icon: "trophy",
+        tiers: [{ level: 1, name: "T", threshold: 10, label: "10 matches" }] },
+      progressToNext: 0.3,
+    });
+    const b = makeProgress({
+      definition: { id: "b", name: "B", description: "", category: "milestone", icon: "trophy",
+        tiers: [{ level: 1, name: "T", threshold: 10, label: "10 matches" }] },
+      progressToNext: 0.9,
+    });
+    const c = makeProgress({
+      definition: { id: "c", name: "C", description: "", category: "milestone", icon: "trophy",
+        tiers: [{ level: 1, name: "T", threshold: 10, label: "10 matches" }] },
+      progressToNext: 0.6,
+    });
+    const result = computeNearAchievements([a, b, c]);
+    expect(result.map((r) => r.progress.definition.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("computes remaining correctly", () => {
+    const p = makeProgress({
+      currentValue: 7,
+      nextTier: { level: 3, name: "Veteran", threshold: 10, label: "10 matches" },
+      progressToNext: 0.4,
+    });
+    const result = computeNearAchievements([p]);
+    expect(result[0].remaining).toBe(3);
+  });
+
+  it("generates nudge with unit from label", () => {
+    const p = makeProgress({
+      currentValue: 7,
+      nextTier: { level: 3, name: "Veteran", threshold: 10, label: "10 matches" },
+      progressToNext: 0.4,
+    });
+    const result = computeNearAchievements([p]);
+    expect(result[0].nudge).toBe("3 more matches");
+  });
+
+  it("nudge uses unit from label with multiple words", () => {
+    const p = makeProgress({
+      definition: {
+        id: "globe-trotter",
+        name: "Globe Trotter",
+        description: "",
+        category: "variety",
+        icon: "globe",
+        tiers: [{ level: 1, name: "Traveller", threshold: 3, label: "3 countries" }],
+      },
+      currentValue: 2,
+      nextTier: { level: 1, name: "Traveller", threshold: 3, label: "3 countries" },
+      progressToNext: 0.5,
+      unlockedTiers: [],
+    });
+    const result = computeNearAchievements([p]);
+    expect(result[0].nudge).toBe("1 more countries");
+  });
+
+  it("exposes the full AchievementProgress on each result", () => {
+    const p = makeProgress();
+    const result = computeNearAchievements([p]);
+    expect(result[0].progress).toBe(p);
+  });
+
+  it("mixed maxed + near + far: only returns near", () => {
+    const near = makeProgress({ progressToNext: 0.7 });
+    const maxed = makeMaxed();
+    const far = makeProgress({ progressToNext: 0.1 });
+    const result = computeNearAchievements([near, maxed, far]);
+    expect(result).toHaveLength(1);
+    expect(result[0].progress).toBe(near);
+  });
+});


### PR DESCRIPTION
Closes #464. IA reference: `docs/coaching-features-ia.md`.

## Summary

- **`lib/achievements/near.ts`** -- pure `computeNearAchievements(achievements)` that filters achievements by `progressToNext >= 0.25` and returns up to 3, sorted by closest first (highest `progressToNext`). No new I/O, no schema changes.
- **`tests/unit/near-achievements.test.ts`** -- 12 unit tests covering: empty input, all maxed, below threshold, boundary at 0.25/0.249, cap at 3, sort order, remaining calculation, nudge text, mixed inputs.
- **`NearAchievementsSection`** component added inline in `shooter-dashboard-client.tsx` (alongside the other achievement components that share `ACHIEVEMENT_ICONS` / `TIER_COLORS`). Each card is a `<Popover>` trigger showing the full tier ladder -- same pattern as `AchievementBubbleButton`. Section uses `<section aria-labelledby="near-achievements-heading">` with a `?` info popover per CLAUDE.md convention.
- Section inserted between anchor stage and trend charts, per IA doc §4a order.

## IA-doc §6 checklist

### Identity gating
- [x] Near achievements renders for the dashboard subject (not identity-gated per §4b -- it's the subject's progress, not the viewer's).

### Hierarchy and order
- [x] Section order: anchor stage → near achievements → trends → upcoming → history → achievements grid (matches §4a exactly).

### Accessibility (WCAG 2.1 AA)
- [x] `<section aria-labelledby="near-achievements-heading">` with unique label.
- [x] `h2` heading, consistent with other dashboard sections.
- [x] `?` info popover follows existing pattern (`aria-label="About close to unlocking"`).
- [x] Each card is a `<button>` with full descriptive `aria-label` (nudge + % complete + "Tap to see full ladder").
- [x] Decorative icons have `aria-hidden="true"`.
- [x] Color paired with icon shape (not color-only).

### Mobile-first at 390px
- [x] `grid-cols-1` on mobile, `sm:grid-cols-3` on >= 640px -- vertical stack, no horizontal scroll.
- [x] No horizontal page overflow introduced.

### Data and content
- [x] Section hidden when no achievements are near (returns `null`).
- [x] Long achievement names use `truncate` to handle overflow.

### Performance
- [x] No new GraphQL call -- pure computation over the `achievements` array already in the API response.

### Tests
- [x] `computeNearAchievements()` unit-tested in `tests/unit/near-achievements.test.ts`.
- [x] `pnpm -w run lint && pnpm -w run typecheck && pnpm -w test` all clean (1797 tests pass).