### PR TITLE
fix(ci): pass JWT auth secrets to schema-drift workflow

### DIFF
--- a/.github/workflows/check-ssi-schema.yml
+++ b/.github/workflows/check-ssi-schema.yml
@@ -8,7 +8,9 @@ name: Check SSI Schema Drift
 # job status (visible in the Actions tab); pair with branch protection or a
 # manual review cadence.
 #
-# Setup: requires `SSI_API_KEY` as a repo secret.
+# Setup: requires `SSI_API_KEY`, `SSI_SERVICE_EMAIL`, and `SSI_SERVICE_PASSWORD`
+# as repo secrets. Schema introspection needs JWT auth (see #425), so the bot
+# account credentials are required in addition to the API key.
 
 on:
   workflow_dispatch:
@@ -35,6 +37,8 @@ jobs:
       - name: Compare snapshot vs live SSI schema
         env:
           SSI_API_KEY: ${{ secrets.SSI_API_KEY }}
+          SSI_SERVICE_EMAIL: ${{ secrets.SSI_SERVICE_EMAIL }}
+          SSI_SERVICE_PASSWORD: ${{ secrets.SSI_SERVICE_PASSWORD }}
         run: pnpm check:ssi-schema
 
       # Belt-and-braces: even when drift detection passes, re-run the static


### PR DESCRIPTION
## Problem

The scheduled **Check SSI Schema Drift** workflow has been failing on every run. It wasn't detecting real drift — it exited early with:

```
[check-ssi-schema] SSI_API_KEY, SSI_SERVICE_EMAIL, and SSI_SERVICE_PASSWORD must be set.
Schema introspection requires JWT auth (see #425).
```

PR #425 made `scripts/check-ssi-schema.ts` require JWT auth (bot-account email + password) for introspection, but the workflow only passed `SSI_API_KEY`, and the two service secrets didn't exist in the repo.

## Fix

- Wire `SSI_SERVICE_EMAIL` and `SSI_SERVICE_PASSWORD` into the workflow `env:` block.
- Update the setup comment to list all three required secrets.
- (Out of band) Added the two missing repo secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)