### PR TITLE
feat(matches): badge private matches and explain in match error view

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -4,6 +4,7 @@ import { checkRateLimit } from "@/lib/rate-limit";
 import { usageTelemetry, bucketCount } from "@/lib/usage-telemetry";
 import { markUpstreamDegraded } from "@/lib/upstream-status";
 import { maybeTagAsMcp } from "@/lib/telemetry-context";
+import { classifyVisibility } from "@/lib/visibility";
 
 import type { EventSummary } from "@/lib/types";
 
@@ -26,6 +27,10 @@ interface RawEvent {
   is_squadding_possible: boolean;
   max_competitors: number | null;
   registration: string;
+  /** SSI visibility code (only present on IpscMatchNode). One of pub/lim/res/csd/clb. */
+  visibility?: string;
+  /** Human-readable visibility description, e.g. "Public, searchable and details/names for all". */
+  get_visibility_display?: string;
 }
 
 interface RawEventsData {
@@ -327,6 +332,13 @@ export async function GET(req: Request) {
       squadding_closes: e.squadding_closes ?? null,
       is_squadding_possible: e.is_squadding_possible ?? false,
       max_competitors: e.max_competitors ?? null,
+      visibility: e.visibility
+        ? {
+            class: classifyVisibility(e.visibility),
+            rawCode: e.visibility,
+            displayName: e.get_visibility_display ?? "",
+          }
+        : null,
     }));
 
   const finalEvents: EventSummary[] = liveMode

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useSyncExternalStore, useEffect, useMemo, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import dynamic from "next/dynamic";
@@ -16,7 +17,7 @@ import { ModeToggle } from "@/components/mode-toggle";
 import { useMatchQuery, useCompareQuery, useCoachingAvailability, useShooterDashboardQuery } from "@/lib/queries";
 import { computeCareerBaseline } from "@/lib/career-baseline";
 import { detectMatchView, isPreMatchEligible } from "@/lib/mode";
-import type { CompareMode } from "@/lib/types";
+import type { CompareMode, EventSummary, Visibility } from "@/lib/types";
 import { CacheInfoBadge } from "@/components/cache-info-badge";
 import { UpstreamDegradedBanner } from "@/components/upstream-degraded-banner";
 import { LoadingBar } from "@/components/loading-bar";
@@ -198,6 +199,33 @@ export default function MatchPageClient() {
   );
 
   const matchQuery = useMatchQuery(ct, id);
+
+  // When match data fails to load, look up the match's visibility from any
+  // events list we already have cached. If the user got here from the home
+  // page or a search result, the events query carries `visibility`, so we
+  // can tell them precisely *why* the match isn't viewable (private vs
+  // missing) instead of giving the generic copy.
+  const queryClient = useQueryClient();
+  const knownVisibility: Visibility | null = useMemo(() => {
+    if (!matchQuery.isError) return null;
+    const ctNum = Number(ct);
+    const idNum = Number(id);
+    const matchEntry = (list: unknown): EventSummary | undefined => {
+      if (!Array.isArray(list)) return undefined;
+      return (list as EventSummary[]).find(
+        (e) => e.id === idNum && e.content_type === ctNum,
+      );
+    };
+    const candidates = [
+      ...queryClient.getQueriesData<EventSummary[]>({ queryKey: ["live-matches"] }),
+      ...queryClient.getQueriesData<EventSummary[]>({ queryKey: ["events"] }),
+    ];
+    for (const [, data] of candidates) {
+      const hit = matchEntry(data);
+      if (hit?.visibility) return hit.visibility;
+    }
+    return null;
+  }, [matchQuery.isError, queryClient, ct, id]);
 
   // Identity and tracked shooters (localStorage-backed, reactive).
   const { identity, setIdentity } = useMyIdentity();
