### PR TITLE
feat(coaching): personalise pre-match AI brief with prior-weakness hooks

### DIFF
--- a/app/api/pre-match/brief/[ct]/[id]/route.ts
+++ b/app/api/pre-match/brief/[ct]/[id]/route.ts
@@ -8,6 +8,7 @@
 import { NextResponse } from "next/server";
 import { createAIProvider } from "@/lib/ai-provider";
 import { buildPreMatchBriefPrompt, computeSquadContext, PRE_MATCH_PROMPT_VERSION } from "@/lib/pre-match-prompt";
+import { computeBriefHooks } from "@/lib/pre-match-brief-hooks";
 import { fetchMatchData } from "@/lib/match-data";
 import { getShooterDashboard } from "@/lib/api-data";
 import { isPreMatchEligible } from "@/lib/mode";
@@ -112,6 +113,8 @@ export async function GET(
     }
   }
 
+  const hooks = dashboard ? computeBriefHooks(match.stages, dashboard, squadContext) : [];
+
   const prompt = buildPreMatchBriefPrompt({
     matchName: match.name,
     matchLevel: match.level,
@@ -119,6 +122,7 @@ export async function GET(
     shooterName,
     dashboard,
     squadContext,
+    hooks,
   });
 
   let tip: string;

--- a/lib/pre-match-brief-hooks.ts
+++ b/lib/pre-match-brief-hooks.ts
@@ -1,0 +1,132 @@
+// Pure function for computing personalised pre-match brief hooks.
+// No I/O, fully unit-tested.
+
+import type { StageInfo, ShooterDashboardResponse, BriefHook } from "@/lib/types";
+import type { SquadContext } from "@/lib/pre-match-prompt";
+
+export const MAX_BRIEF_HOOKS = 5;
+
+/**
+ * Minimum match history required for trend-based hooks.
+ * Below this the data is too noisy to emit actionable signals.
+ */
+const MIN_MATCHES = 5;
+
+/** High penalty rate threshold: >= 5 penalties per 100 rounds. */
+const HIGH_PENALTY_RATE = 0.05;
+
+/** High CV (hit-factor coefficient of variation) threshold. */
+const HIGH_CV = 0.2;
+
+function countConstrainedStages(stages: StageInfo[]): number {
+  return stages.filter((s) => {
+    const proc = s.procedure ?? "";
+    const fc = s.firearm_condition ?? "";
+    return /unloaded|empty/i.test(fc) || /strong hand|weak hand/i.test(proc);
+  }).length;
+}
+
+function countLongStages(stages: StageInfo[]): number {
+  return stages.filter((s) => /long/i.test(s.course_display ?? "")).length;
+}
+
+/**
+ * Compute personalised coaching hooks for the pre-match brief.
+ *
+ * Each hook is a one-sentence signal grounded in the shooter's career data
+ * cross-referenced with this match's stage shape. The AI prompt receives
+ * these as structured input to write personalised brief prose.
+ *
+ * Returns up to MAX_BRIEF_HOOKS hooks sorted by priority descending.
+ * Returns [] when the dashboard has no matches or all guards fail.
+ */
+export function computeBriefHooks(
+  stages: StageInfo[],
+  dashboard: ShooterDashboardResponse,
+  squadContext: SquadContext | null = null,
+): BriefHook[] {
+  const hooks: BriefHook[] = [];
+  const { stats, matches } = dashboard;
+  const recentMatches = matches.slice(0, 5);
+  const hasEnoughHistory = matches.length >= MIN_MATCHES;
+
+  // 1. Recent DQ -- safety-first, always highest priority.
+  if (recentMatches.some((m) => m.dq)) {
+    hooks.push({
+      tag: "recent-dq",
+      signal:
+        "Had a DQ in recent matches -- review safety rules and procedural requirements before this match.",
+      priority: 10,
+    });
+  }
+
+  // 2. Constrained stages present in this match -- cross with penalty rate for context.
+  const constrainedCount = countConstrainedStages(stages);
+  if (constrainedCount > 0) {
+    const penaltyNote =
+      stats.avgPenaltyRate != null
+        ? ` (career penalty rate: ${(stats.avgPenaltyRate * 100).toFixed(1)} per 100 rounds)`
+        : "";
+    hooks.push({
+      tag: "constraint-stages",
+      signal: `${constrainedCount} constrained stage${constrainedCount > 1 ? "s" : ""} (weak-hand, strong-hand, or unloaded start) in this match${penaltyNote} -- plan these deliberately.`,
+      priority: 8,
+    });
+  }
+
+  // 3. High penalty rate when no constraint context already covers it.
+  if (
+    hasEnoughHistory &&
+    constrainedCount === 0 &&
+    stats.avgPenaltyRate != null &&
+    stats.avgPenaltyRate >= HIGH_PENALTY_RATE
+  ) {
+    hooks.push({
+      tag: "penalty-rate",
+      signal: `Career penalty rate is ${(stats.avgPenaltyRate * 100).toFixed(1)} per 100 rounds -- penalties are costing match %; prioritise clean runs over speed.`,
+      priority: 7,
+    });
+  }
+
+  // 4. Long stages with high variance -- stamina and consistency flag.
+  const longCount = countLongStages(stages);
+  if (
+    hasEnoughHistory &&
+    longCount > 0 &&
+    stats.consistencyCV != null &&
+    stats.consistencyCV >= HIGH_CV
+  ) {
+    hooks.push({
+      tag: "long-stage-consistency",
+      signal: `${longCount} long course stage${longCount > 1 ? "s" : ""} in this match; your consistency varies between matches (CV ${(stats.consistencyCV * 100).toFixed(0)}%) -- commit fully to each stage plan.`,
+      priority: 6,
+    });
+  }
+
+  // 5. Squad position -- timing and warm-up advice.
+  if (squadContext && hasEnoughHistory) {
+    const isLateInSquad = squadContext.position > Math.ceil(squadContext.squadSize / 2);
+    const isDeclining =
+      stats.hfTrendSlope != null && stats.hfTrendSlope < -0.002;
+
+    if (isLateInSquad) {
+      hooks.push({
+        tag: "squad-timing",
+        signal: isDeclining
+          ? `Squad position ${squadContext.position} of ${squadContext.squadSize} (late in the rotation) and a declining performance trend -- plan an extended warm-up.`
+          : `Squad position ${squadContext.position} of ${squadContext.squadSize} (later in the rotation) -- allow enough warm-up time before the first stage.`,
+        priority: 5,
+      });
+    } else if (squadContext.startingStages.length > 0) {
+      const stageList = squadContext.startingStages.join(", ");
+      hooks.push({
+        tag: "squad-starter",
+        signal: `Starts first on stage${squadContext.startingStages.length > 1 ? "s" : ""} ${stageList} -- must be at full intensity from the opening buzzer; warm up accordingly.`,
+        priority: 4,
+      });
+    }
+  }
+
+  hooks.sort((a, b) => b.priority - a.priority);
+  return hooks.slice(0, MAX_BRIEF_HOOKS);
+}

--- a/lib/pre-match-prompt.ts
+++ b/lib/pre-match-prompt.ts
@@ -1,13 +1,13 @@
 // Pure functions — no I/O, no side effects.
 // Builds the AI prompt for a pre-match coaching brief.
 
-import type { StageInfo, ShooterDashboardResponse } from "@/lib/types";
+import type { StageInfo, ShooterDashboardResponse, BriefHook } from "@/lib/types";
 
 /**
  * Bump when the prompt structure changes enough that cached briefs should
  * be regenerated. Embedded in the cache key alongside the model ID.
  */
-export const PRE_MATCH_PROMPT_VERSION = 3;
+export const PRE_MATCH_PROMPT_VERSION = 4;
 
 /**
  * Within-squad starting-order context for one shooter.
@@ -54,6 +54,12 @@ export interface PreMatchBriefInput {
   dashboard: ShooterDashboardResponse | null;
   /** Within-squad starting context. Null when squad is unknown or not yet assigned. */
   squadContext: SquadContext | null;
+  /**
+   * Personalised coaching signals derived from the shooter's career history
+   * cross-referenced with this match's stage shape. Empty when the viewer is
+   * anonymous or has insufficient match history.
+   */
+  hooks?: BriefHook[];
 }
 
 /** Summarise stage breakdown by course length. */
