### PR TITLE
fix(d1): gate last_accessed_at touch behind a cross-isolate lock

### DIFF
--- a/lib/match-data-store.ts
+++ b/lib/match-data-store.ts
@@ -31,6 +31,20 @@ const TOUCH_DEBOUNCE_MS = 60_000;
  *  debounces — duplicate writes are harmless since touch is idempotent. */
 const lastTouchedAt = new Map<string, number>();
 
+/** Redis key prefix for the cross-isolate touch single-flight lock. */
+const TOUCH_LOCK_PREFIX = "touchlock:";
+
+/** Global (cross-isolate) debounce window for `last_accessed_at` bumps, in
+ *  seconds. The per-process `lastTouchedAt` map only debounces within one
+ *  Worker isolate; during a traffic burst Cloudflare spins up many fresh
+ *  isolates that each fire their own UPDATE, which is what overloaded D1
+ *  ("D1 DB is overloaded"). This Redis-backed single-flight bounds the touch
+ *  to ~one UPDATE per cache key per window across ALL isolates. The window is
+ *  deliberately generous: the only consumer of `last_accessed_at` is the admin
+ *  "served in the last 30 days" diagnostic (app/admin/access), so hour-level
+ *  freshness is plenty. */
+const TOUCH_GLOBAL_DEBOUNCE_SECONDS = 3_600;
+
 interface CacheEntryMeta {
   v?: number;
 }
