### PR TITLE
feat(coaching): compare-to-self career baseline overlay on match charts

### DIFF
--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -13,7 +13,8 @@ import { SquadPicker } from "@/components/squad-picker";
 import { BenchmarkPicker } from "@/components/benchmark-picker";
 import { ComparisonTable } from "@/components/comparison-table";
 import { ModeToggle } from "@/components/mode-toggle";
-import { useMatchQuery, useCompareQuery, useCoachingAvailability } from "@/lib/queries";
+import { useMatchQuery, useCompareQuery, useCoachingAvailability, useShooterDashboardQuery } from "@/lib/queries";
+import { computeCareerBaseline } from "@/lib/career-baseline";
 import { detectMatchView, isPreMatchEligible } from "@/lib/mode";
 import type { CompareMode } from "@/lib/types";
 import { CacheInfoBadge } from "@/components/cache-info-badge";
@@ -202,6 +203,13 @@ export default function MatchPageClient() {
   const { identity, setIdentity } = useMyIdentity();
   const { tracked: trackedShooters, trackedIds, add: addTracked, remove: removeTracked } =
     useTrackedShooters();
+
+  // Career baseline: fetch the identity's dashboard only when they are one
+  // of the selected competitors. The query is disabled when shooterId is null
+  // (anonymous viewer) or when match data hasn't loaded yet.
+  const shooterDashQuery = useShooterDashboardQuery(identity?.shooterId ?? null);
+  const careerBaseline =
+    shooterDashQuery.data ? computeCareerBaseline(shooterDashQuery.data.matches) : null;
 
   // Capture mount timestamp once to avoid impure Date.now() in render path.
   const [mountMs] = useState(() => Date.now());
@@ -1001,7 +1009,11 @@ export default function MatchPageClient() {
                     </PopoverContent>
                   </Popover>
                 </div>
-                <ComparisonChart data={compareQuery.data} stages={sortedStages} />
+                <ComparisonChart
+                  data={compareQuery.data}
+                  stages={sortedStages}
+                  careerBaselineHF={myCompetitorId != null ? careerBaseline?.medianHF : null}
+                />
               </div>
 
               <div className="rounded-lg border p-4 space-y-3">
@@ -1035,7 +1047,11 @@ export default function MatchPageClient() {
                     </PopoverContent>
                   </Popover>
                 </div>
-                <HfPercentChart data={compareQuery.data} stages={sortedStages} />
+                <HfPercentChart
+                  data={compareQuery.data}
+                  stages={sortedStages}
+                  careerBaselinePct={myCompetitorId != null ? careerBaseline?.medianMatchPct : null}
+                />
               </div>
 
               {compareQuery.data.stages.some(

--- a/app/shooter/[shooterId]/shooter-dashboard-client.tsx
+++ b/app/shooter/[shooterId]/shooter-dashboard-client.tsx
@@ -73,6 +73,7 @@ import {
 } from "@/components/ui/popover";
 import { ShareDrawer } from "@/components/share-drawer";
 import { useTrackedShooters } from "@/lib/hooks/use-tracked-shooters";
+import { useMyIdentity } from "@/lib/hooks/use-my-identity";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useShooterDashboardQuery } from "@/lib/queries";
 import { triggerBackfill, addMatchToShooter } from "@/lib/api";
@@ -1748,6 +1749,8 @@ export function ShooterDashboardClient({ shooterId, from }: Props) {
     shooterId,
   );
   const { trackedIds, add: addTracked, remove: removeTracked } = useTrackedShooters();
+  const { identity } = useMyIdentity();
+  const isOwnDashboard = identity?.shooterId != null && identity.shooterId === shooterId;
   const [historyOpen, setHistoryOpen] = useState(true);
   const [upcomingOpen, setUpcomingOpen] = useState(true);
   const [trendsOpen, setTrendsOpen] = useState(false);
@@ -2068,8 +2071,13 @@ export function ShooterDashboardClient({ shooterId, from }: Props) {
                   id="trends-heading"
                   className="flex w-full items-center justify-between text-left gap-2 min-h-[2.75rem]"
                 >
-                  <span className="text-muted-foreground uppercase tracking-wide">
-                    Performance trends
+                  <span className="flex items-center gap-2">
+                    <span className="text-muted-foreground uppercase tracking-wide">
+                      Performance trends
+                    </span>
+                    {isOwnDashboard && displayStats.hfTrendSlope != null && (
+                      <TrendIndicator slope={displayStats.hfTrendSlope} />
+                    )}
                   </span>
                   {trendsOpen ? (
                     <ChevronUp className="w-4 h-4 flex-none text-muted-foreground" aria-hidden="true" />

--- a/components/comparison-chart.tsx
+++ b/components/comparison-chart.tsx
@@ -5,6 +5,7 @@ import {
   ComposedChart,
   Bar,
   Line,
+  ReferenceLine,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -19,9 +20,11 @@ interface ComparisonChartProps {
   data: CompareResponse;
   stages?: StageComparison[];
   showBenchmark?: boolean;
+  /** Career median hit factor -- shown as a dashed reference line when provided. */
+  careerBaselineHF?: number | null;
 }
 
-export function ComparisonChart({ data, stages: stagesProp, showBenchmark = false }: ComparisonChartProps) {
+export function ComparisonChart({ data, stages: stagesProp, showBenchmark = false, careerBaselineHF }: ComparisonChartProps) {
   const stages = stagesProp ?? data.stages;
   const { competitors } = data;
   const colorMap = buildColorMap(competitors.map((c) => c.id));
@@ -145,6 +148,20 @@ export function ComparisonChart({ data, stages: stagesProp, showBenchmark = fals
               connectNulls={false}
             />
           )}
+          {careerBaselineHF != null && (
+            <ReferenceLine
+              y={careerBaselineHF}
+              stroke="var(--color-amber-500)"
+              strokeDasharray="6 3"
+              strokeWidth={1.5}
+              strokeOpacity={0.8}
+              label={{
+                value: "My career avg",
+                position: "insideTopRight",
+                style: { fontSize: 9, fill: "var(--color-amber-500)", opacity: 0.9 },
+              }}
+            />
+          )}
           {competitors.map((comp) => {
             if (hiddenIds.has(comp.id)) return null;
             const key = `${comp.competitor_number}_${comp.id}`;
@@ -165,6 +182,19 @@ export function ComparisonChart({ data, stages: stagesProp, showBenchmark = fals
         aria-label="Chart legend"
         className="flex flex-wrap justify-center gap-2 pt-2"
       >
+        {careerBaselineHF != null && (
+          <span
+            className="flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400"
+            aria-label={`Your career average: ${careerBaselineHF.toFixed(2)} HF`}
+          >
+            <span
+              className="inline-block w-4"
+              style={{ borderTop: "2px dashed var(--color-amber-500)" }}
+              aria-hidden="true"
+            />
+            My career avg
+          </span>
+        )}
         {hasBenchmark && (
           <button
             type="button"

--- a/components/hf-percent-chart.tsx
+++ b/components/hf-percent-chart.tsx
@@ -23,9 +23,11 @@ import { computeHfPct, type RefMode } from "@/lib/hf-percent-utils";
 interface HfPercentChartProps {
   data: CompareResponse;
   stages?: StageComparison[];
+  /** Career median match % (0–100) -- shown as a dashed reference line when provided. */
+  careerBaselinePct?: number | null;
 }
 
-export function HfPercentChart({ data, stages: stagesProp }: HfPercentChartProps) {
+export function HfPercentChart({ data, stages: stagesProp, careerBaselinePct }: HfPercentChartProps) {
   const stages = stagesProp ?? data.stages;
   const { competitors } = data;
   const colorMap = buildColorMap(competitors.map((c) => c.id));
@@ -164,6 +166,20 @@ export function HfPercentChart({ data, stages: stagesProp }: HfPercentChartProps
               style: { fontSize: 10, fill: "var(--muted-foreground)" },
             }}
           />
+          {careerBaselinePct != null && (
+            <ReferenceLine
+              y={careerBaselinePct}
+              stroke="var(--color-amber-500)"
+              strokeDasharray="6 3"
+              strokeWidth={1.5}
+              strokeOpacity={0.8}
+              label={{
+                value: "My career avg",
+                position: "insideTopRight",
+                style: { fontSize: 9, fill: "var(--color-amber-500)", opacity: 0.9 },
+              }}
+            />
+          )}
           {competitors.map((comp) => {
             if (hiddenIds.has(comp.id)) return null;
             const color = colorMap[comp.id];
@@ -240,6 +256,22 @@ export function HfPercentChart({ data, stages: stagesProp }: HfPercentChartProps
           <span aria-hidden="true">■</span> &lt;85% leak
         </span>
       </div>
+
+      {careerBaselinePct != null && (
+        <div className="flex justify-center pt-1">
+          <span
+            className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400"
+            aria-label={`Your career average: ${careerBaselinePct.toFixed(1)}%`}
+          >
+            <span
+              className="inline-block w-4"
+              style={{ borderTop: "2px dashed var(--color-amber-500)" }}
+              aria-hidden="true"
+            />
+            My career avg ({careerBaselinePct.toFixed(1)}%)
+          </span>
+        </div>
+      )}
 
       {/* Series visibility legend */}
       <div

--- a/lib/career-baseline.ts
+++ b/lib/career-baseline.ts
@@ -1,0 +1,44 @@
+// Pure function for computing a shooter's career performance baseline.
+// No I/O, fully unit-tested.
+
+import type { ShooterMatchSummary } from "@/lib/types";
+
+export interface CareerBaseline {
+  /** Median per-match average hit factor, or null when insufficient data. */
+  medianHF: number | null;
+  /** Median per-match division % (0–100), or null when insufficient data. */
+  medianMatchPct: number | null;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+/**
+ * Compute career performance medians from match history.
+ *
+ * Returns null for each metric when fewer than `minMatches` valid data
+ * points exist — a sparse history makes the baseline too noisy to display.
+ */
+export function computeCareerBaseline(
+  matches: ShooterMatchSummary[],
+  minMatches = 5,
+): CareerBaseline {
+  const hfValues = matches
+    .map((m) => m.avgHF)
+    .filter((v): v is number => v != null && v > 0);
+
+  const pctValues = matches
+    .map((m) => m.matchPct)
+    .filter((v): v is number => v != null && v > 0);
+
+  return {
+    medianHF: hfValues.length >= minMatches ? median(hfValues) : null,
+    medianMatchPct: pctValues.length >= minMatches ? median(pctValues) : null,
+  };
+}

--- a/tests/unit/career-baseline.test.ts
+++ b/tests/unit/career-baseline.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { computeCareerBaseline } from "@/lib/career-baseline";
+import type { ShooterMatchSummary } from "@/lib/types";
+
+function makeMatch(overrides: Partial<ShooterMatchSummary> = {}): ShooterMatchSummary {
+  return {
+    ct: "22",
+    matchId: "100",
+    name: "Test Match",
+    date: "2025-01-01",
+    venue: null,
+    level: "l2",
+    region: null,
+    division: "Production Optics",
+    competitorId: 1,
+    competitorsInDivision: 10,
+    stageCount: 5,
+    avgHF: 3.5,
+    matchPct: 80,
+    totalA: 50,
+    totalC: 5,
+    totalD: 2,
+    totalMiss: 0,
+    totalNoShoots: 0,
+    ...overrides,
+  };
+}
+
+function makeMatches(avgHFs: (number | null)[], matchPcts: (number | null)[]): ShooterMatchSummary[] {
+  return avgHFs.map((avgHF, i) => makeMatch({ matchId: String(i), avgHF, matchPct: matchPcts[i] }));
+}
+
+describe("computeCareerBaseline", () => {
+  it("returns null for both when input is empty", () => {
+    expect(computeCareerBaseline([])).toEqual({ medianHF: null, medianMatchPct: null });
+  });
+
+  it("returns null when fewer than minMatches valid HF values", () => {
+    const matches = makeMatches([3.0, 3.5, 4.0, 3.2], [80, 82, 85, 78]);
+    const result = computeCareerBaseline(matches); // default minMatches=5
+    expect(result.medianHF).toBeNull();
+    expect(result.medianMatchPct).toBeNull();
+  });
+
+  it("returns values when exactly minMatches valid values", () => {
+    const matches = makeMatches([3.0, 3.5, 4.0, 3.2, 3.8], [80, 82, 85, 78, 84]);
+    const result = computeCareerBaseline(matches);
+    expect(result.medianHF).not.toBeNull();
+    expect(result.medianMatchPct).not.toBeNull();
+  });
+
+  it("computes correct median for odd count", () => {
+    const matches = makeMatches([1.0, 3.0, 5.0, 2.0, 4.0], [60, 80, 100, 70, 90]);
+    const result = computeCareerBaseline(matches);
+    expect(result.medianHF).toBe(3.0); // sorted: 1, 2, 3, 4, 5 → middle = 3
+    expect(result.medianMatchPct).toBe(80); // sorted: 60, 70, 80, 90, 100 → middle = 80
+  });
+
+  it("computes correct median for even count", () => {
+    const matches = makeMatches([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [60, 70, 80, 90, 100, 110]);
+    const result = computeCareerBaseline(matches);
+    expect(result.medianHF).toBe(3.5); // sorted: 1,2,3,4,5,6 → (3+4)/2
+    expect(result.medianMatchPct).toBe(85); // sorted: 60,70,80,90,100,110 → (80+90)/2
+  });
+
+  it("excludes null and zero avgHF values from median", () => {
+    const matches = makeMatches([null, 0, 3.0, 3.5, 4.0, 3.2, 3.8], [80, 80, 80, 82, 85, 78, 84]);
+    const result = computeCareerBaseline(matches); // 5 valid HF values (null and 0 excluded)
+    expect(result.medianHF).not.toBeNull();
+  });
+
+  it("excludes null and zero matchPct from median", () => {
+    const matches = makeMatches([3.0, 3.5, 4.0, 3.2, 3.8], [null, 0, 85, 78, 84]);
+    const result = computeCareerBaseline(matches, 3); // only 3 valid pct values
+    expect(result.medianMatchPct).not.toBeNull();
+  });
+
+  it("respects custom minMatches argument", () => {
+    const matches = makeMatches([3.0, 3.5, 4.0], [80, 82, 85]);
+    const resultDefault = computeCareerBaseline(matches); // needs 5
+    const resultCustom = computeCareerBaseline(matches, 3); // needs 3
+    expect(resultDefault.medianHF).toBeNull();
+    expect(resultCustom.medianHF).toBe(3.5); // median of [3.0, 3.5, 4.0]
+  });
+
+  it("medianHF and medianMatchPct are independent", () => {
+    // Only 4 HF values, 6 pct values
+    const matches = [
+      makeMatch({ matchId: "1", avgHF: 3.0, matchPct: 80 }),
+      makeMatch({ matchId: "2", avgHF: null, matchPct: 82 }),
+      makeMatch({ matchId: "3", avgHF: 4.0, matchPct: 85 }),
+      makeMatch({ matchId: "4", avgHF: 3.5, matchPct: 78 }),
+      makeMatch({ matchId: "5", avgHF: null, matchPct: 84 }),
+      makeMatch({ matchId: "6", avgHF: 3.2, matchPct: 90 }),
+    ];
+    const result = computeCareerBaseline(matches); // 4 HF (< 5), 6 pct (>= 5)
+    expect(result.medianHF).toBeNull();
+    expect(result.medianMatchPct).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #463. IA reference: `docs/coaching-features-ia.md`.

## Summary

- **`lib/career-baseline.ts`** -- pure `computeCareerBaseline(matches, minMatches=5)` returning `{ medianHF, medianMatchPct }`. Returns null for each metric when fewer than 5 valid data points exist (noisy history guard). Fully unit-tested.
- **`tests/unit/career-baseline.test.ts`** -- 9 tests: empty input, below-min guard, exact-min boundary, odd/even median, null exclusion, custom minMatches, independent HF/pct nullability.
- **`components/comparison-chart.tsx`** -- new optional `careerBaselineHF?: number | null` prop. When set, renders an amber dashed `ReferenceLine` at the median HF value plus a static legend swatch. No impact on existing renders when prop is absent.
- **`components/hf-percent-chart.tsx`** -- new optional `careerBaselinePct?: number | null` prop. Same pattern: amber dashed ReferenceLine + legend entry with the actual % value displayed.
- **`app/match/[ct]/[id]/match-page-client.tsx`** -- fetches `useShooterDashboardQuery(identity?.shooterId)` (zero new GraphQL calls; reuses the existing shooter dashboard cache). Computes baseline from the response. Passes `careerBaselineHF` / `careerBaselinePct` to the two charts only when `myCompetitorId != null` (viewer is one of the competitors -- identity gating per IA doc §2 decision #2).
- **`app/shooter/[shooterId]/shooter-dashboard-client.tsx`** -- adds `useMyIdentity()` + `isOwnDashboard` check; shows `TrendIndicator` badge in the Performance trends section heading when `isOwnDashboard && hfTrendSlope != null` (identity-gated per IA doc §4b).

## Not included (scope decision)

- **Radar ghost overlay**: the radar chart shows per-stage HF% for the *current match*. Comparing against a "career median per stage" would require per-stage career history aggregated across all matches -- data not currently in the `ShooterDashboardResponse`. Deferred to a separate issue if ever needed.

## IA-doc §6 checklist

### Identity gating
- [x] Chart overlays render only when `myCompetitorId !== null` (viewer matched to a competitor).
- [x] Dashboard trend badge renders only for `isOwnDashboard` viewers.
- [x] Anonymous viewers see today's page shape unchanged.

### Hierarchy and order
- [x] No section displaced. Charts remain in their existing order.

### Accessibility (WCAG 2.1 AA)
- [x] Career baseline legend entries use both dashed-line swatch and text label (not color-only).
- [x] Amber color paired with the dashed-line glyph (WCAG 1.4.1 Use of Color).
- [x] `aria-label` on the legend entries includes the numeric value.
- [x] Trend badge uses existing `TrendIndicator` which already has `aria-label`.
- [x] No `outline-none` without replacement.
- [x] No new touch targets -- overlays are purely visual, non-interactive.

### Performance
- [x] Zero new GraphQL calls. `useShooterDashboardQuery` reuses the existing TanStack Query cache keyed on `["shooter-dashboard", shooterId]`.
- [x] No layout reads in render.

### Tests
- [x] `computeCareerBaseline()` unit-tested in `tests/unit/career-baseline.test.ts`.
- [x] `pnpm -w run lint && pnpm -w run typecheck && pnpm -w test` all clean (1806 tests pass).