@@ -95,7 +101,7 @@ function listConstraints(stages: StageInfo[]): string[] {
  * Pure function — no network calls.
  */
 export function buildPreMatchBriefPrompt(input: PreMatchBriefInput): string {
-  const { matchName, matchLevel, stages, shooterName, dashboard, squadContext } = input;
+  const { matchName, matchLevel, stages, shooterName, dashboard, squadContext, hooks } = input;
 
   const levelStr = matchLevel ?? "IPSC match";
   const courseBreakdown = summariseStageCourses(stages);
@@ -198,12 +204,17 @@ CONSISTENCY: ${consistencyStr}
 PENALTY RATE: ${penaltyStr}`;
   }
 
+  const hooksSection =
+    hooks && hooks.length > 0
+      ? `\nPERSONAL FOCUS HOOKS (highest priority first -- weave these into your brief):\n${hooks.map((h) => `- ${h.signal}`).join("\n")}`
+      : "";
+
   return `You are an IPSC performance coach preparing a competitor for a match.
 Write a concise 2–3 sentence coaching brief (max 55 words). Be direct, specific to this match and competitor. No lists, no bullet points, no markdown. Focus on the most actionable preparation tip.
 
 ${matchSection}
 
-${competitorSection}
+${competitorSection}${hooksSection}
 
 PRE-MATCH BRIEF:`;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -997,6 +997,19 @@ export interface ShooterDashboardResponse {
   anchorStage?: AnchorStage | null;
 }
 
+/**
+ * A single personalised coaching signal injected into the pre-match brief prompt.
+ * Computed from the shooter's career history cross-referenced with this match's stages.
+ */
+export interface BriefHook {
+  /** Stable category tag (used for deduplication and logging). */
+  tag: string;
+  /** One-sentence signal for the AI to weave into the brief. */
+  signal: string;
+  /** Sort key -- higher is more important. Top MAX_HOOKS hooks are kept. */
+  priority: number;
+}
+
 // Response from GET /api/shooter/search.
 export interface ShooterSearchResult {
   shooterId: number;

--- a/tests/unit/pre-match-brief-hooks.test.ts
+++ b/tests/unit/pre-match-brief-hooks.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect } from "vitest";
+import { computeBriefHooks, MAX_BRIEF_HOOKS } from "@/lib/pre-match-brief-hooks";
+import type { StageInfo, ShooterDashboardResponse } from "@/lib/types";
+import type { SquadContext } from "@/lib/pre-match-prompt";
+
+function makeStage(overrides: Partial<StageInfo> = {}): StageInfo {
+  return {
+    id: 1,
+    name: "Stage 1",
+    stage_number: 1,
+    max_points: 100,
+    min_rounds: 12,
+    paper_targets: 6,
+    steel_targets: 0,
+    ssi_url: null,
+    course_display: "Medium",
+    procedure: null,
+    firearm_condition: null,
+    ...overrides,
+  };
+}
+
+function makeStages(count: number, overrides: Partial<StageInfo> = {}): StageInfo[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeStage({ id: i + 1, stage_number: i + 1, name: `Stage ${i + 1}`, ...overrides }),
+  );
+}
+
+function makeDashboard(overrides: Partial<ShooterDashboardResponse> = {}): ShooterDashboardResponse {
+  return {
+    shooterId: 1,
+    profile: { name: "Test Shooter", club: null, division: "Production Optics", lastSeen: "2025-01-01", region: null, region_display: null, category: null, ics_alias: null, license: null },
+    matchCount: 10,
+    matches: Array.from({ length: 10 }, (_, i) => ({
+      ct: "22",
+      matchId: String(i + 1),
+      name: `Match ${i + 1}`,
+      date: `2025-0${(i % 9) + 1}-01`,
+      venue: null,
+      level: "l2",
+      region: null,
+      division: "Production Optics",
+      competitorId: 1,
+      competitorsInDivision: 20,
+      stageCount: 6,
+      avgHF: 3.5,
+      matchPct: 80,
+      totalA: 50,
+      totalC: 5,
+      totalD: 2,
+      totalMiss: 0,
+      totalNoShoots: 0,
+      dq: false,
+    })),
+    stats: {
+      totalStages: 60,
+      dateRange: { from: "2024-01-01", to: "2025-01-01" },
+      overallAvgHF: 3.5,
+      overallMatchPct: 80,
+      aPercent: 75,
+      cPercent: 15,
+      dPercent: 5,
+      missPercent: 2,
+      hfTrendSlope: 0.001,
+      consistencyCV: 0.15,
+      avgPenaltyRate: 0.02,
+    },
+    ...overrides,
+  };
+}
+
+function makeSquadContext(overrides: Partial<SquadContext> = {}): SquadContext {
+  return {
+    position: 1,
+    squadSize: 4,
+    startingStages: [1, 5],
+    ...overrides,
+  };
+}
+
+describe("computeBriefHooks", () => {
+  it("returns empty array when matches list is empty", () => {
+    const dashboard = makeDashboard({ matches: [], matchCount: 0 });
+    const result = computeBriefHooks(makeStages(6), dashboard, null);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when fewer than MIN_MATCHES and no high-priority rules fire", () => {
+    const dashboard = makeDashboard({
+      matches: Array.from({ length: 4 }, (_, i) => ({
+        ct: "22", matchId: String(i), name: `M${i}`, date: null, venue: null, level: "l2",
+        region: null, division: null, competitorId: 1, competitorsInDivision: null,
+        stageCount: 5, avgHF: 3.5, matchPct: 80, totalA: 50, totalC: 5, totalD: 2,
+        totalMiss: 0, totalNoShoots: 0, dq: false,
+      })),
+      matchCount: 4,
+    });
+    const result = computeBriefHooks(makeStages(6), dashboard, null);
+    expect(result).toEqual([]);
+  });
+
+  describe("recent DQ hook", () => {
+    it("fires when a recent match has dq=true", () => {
+      const dashboard = makeDashboard();
+      dashboard.matches[2] = { ...dashboard.matches[2], dq: true };
+      const result = computeBriefHooks(makeStages(6), dashboard, null);
+      expect(result.some((h) => h.tag === "recent-dq")).toBe(true);
+    });
+
+    it("does not fire when no recent DQ", () => {
+      const dashboard = makeDashboard();
+      const result = computeBriefHooks(makeStages(6), dashboard, null);
+      expect(result.some((h) => h.tag === "recent-dq")).toBe(false);
+    });
+
+    it("recent-dq is highest priority hook", () => {
+      const dashboard = makeDashboard({ stats: { ...makeDashboard().stats, avgPenaltyRate: 0.1 } });
+      dashboard.matches[0] = { ...dashboard.matches[0], dq: true };
+      const constrained = makeStage({ procedure: "Weak hand only" });
+      const stages = [constrained, ...makeStages(5, {})];
+      const result = computeBriefHooks(stages, dashboard, null);
+      expect(result[0].tag).toBe("recent-dq");
+    });
+  });
+
+  describe("constraint-stages hook", () => {
+    it("fires for weak-hand stage", () => {
+      const stages = [makeStage({ procedure: "Weak hand only" }), ...makeStages(5)];
+      const result = computeBriefHooks(stages, makeDashboard(), null);
+      expect(result.some((h) => h.tag === "constraint-stages")).toBe(true);
+    });
+
+    it("fires for strong-hand stage", () => {
+      const stages = [makeStage({ procedure: "Strong hand only" }), ...makeStages(5)];
+      const result = computeBriefHooks(stages, makeDashboard(), null);
+      expect(result.some((h) => h.tag === "constraint-stages")).toBe(true);
+    });
+
+    it("fires for unloaded start", () => {
+      const stages = [makeStage({ firearm_condition: "Unloaded, hammer down" }), ...makeStages(5)];
+      const result = computeBriefHooks(stages, makeDashboard(), null);
+      expect(result.some((h) => h.tag === "constraint-stages")).toBe(true);
+    });
+
+    it("includes count in signal", () => {
+      const stages = [
+        makeStage({ id: 1, stage_number: 1, procedure: "Weak hand only" }),
+        makeStage({ id: 2, stage_number: 2, procedure: "Strong hand only" }),
+        ...makeStages(4),
+      ];
+      const result = computeBriefHooks(stages, makeDashboard(), null);
+      const hook = result.find((h) => h.tag === "constraint-stages");
+      expect(hook?.signal).toContain("2 constrained stages");
+    });
+
+    it("does not fire when no constrained stages", () => {
+      const result = computeBriefHooks(makeStages(6), makeDashboard(), null);
+      expect(result.some((h) => h.tag === "constraint-stages")).toBe(false);
+    });
+  });
+
+  describe("penalty-rate hook", () => {
+    it("fires when penalty rate >= 0.05 and no constraint stages and enough history", () => {
+      const dashboard = makeDashboard({
+        stats: { ...makeDashboard().stats, avgPenaltyRate: 0.06 },
+      });
+      const result = computeBriefHooks(makeStages(6), dashboard, null);
+      expect(result.some((h) => h.tag === "penalty-rate")).toBe(true);
+    });
+
+    it("does not fire when penalty rate < 0.05", () => {
+      const dashboard = makeDashboard({
+        stats: { ...makeDashboard().stats, avgPenaltyRate: 0.03 },
+      });
+      const result = computeBriefHooks(makeStages(6), dashboard, null);
+      expect(result.some((h) => h.tag === "penalty-rate")).toBe(false);
+    });
+
+    it("does not fire when constraint-stages hook already covers context", () => {
+      const dashboard = makeDashboard({
+        stats: { ...makeDashboard().stats, avgPenaltyRate: 0.1 },
+      });
+      const stages = [makeStage({ procedure: "Weak hand only" }), ...makeStages(5)];
+      const result = computeBriefHooks(stages, dashboard, null);
+      expect(result.some((h) => h.tag === "penalty-rate")).toBe(false);
+    });
+
+    it("does not fire when fewer than MIN_MATCHES", () => {
+      const dashboard = makeDashboard({
+        matches: Array.from({ length: 3 }, (_, i) => ({
+          ct: "22", matchId: String(i), name: `M${i}`, date: null, venue: null, level: "l2",
+          region: null, division: null, competitorId: 1, competitorsInDivision: null,
+          stageCount: 5, avgHF: 3.5, matchPct: 80, totalA: 50, totalC: 5, totalD: 2,
+          totalMiss: 0, totalNoShoots: 0, dq: false,
+        })),
+        stats: { ...makeDashboard().stats, avgPenaltyRate: 0.1 },
+      });
+      const result = computeBriefHooks(makeStages(6), dashboard, null);
+      expect(result.some((h) => h.tag === "penalty-rate")).toBe(false);
+    });
+  });
+
+  describe("long-stage-consistency hook", () => {
+    it("fires for long stage with high CV", () => {
+      const stages = [makeStage({ course_display: "Long" }), ...makeStages(5)];
+      const dashboard = makeDashboard({
+        stats: { ...makeDashboard().stats, consistencyCV: 0.25 },
+      });
+      const result = computeBriefHooks(stages, dashboard, null);
+      expect(result.some((h) => h.tag === "long-stage-consistency")).toBe(true);
+    });
+
+    it("does not fire when no long stages", () => {
+      const result = computeBriefHooks(makeStages(6), makeDashboard(), null);
+      expect(result.some((h) => h.tag === "long-stage-consistency")).toBe(false);
+    });
+
+    it("does not fire when CV is below threshold", () => {
+      const stages = [makeStage({ course_display: "Long" }), ...makeStages(5)];
+      const dashboard = makeDashboard({
+        stats: { ...makeDashboard().stats, consistencyCV: 0.15 },
+      });
+      const result = computeBriefHooks(stages, dashboard, null);
+      expect(result.some((h) => h.tag === "long-stage-consistency")).toBe(false);
+    });
+  });
+
+  describe("squad timing hooks", () => {
+    it("fires squad-timing for late squad position", () => {
+      const squad = makeSquadContext({ position: 3, squadSize: 4, startingStages: [] });
+      const result = computeBriefHooks(makeStages(6), makeDashboard(), squad);
+      expect(result.some((h) => h.tag === "squad-timing")).toBe(true);
+    });
+
+    it("squad-timing signal mentions declining trend when present", () => {
+      const squad = makeSquadContext({ position: 4, squadSize: 4, startingStages: [] });
+      const dashboard = makeDashboard({
+        stats: { ...makeDashboard().stats, hfTrendSlope: -0.01 },
+      });
+      const result = computeBriefHooks(makeStages(6), dashboard, squad);
+      const hook = result.find((h) => h.tag === "squad-timing");
+      expect(hook?.signal).toContain("declining");
+    });
+
+    it("fires squad-starter for early position that starts stages", () => {
+      const squad = makeSquadContext({ position: 1, squadSize: 4, startingStages: [1, 5] });
+      const result = computeBriefHooks(makeStages(6), makeDashboard(), squad);
+      expect(result.some((h) => h.tag === "squad-starter")).toBe(true);
+    });
+
+    it("squad-starter not fired when early position but no starting stages", () => {
+      const squad = makeSquadContext({ position: 1, squadSize: 4, startingStages: [] });
+      const result = computeBriefHooks(makeStages(6), makeDashboard(), squad);
+      expect(result.some((h) => h.tag === "squad-starter")).toBe(false);
+    });
+
+    it("does not fire squad hooks when squadContext is null", () => {
+      const result = computeBriefHooks(makeStages(6), makeDashboard(), null);
+      expect(result.some((h) => h.tag === "squad-timing" || h.tag === "squad-starter")).toBe(false);
+    });
+  });
+
+  it("caps output at MAX_BRIEF_HOOKS", () => {
+    const stages = [
+      makeStage({ procedure: "Weak hand only" }),
+      makeStage({ id: 2, stage_number: 2, procedure: "Strong hand only" }),
+      makeStage({ id: 3, stage_number: 3, course_display: "Long" }),
+      ...makeStages(3),
+    ];
+    const dashboard = makeDashboard({
+      stats: { ...makeDashboard().stats, consistencyCV: 0.3, avgPenaltyRate: 0.1, hfTrendSlope: -0.01 },
+    });
+    dashboard.matches[0] = { ...dashboard.matches[0], dq: true };
+    const squad = makeSquadContext({ position: 4, squadSize: 4, startingStages: [] });
+    const result = computeBriefHooks(stages, dashboard, squad);
+    expect(result.length).toBeLessThanOrEqual(MAX_BRIEF_HOOKS);
+  });
+
+  it("returns hooks sorted by priority descending", () => {
+    const stages = [makeStage({ procedure: "Weak hand only" }), ...makeStages(5)];
+    const dashboard = makeDashboard({
+      stats: { ...makeDashboard().stats, consistencyCV: 0.3 },
+    });
+    // Add a long stage too
+    stages.push(makeStage({ id: 7, stage_number: 7, course_display: "Long" }));
+    const result = computeBriefHooks(stages, dashboard, null);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i - 1].priority).toBeGreaterThanOrEqual(result[i].priority);
+    }
+  });
+});


### PR DESCRIPTION
Closes #466. IA reference: `docs/coaching-features-ia.md`.

## Summary

**`lib/pre-match-brief-hooks.ts`** (new) -- pure `computeBriefHooks(stages, dashboard, squadContext)` producing up to 5 `BriefHook[]` entries sorted by priority. Rules (in priority order):

| Priority | Tag | Trigger |
|---|---|---|
| 10 | `recent-dq` | Any DQ in last 5 matches |
| 8 | `constraint-stages` | >= 1 constrained stage (weak/strong-hand, unloaded) in this match |
| 7 | `penalty-rate` | Career rate >= 5/100 rounds and no constraint context already present |
| 6 | `long-stage-consistency` | Long-course stages + career CV >= 0.2 |
| 5 | `squad-timing` | Late squad position (> half the squad) |
| 4 | `squad-starter` | Early position with starting-stage assignments |

All trend-based hooks require >= 5 matches in history (sample-size guard).

**`lib/types.ts`** -- adds `BriefHook` interface (tag, signal, priority) following the CLAUDE.md rule that all interfaces live in `lib/types.ts`.

**`lib/pre-match-prompt.ts`** -- adds `hooks?: BriefHook[]` to `PreMatchBriefInput`. When present, injects a `PERSONAL FOCUS HOOKS:` section into the prompt. `PRE_MATCH_PROMPT_VERSION` bumped from 3 to 4 (invalidates stale cached briefs).

**`app/api/pre-match/brief/[ct]/[id]/route.ts`** -- calls `computeBriefHooks(match.stages, dashboard, squadContext)` when a dashboard is available; passes hooks to `buildPreMatchBriefPrompt`. Anonymous viewers (no `shooterId`) get no hooks; the existing generic brief is unchanged.

**`tests/unit/pre-match-brief-hooks.test.ts`** (new) -- 24 tests covering every rule trigger, guard, and edge case.

## Privacy

- No shooter IDs, no competitor IDs, no raw text in any telemetry event -- hooks are derived server-side from data already on the server.
- The AI receives structured one-sentence signals, not free text entered by the user.

## IA-doc §6 checklist

### Identity gating
- [x] Anonymous viewers get the existing generic brief (no regression). Hooks path is only entered when `dashboard != null` (requires `?shooterId=`).
- [x] No new UI added -- the brief component and its "Generate personalised brief" button are unchanged (§5 of IA doc: no new UI element).

### Data and content
- [x] Hooks are capped at 5 (`MAX_BRIEF_HOOKS`).
- [x] Prioritised by the `priority` field (consistent with the `estimatedRecoverableMatchPct` ranking approach used in focus areas).
- [x] Prompt version constant bumped alongside the change (`PRE_MATCH_PROMPT_VERSION = 4`).
- [x] No personal text from the user in the prompt (signals are derived from server-side data only).

### Performance
- [x] Zero new GraphQL calls. Dashboard is loaded via Redis cache first, already fetched by the existing route for squad context.
- [x] `computeBriefHooks` is a pure synchronous function -- no async overhead.

### Tests
- [x] 24 unit tests in `tests/unit/pre-match-brief-hooks.test.ts`.
- [x] `pnpm -w run lint && pnpm -w run typecheck && pnpm -w test` all clean (1830 tests pass).