@@ -78,10 +92,24 @@ function maybeTouchMatchDataCache(cacheKey: string): void {
   const last = lastTouchedAt.get(cacheKey);
   if (last !== undefined && now - last < TOUCH_DEBOUNCE_MS) return;
   lastTouchedAt.set(cacheKey, now);
-  // Fire-and-forget — never block the read path on the audit write.
-  void db
-    .touchMatchDataCache(cacheKey, new Date(now).toISOString())
-    .catch((err) => reportError("match-data-store.touch", err, { matchKey: cacheKey }));
+  // Fire-and-forget — never block the read path on the audit write. A
+  // Redis-backed single-flight (SET NX EX) gates the D1 UPDATE so a traffic
+  // burst's many cold isolates don't storm the primary with redundant touches:
+  // only the first caller per key per window actually writes. A benign race
+  // (two isolates both acquiring) is harmless since the UPDATE is idempotent.
+  void (async () => {
+    try {
+      const acquired = await cache.setIfAbsent(
+        `${TOUCH_LOCK_PREFIX}${cacheKey}`,
+        "1",
+        TOUCH_GLOBAL_DEBOUNCE_SECONDS,
+      );
+      if (!acquired) return; // another isolate touched this key recently
+      await db.touchMatchDataCache(cacheKey, new Date(now).toISOString());
+    } catch (err) {
+      reportError("match-data-store.touch", err, { matchKey: cacheKey });
+    }
+  })();
 }
 
 /**

--- a/tests/unit/match-data-store.test.ts
+++ b/tests/unit/match-data-store.test.ts
@@ -12,9 +12,13 @@ const dbMock = vi.hoisted(() => ({
       meta: { keyType: string; ct: number; matchId: string; schemaVersion: number },
     ) => Promise<void>
   >(),
+  getMatchDataCache: vi.fn<(k: string) => Promise<string | null>>(),
+  touchMatchDataCache: vi.fn<(k: string, when: string) => Promise<void>>(),
 }));
 const cacheMock = vi.hoisted(() => ({
   expire: vi.fn<(k: string, ttl: number) => Promise<void>>(),
+  get: vi.fn<(k: string) => Promise<string | null>>(),
+  setIfAbsent: vi.fn<(k: string, v: string, ttl: number) => Promise<boolean>>(),
 }));
 
 vi.mock("@/lib/db-impl", () => ({
@@ -149,5 +153,77 @@ describe("persistActiveMatchToD1", () => {
     dbMock.setMatchDataCache.mockRejectedValue(new Error("d1 down"));
 
     await expect(persistActiveMatchToD1(KEY, PAYLOAD)).resolves.toBeUndefined();
+  });
+});
+
+describe("getMatchDataWithFallback — last_accessed_at touch", () => {
+  // Each test uses a distinct match id so the process-local per-isolate
+  // debounce (lastTouchedAt map, module state) never suppresses the touch.
+  beforeEach(() => {
+    cacheMock.get.mockReset();
+    cacheMock.setIfAbsent.mockReset();
+    dbMock.getMatchDataCache.mockReset();
+    dbMock.touchMatchDataCache.mockReset();
+  });
+
+  it("touches D1 only after acquiring the cross-isolate single-flight lock", async () => {
+    const { getMatchDataWithFallback } = await import("@/lib/match-data-store");
+    const KEY = 'gql:GetMatch:{"ct":22,"id":"1001"}';
+    cacheMock.get.mockResolvedValue("cached-value");
+    cacheMock.setIfAbsent.mockResolvedValue(true);
+    dbMock.touchMatchDataCache.mockResolvedValue(undefined);
+
+    const raw = await getMatchDataWithFallback(KEY);
+    expect(raw).toBe("cached-value");
+
+    await vi.waitFor(() => {
+      expect(cacheMock.setIfAbsent).toHaveBeenCalledWith(`touchlock:${KEY}`, "1", 3600);
+      expect(dbMock.touchMatchDataCache).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("skips the D1 touch when another isolate already holds the lock", async () => {
+    const { getMatchDataWithFallback } = await import("@/lib/match-data-store");
+    const KEY = 'gql:GetMatch:{"ct":22,"id":"1002"}';
+    cacheMock.get.mockResolvedValue("cached-value");
+    cacheMock.setIfAbsent.mockResolvedValue(false);
+
+    await getMatchDataWithFallback(KEY);
+
+    await vi.waitFor(() => expect(cacheMock.setIfAbsent).toHaveBeenCalledTimes(1));
+    expect(dbMock.touchMatchDataCache).not.toHaveBeenCalled();
+  });
+
+  it("does not attempt a touch for non-match cache keys", async () => {
+    const { getMatchDataWithFallback } = await import("@/lib/match-data-store");
+    cacheMock.get.mockResolvedValue("v");
+
+    await getMatchDataWithFallback("computed:shooter:123:dashboard");
+    await Promise.resolve();
+
+    expect(cacheMock.setIfAbsent).not.toHaveBeenCalled();
+    expect(dbMock.touchMatchDataCache).not.toHaveBeenCalled();
+  });
+
+  it("does not touch when neither cache layer has the entry", async () => {
+    const { getMatchDataWithFallback } = await import("@/lib/match-data-store");
+    const KEY = 'gql:GetMatch:{"ct":22,"id":"1004"}';
+    cacheMock.get.mockResolvedValue(null);
+    dbMock.getMatchDataCache.mockResolvedValue(null);
+
+    const raw = await getMatchDataWithFallback(KEY);
+    await Promise.resolve();
+
+    expect(raw).toBeNull();
+    expect(cacheMock.setIfAbsent).not.toHaveBeenCalled();
+  });
+
+  it("swallows touch errors so the read path never fails", async () => {
+    const { getMatchDataWithFallback } = await import("@/lib/match-data-store");
+    const KEY = 'gql:GetMatch:{"ct":22,"id":"1003"}';
+    cacheMock.get.mockResolvedValue("cached-value");
+    cacheMock.setIfAbsent.mockRejectedValue(new Error("redis down"));
+
+    await expect(getMatchDataWithFallback(KEY)).resolves.toBe("cached-value");
   });
 });


### PR DESCRIPTION
## Problem

Follow-up to #475. The `last_accessed_at` audit bump in `lib/match-data-store.ts` was debounced **only per-isolate** (the `lastTouchedAt` map). During a traffic burst Cloudflare spins up many fresh isolates, each with an empty map, so each fires its own D1 `UPDATE` for the same hot match — a write storm. `match-data-store.touch` was the single largest error site in the `D1 DB is overloaded. Requests queued for too long.` bursts (51 of 98 errors over 30 days).

Read replication (#475) offloads the *reads*, but these touch *writes* still land on the primary, so the storm needed its own fix.

## Change

Gate the D1 `UPDATE` behind a Redis `SET NX EX` single-flight (`cache.setIfAbsent`, the same primitive used for SWR refresh dedup): at most **one touch per cache key per hour across all isolates**. The per-isolate map stays as a cheap first gate so repeat reads within one warm isolate don't even hit Redis.

```
read served → per-isolate 60s debounce → Redis SET NX EX (1h) → D1 UPDATE (only if lock acquired)
```

### Why this is safe

- The **only** consumer of `last_accessed_at` is the admin "served in the last 30 days" diagnostic (`app/admin/access`). Hour-level freshness is far more than enough — no eviction/retention logic depends on it.
- A benign lock race (two isolates both acquiring) is harmless: the `UPDATE` is idempotent.
- Any lock or write error is swallowed (reported to telemetry as `match-data-store.touch`) so the read path never fails — and on a Redis blip we skip the touch rather than fall back to storming D1.

## Tests

Added 5 cases to `tests/unit/match-data-store.test.ts` covering: touch fires only when the lock is acquired, skip when held by another isolate, no touch for non-match keys, no touch on a full cache miss, and errors are swallowed. Full suite: **1837 pass**, lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)