@@ -502,18 +530,91 @@ export default function MatchPageClient() {
   }
 
   if (matchQuery.isError || !matchQuery.data) {
+    // SSI returns null for the match node when the requesting account isn't
+    // allowed to read it — most often a non-public match where the bot hasn't
+    // been invited as Staff. When the user reached this page from a list that
+    // carries visibility info, we can say so explicitly (`knownVisibility`).
+    // Otherwise we hedge between "private" and "removed" so the copy is
+    // accurate either way.
+    const errMsg = matchQuery.error?.message ?? "";
+    // fetchMatch() throws `Match fetch failed (404): ...` when the API returns
+    // 404. Any non-404 (e.g. 502 from a degraded upstream) renders the
+    // generic failure copy instead of the "private" explainer.
+    const isNotFound = !matchQuery.isError || /\(404\)/.test(errMsg);
+    const confirmedPrivate =
+      isNotFound && knownVisibility?.class === "organizer-published";
     return (
-      <main id="main-content" tabIndex={-1} className="min-h-screen flex flex-col items-center justify-center gap-4 p-8">
-        <AlertCircle className="w-8 h-8 text-destructive" />
-        <p className="text-destructive font-medium" role="alert">
-          {matchQuery.error?.message ?? "Failed to load match"}
-        </p>
-        <Button variant="outline" asChild>
-          <Link href="/">
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            Back
-          </Link>
-        </Button>
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="min-h-screen flex flex-col items-center justify-center gap-4 p-8"
+      >
+        <div className="w-full max-w-md rounded-lg border bg-card p-6 text-center space-y-4">
+          <AlertCircle className="w-8 h-8 text-muted-foreground mx-auto" aria-hidden="true" />
+          {isNotFound && confirmedPrivate ? (
+            <>
+              <h1 className="text-lg font-semibold">This match is private</h1>
+              <div className="text-sm text-muted-foreground space-y-2 text-left" role="alert">
+                <p>
+                  The organizer marked this match as{" "}
+                  <em>{knownVisibility?.displayName || "non-public"}</em> on
+                  ShootNScoreIt and hasn{"’"}t published it to the scoreboard,
+                  so we can{"’"}t show its details here.
+                </p>
+                <p>
+                  If you organize this match and want to make it viewable, see{" "}
+                  <Link
+                    href="/about/organizer-published"
+                    className="text-primary hover:underline underline-offset-2"
+                  >
+                    how to publish a private match
+                  </Link>
+                  .
+                </p>
+              </div>
+            </>
+          ) : isNotFound ? (
+            <>
+              <h1 className="text-lg font-semibold">Match not viewable</h1>
+              <div className="text-sm text-muted-foreground space-y-2 text-left" role="alert">
+                <p>
+                  We couldn{"’"}t load this match. There are two common reasons:
+                </p>
+                <ul className="list-disc list-inside space-y-1">
+                  <li>
+                    It{"’"}s a <strong>private match</strong> on ShootNScoreIt
+                    and the organizer hasn{"’"}t published it to the scoreboard.
+                  </li>
+                  <li>The match has been removed or doesn{"’"}t exist.</li>
+                </ul>
+                <p>
+                  If you organize a private match and want to make it viewable
+                  here, see{" "}
+                  <Link
+                    href="/about/organizer-published"
+                    className="text-primary hover:underline underline-offset-2"
+                  >
+                    how to publish a private match
+                  </Link>
+                  .
+                </p>
+              </div>
+            </>
+          ) : (
+            <>
+              <h1 className="text-lg font-semibold">Failed to load match</h1>
+              <p className="text-sm text-muted-foreground" role="alert">
+                {errMsg || "Something went wrong."}
+              </p>
+            </>
+          )}
+          <Button variant="outline" asChild>
+            <Link href="/">
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              Back
+            </Link>
+          </Button>
+        </div>
       </main>
     );
   }

--- a/components/event-search.tsx
+++ b/components/event-search.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/command";
 import { useEventsQuery } from "@/lib/queries";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { PrivateMatchPill } from "@/components/private-match-pill";
 import type { EventSummary } from "@/lib/types";
 import { parseMatchUrl, cn } from "@/lib/utils";
 
@@ -444,7 +445,10 @@ export function EventSearch() {
                   onSelect={() => handleSelect(event)}
                   className="flex flex-col items-start gap-0.5 py-2.5"
                 >
-                  <span className="font-medium leading-snug">{event.name}</span>
+                  <span className="font-medium leading-snug">
+                    {event.name}
+                    <PrivateMatchPill visibility={event.visibility} className="ml-2 align-middle" />
+                  </span>
                   <span className="text-xs text-muted-foreground leading-snug">
                     {formatEventDate(event.date)}
                     {" · "}

--- a/components/live-matches.tsx
+++ b/components/live-matches.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useLiveMatchesQuery } from "@/lib/queries";
+import { PrivateMatchPill } from "@/components/private-match-pill";
 import type { EventSummary } from "@/lib/types";
 
 /**
@@ -76,7 +77,10 @@ export function LiveMatchCard({ match }: { match: EventSummary }) {
       aria-label={`Open ${match.name}, live, started ${startedAgo}`}
     >
       <div className="flex items-start justify-between gap-2">
-        <span className="font-semibold leading-snug">{match.name}</span>
+        <span className="font-semibold leading-snug">
+          {match.name}
+          <PrivateMatchPill visibility={match.visibility} className="ml-2 align-middle" />
+        </span>
         <span
           className="text-sm font-medium text-muted-foreground shrink-0 tabular-nums"
           aria-hidden="true"

--- a/components/private-match-pill.tsx
+++ b/components/private-match-pill.tsx
@@ -1,0 +1,30 @@
+import { Lock } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { Visibility } from "@/lib/types";
+
+/**
+ * Compact "Private" pill rendered next to non-public matches in list-card
+ * surfaces (home page Live now, event search results). Purely visual --
+ * clicking still opens the match page, which carries the full explainer
+ * when the match isn't viewable. Keep it small so the card layout doesn't
+ * change shape between public and private matches.
+ */
+export function PrivateMatchPill({
+  visibility,
+  className,
+}: {
+  visibility: Visibility | null | undefined;
+  className?: string;
+}) {
+  if (!visibility || visibility.class !== "organizer-published") return null;
+  return (
+    <Badge
+      variant="outline"
+      className={`gap-1 text-[10px] py-0 px-1.5 font-medium ${className ?? ""}`}
+      aria-label="Private match -- details may be restricted"
+    >
+      <Lock className="h-2.5 w-2.5" aria-hidden="true" />
+      Private
+    </Badge>
+  );
+}

