### PR TITLE
ci: run scoreboard job in Playwright container (fixes browser-download hang)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,29 @@ jobs:
           cp -r .next/static .next/standalone/.next/static
           cp -r public .next/standalone/public
 
-      - name: Install Playwright browsers
+      # Cache the Chromium binary (~150MB) keyed on the Playwright version so
+      # the slow download isn't repeated every run -- the uncached download is
+      # what occasionally stalls past the 6-min timeout. OS-level apt deps are
+      # NOT in this cache, so install-deps still runs on a cache hit (it's fast).
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(pnpm exec playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers (cache miss)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 6
+
+      - name: Install Playwright OS deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
         timeout-minutes: 6
 
       - run: pnpm test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
               - 'eslint.config.*'
               - 'vitest.config.*'
               - 'playwright.config.*'
+              # Run the full pipeline when CI itself changes, so workflow edits
+              # (e.g. the Playwright install steps) are exercised on their own PR.
+              - '.github/workflows/ci.yml'
             discord:
               - 'discord/**'
               - 'pnpm-lock.yaml'
@@ -106,30 +109,51 @@ jobs:
           cp -r .next/static .next/standalone/.next/static
           cp -r public .next/standalone/public
 
-      # Cache the Chromium binary (~150MB) keyed on the Playwright version so
-      # the slow download isn't repeated every run -- the uncached download is
-      # what occasionally stalls past the 6-min timeout. OS-level apt deps are
-      # NOT in this cache, so install-deps still runs on a cache hit (it's fast).
+      # The Chromium binary download (~150MB) has been hanging to the 6-min
+      # step timeout on the GitHub-hosted runner (reliably, across re-runs),
+      # failing CI with no code fault. Two defences:
+      #   1. Cache ~/.cache/ms-playwright keyed on the Playwright version, so
+      #      steady-state runs restore the binary and skip the download.
+      #   2. On a cache miss, retry the download with a PER-ATTEMPT timeout, so
+      #      one stalled attempt is killed at 3 min and retried instead of
+      #      eating the whole step budget. Cache is saved only after the binary
+      #      install succeeds (split restore/save), so a partial/hung download
+      #      is never cached.
+      # OS-level apt deps are not in the cache, so install-deps always runs
+      # (it's quick).
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(pnpm exec playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
 
-      - name: Cache Playwright browsers
+      - name: Restore Playwright browser cache
         id: playwright-cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
 
-      - name: Install Playwright browsers (cache miss)
+      - name: Install Playwright browser binary (cache miss, retried)
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
-        timeout-minutes: 6
+        run: |
+          ok=
+          for i in 1 2 3; do
+            if timeout 180 pnpm exec playwright install chromium; then ok=1; break; fi
+            echo "playwright install attempt $i failed or stalled; retrying in 10s..." >&2
+            sleep 10
+          done
+          [ -n "$ok" ]
+        timeout-minutes: 12
 
-      - name: Install Playwright OS deps (cache hit)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+      - name: Save Playwright browser cache
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright OS deps
         run: pnpm exec playwright install-deps chromium
-        timeout-minutes: 6
+        timeout-minutes: 5
 
       - run: pnpm test:e2e
         timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,19 @@ jobs:
     needs: changes
     if: needs.changes.outputs.scoreboard == 'true'
     runs-on: ubuntu-latest
+    # Run inside the official Playwright image so the browsers are pre-baked and
+    # we never hit cdn.playwright.dev at CI time. The download-at-runtime step
+    # was hanging in end-of-transfer finalization on the hosted runner (started
+    # ~2026-06-01, deterministic across re-runs) and failing CI with no code
+    # fault. The image tag MUST track the @playwright/test version in
+    # package.json (currently 1.58.2) -- a mismatch makes Playwright try to
+    # download the matching browser at runtime, reintroducing the failure.
+    # --user 1001 is the image's pwuser, per Playwright's CI guidance.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      options: --user 1001
     # A healthy run is 3-7 min; this is a backstop so a hung step fails fast
-    # instead of running to GitHub's 6h job default. The e2e steps below carry
-    # tighter per-step limits since the Playwright install / test:e2e step is
-    # the one that occasionally hangs on the runner.
+    # instead of running to GitHub's 6h job default.
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -109,51 +118,20 @@ jobs:
           cp -r .next/static .next/standalone/.next/static
           cp -r public .next/standalone/public
 
-      # The Chromium binary download (~150MB) has been hanging to the 6-min
-      # step timeout on the GitHub-hosted runner (reliably, across re-runs),
-      # failing CI with no code fault. Two defences:
-      #   1. Cache ~/.cache/ms-playwright keyed on the Playwright version, so
-      #      steady-state runs restore the binary and skip the download.
-      #   2. On a cache miss, retry the download with a PER-ATTEMPT timeout, so
-      #      one stalled attempt is killed at 3 min and retried instead of
-      #      eating the whole step budget. Cache is saved only after the binary
-      #      install succeeds (split restore/save), so a partial/hung download
-      #      is never cached.
-      # OS-level apt deps are not in the cache, so install-deps always runs
-      # (it's quick).
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "version=$(pnpm exec playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore Playwright browser cache
-        id: playwright-cache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
-
-      - name: Install Playwright browser binary (cache miss, retried)
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      # No "playwright install" step: the container image already ships the
+      # browsers matching @playwright/test 1.58.2 (see the container tag above).
+      # Guard against drift -- if package.json's Playwright is bumped without
+      # bumping the container tag, e2e would silently fall back to the broken
+      # runtime download. Fail fast with a clear message instead.
+      - name: Verify Playwright version matches container image
         run: |
-          ok=
-          for i in 1 2 3; do
-            if timeout 180 pnpm exec playwright install chromium; then ok=1; break; fi
-            echo "playwright install attempt $i failed or stalled; retrying in 10s..." >&2
-            sleep 10
-          done
-          [ -n "$ok" ]
-        timeout-minutes: 12
-
-      - name: Save Playwright browser cache
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
-
-      - name: Install Playwright OS deps
-        run: pnpm exec playwright install-deps chromium
-        timeout-minutes: 5
+          want=1.58.2
+          got=$(pnpm exec playwright --version | cut -d' ' -f2)
+          if [ "$got" != "$want" ]; then
+            echo "::error::@playwright/test is $got but the CI container is pinned to v$want." \
+                 "Bump the 'mcr.microsoft.com/playwright:v...' image tag in this workflow to match." >&2
+            exit 1
+          fi
 
       - run: pnpm test:e2e
         timeout-minutes: 10

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,14 @@ export default defineConfig({
   webServer: {
     // In CI the production build is already done — serve the standalone output directly
     // (next start is incompatible with output: "standalone"). Locally use next dev.
-    command: process.env.CI ? "node .next/standalone/server.js" : "pnpm dev",
+    // HOSTNAME is pinned to 0.0.0.0: Next's standalone server.js binds to
+    // process.env.HOSTNAME, and inside a container (the CI job runs in the
+    // Playwright image) Docker sets HOSTNAME to the container ID, so the server
+    // would bind to the container's internal IP and the localhost:3000
+    // healthcheck would never connect. 0.0.0.0 binds all interfaces incl. loopback.
+    command: process.env.CI
+      ? "HOSTNAME=0.0.0.0 PORT=3000 node .next/standalone/server.js"
+      : "pnpm dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,


### PR DESCRIPTION
## Problem

CI on `main` (`11ac451`, #477) failed only at **Install Playwright browsers** — all 69 unit tests passed, no code fault.

Root cause, confirmed against the last green run (2026-05-25), identical Playwright 1.58.2 / Chromium v1208:

- **2026-05-25 (green):** `chrome-linux64.zip` prints `... downloaded to ...` ~4s after starting; FFmpeg + headless-shell follow; step ~7s.
- **2026-06-01 onward (red):** the progress bar reaches `100% of 167.3 MiB` in ~2s, then **hangs with no `downloaded to` confirmation** and is killed at the timeout — identical on every attempt and re-run.

Bytes arrive fine (bandwidth isn't the issue); Playwright hangs in the **end-of-transfer finalization** of the zip from `cdn.playwright.dev`. Same package version that worked a week ago ⇒ external CDN / hosted-runner regression. Caching + retry can't fix it: the install never completes, so no cache entry is ever produced and every retry hits the same deterministic stall.

## Fix

Run the `scoreboard` job inside the official Playwright image, which ships the browsers pre-baked — no CDN access at CI time:

```yaml
container:
  image: mcr.microsoft.com/playwright:v1.58.2-noble
  options: --user 1001
```

- Removes the `playwright install` step entirely (and the cache/retry steps from earlier commits on this branch).
- The image tag is pinned to match `@playwright/test` (1.58.2). A **version-guard step** fails fast with a clear message if the package is bumped without bumping the image tag — otherwise e2e would silently fall back to the broken runtime download.
- Adds `.github/workflows/ci.yml` to the `scoreboard` paths filter so CI edits self-test (this PR runs the full e2e pipeline).

## Verification

Pushed; this PR's own CI run now exercises the containerized e2e job. Watching it to confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)