### PR TITLE
ci: add timeouts to scoreboard job so hung e2e fails fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.scoreboard == 'true'
     runs-on: ubuntu-latest
+    # A healthy run is 3-7 min; this is a backstop so a hung step fails fast
+    # instead of running to GitHub's 6h job default. The e2e steps below carry
+    # tighter per-step limits since the Playwright install / test:e2e step is
+    # the one that occasionally hangs on the runner.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -103,8 +108,10 @@ jobs:
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 6
 
       - run: pnpm test:e2e
+        timeout-minutes: 10
         env:
           SSI_API_KEY: dummy_key_for_e2e
 


### PR DESCRIPTION
## Problem

The `scoreboard` CI job had no `timeout-minutes`, so a hung step ran to GitHub's **6-hour** job default. This surfaced live while merging #475: a run sat ~37 min on the Playwright e2e step before being cancelled by hand, and a re-run hung the same way. The hang is an occasional runner/CDN flake on `Install Playwright browsers` / `pnpm test:e2e`, not a test failure — but with no timeout it blocks the PR indefinitely.

## Change

- **Job backstop:** `timeout-minutes: 20` on the `scoreboard` job. Healthy runs are 3-7 min, so 20 is comfortable headroom.
- **Per-step limits** on the two steps that actually hang: 6 min for `Install Playwright browsers`, 10 min for `pnpm test:e2e`. A hang now fails fast (and the existing `if: failure()` artifact upload still captures the Playwright report).

No change to what the tests do — only how long a stuck step is allowed to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)