--- a/components/recent-competitions.tsx
+++ b/components/recent-competitions.tsx
@@ -10,6 +10,8 @@ import {
   removeRecentCompetition,
   type StoredCompetition,
 } from "@/lib/competition-store";
+import { PrivateMatchPill } from "@/components/private-match-pill";
+import type { Visibility } from "@/lib/types";
 
 /** Minimum data needed to render a CompetitionCard. */
 export interface CompetitionCardData {
@@ -19,6 +21,7 @@ export interface CompetitionCardData {
   venue: string | null;
   date: string | null;
   scoring_completed: number;
+  visibility?: Visibility | null;
 }
 
 export function CompetitionCard({
@@ -59,7 +62,10 @@ export function CompetitionCard({
         aria-label={`Open ${comp.name}`}
       >
         <div className="flex items-start justify-between gap-2 pr-6">
-          <span className="font-semibold leading-snug">{comp.name}</span>
+          <span className="font-semibold leading-snug">
+            {comp.name}
+            <PrivateMatchPill visibility={comp.visibility} className="ml-2 align-middle" />
+          </span>
           <span className="text-sm font-medium text-muted-foreground shrink-0">
             {Math.round(comp.scoring_completed)}%
           </span>

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -72,6 +72,7 @@ directly). The array is sorted by start date descending.
 | `is_squadding_possible` | boolean | |
 | `max_competitors` | number \| null | Cap configured by the organizer. |
 | `scoring_completed` | number | Percent 0-100. `0` for upcoming or empty matches. |
+| `visibility` | `Visibility` \| null | SSI visibility classification (same shape as on `/api/v1/match/{ct}/{id}`). Optional -- present only for IPSC match rows. Use it to badge non-public matches in client UIs. Added 2026-05. |
 
 There is no pagination -- v1 returns the full result set for the given window.
 For broad browse queries, narrow the window or add filters rather than relying

--- a/lib/api-v1-schemas.ts
+++ b/lib/api-v1-schemas.ts
@@ -51,6 +51,14 @@ export type V1ErrorEnvelope = z.infer<typeof v1ErrorEnvelopeSchema>;
 
 // ─── /api/v1/events ──────────────────────────────────────────────────────────
 
+const v1VisibilitySchema = z
+  .object({
+    class: z.enum(["public", "unlisted", "organizer-published"]),
+    rawCode: z.string(),
+    displayName: z.string(),
+  })
+  .strict();
+
 export const v1EventSchema = z
   .object({
     id: z.number(),
@@ -79,6 +87,9 @@ export const v1EventSchema = z
     squadding_closes: z.string().nullable(),
     is_squadding_possible: z.boolean(),
     max_competitors: z.number().nullable(),
+    // Optional / additive — present on IpscMatchNode rows, omitted for other
+    // event kinds. Mirrors the shape on /api/v1/match/{ct}/{id}.
+    visibility: v1VisibilitySchema.nullable().optional(),
   })
   .strict();
 export type V1Event = z.infer<typeof v1EventSchema>;
@@ -126,14 +137,6 @@ const v1SquadSchema = z
     number: z.number(),
     name: z.string(),
     competitorIds: z.array(z.number()),
-  })
-  .strict();
-
-const v1VisibilitySchema = z
-  .object({
-    class: z.enum(["public", "unlisted", "organizer-published"]),
-    rawCode: z.string(),
-    displayName: z.string(),
   })
   .strict();
 

--- a/lib/competition-store.ts
+++ b/lib/competition-store.ts
@@ -1,4 +1,4 @@
-import type { MatchResponse, MatchView } from "@/lib/types";
+import type { MatchResponse, MatchView, Visibility } from "@/lib/types";
 
 export interface StoredCompetition {
   ct: string;
@@ -8,6 +8,11 @@ export interface StoredCompetition {
   date: string | null;
   scoring_completed: number;
   last_visited: number;
+  /** SSI visibility classification at the time of the last visit. Optional
+   *  so older localStorage entries (before this field existed) still parse;
+   *  they get re-populated on the next visit. The recents card uses it to
+   *  badge non-public matches without re-fetching. */
+  visibility?: Visibility | null;
 }
 
 const RECENT_KEY = "ssi_recent_competitions";
@@ -51,6 +56,7 @@ export function saveRecentCompetition(
       // localStorage entries don't lose the field on read.
       scoring_completed: match.scoring_pct,
       last_visited: Date.now(),
+      visibility: match.visibility ?? null,
     };
     const updated = [entry, ...existing].slice(0, MAX_RECENT);
     localStorage.setItem(RECENT_KEY, JSON.stringify(updated));

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -723,6 +723,8 @@ export const EVENTS_QUERY = `
         is_squadding_possible
         max_competitors
         registration
+        visibility
+        get_visibility_display
       }
     }
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -732,6 +732,11 @@ export interface EventSummary {
   is_squadding_possible: boolean;
   /** Maximum number of competitors allowed; null if not set. */
   max_competitors: number | null;
+  /** SSI visibility classification (issue #426). Optional because the field
+   *  was added later and non-IpscMatch nodes don't expose it. When present,
+   *  list-card UIs render a badge for `organizer-published` so users know
+   *  the match isn't fully public on SSI (and may not be viewable here). */
+  visibility?: Visibility | null;
 }
 
 // ── Stage Simulator ──────────────────────────────────────────────────────────

--- a/tests/components/live-matches.test.tsx
+++ b/tests/components/live-matches.test.tsx
@@ -51,4 +51,39 @@ describe("LiveMatches card", () => {
     expect(screen.getByText("Hello Cup")).toBeTruthy();
     expect(screen.getByText(/Range B/)).toBeTruthy();
   });
+
+  it("renders a Private pill for organizer-published matches", () => {
+    // SSI's events list surfaces matches with non-public visibility (res/csd/clb)
+    // even though their details may not be accessible. The pill warns the user
+    // before they tap into a match that might 404.
+    render(
+      <LiveMatchCard
+        match={event({
+          id: 3,
+          visibility: {
+            class: "organizer-published",
+            rawCode: "res",
+            displayName: "Restricted, searchable but details/names only participants",
+          },
+        })}
+      />,
+    );
+    expect(screen.getByText("Private")).toBeTruthy();
+  });
+
+  it("does not render a Private pill for public matches", () => {
+    render(
+      <LiveMatchCard
+        match={event({
+          id: 4,
+          visibility: {
+            class: "public",
+            rawCode: "pub",
+            displayName: "Public, searchable and details/names for all",
+          },
+        })}
+      />,
+    );
+    expect(screen.queryByText("Private")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

- The events list surfaces matches whose SSI visibility is restricted (`res` / `csd` / `clb`) because they remain searchable on SSI, but our match query 404s when the service account isn't a participant. Reported via match `22/28429` ("12May26. IPSC HG Lynnwood") -- it shows in "Live now" on the home page but the match page returned a bare 404.
- Keep non-public matches in the list (organizers may have shared the URL on purpose) but flag them with a compact "Private" pill on the home page and search results.
- The match page's error view now branches into three states:
  - **Confirmed private** -- the user reached the page from a list whose `visibility` is cached, so we surface SSI's exact label and link to [`/about/organizer-published`](https://scoreboard.urdr.dev/about/organizer-published).
  - **404 without context** (deep link, nothing cached) -- hedged "private or removed" copy with the same instructions link.
  - **Other errors** (502, etc.) -- generic failure copy.
- `/api/v1/events` gains an optional `visibility` field on each entry. Additive only, no v2 needed.

## Test plan

- [x] `pnpm -w run typecheck` clean
- [x] `pnpm -w run lint` clean
- [x] `pnpm -w test` -- 1832 tests pass (new tests cover the Private pill for organizer-published matches and confirm public matches don't render the pill)
- [x] `pnpm validate:ssi-queries` clean (new `visibility` selection exists in the snapshot)
- [ ] Smoke test in dev: home page Live now renders the pill for a non-public match; match page for a known-private match shows the tailored explainer; direct deep link to a 404 match shows the hedged copy
- [ ] Verify `/api/v1/events` response still validates against the updated schema for a real fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)