### PR TITLE
chore(mcp): remove dead start script

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "module": "./src/index.ts",
   "scripts": {
-    "start": "tsx src/index.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {


### PR DESCRIPTION
Removes the unused `start: "tsx src/index.ts"` script from `mcp/package.json`.

## Why

Nothing invokes `cd mcp && pnpm start`. The two real entry points for the MCP server are:

1. **Smithery (hosted/published)** — `smithery.yaml` uses `runtime: typescript` + `buildCommand: "cd mcp && npx @smithery/cli build"`, which bundles `src/index.ts` and ignores npm scripts.
2. **Local Claude (dev)** — `.mcp.json` runs root `node_modules/.bin/tsx mcp/src/index.ts`.

The dead script referenced `tsx`, which is not an `mcp/` dependency. Its presence is what caused the standalone `mcp/pnpm-lock.yaml` to carry a stale `tsx -> esbuild@0.27.3` chain — the source of Dependabot alert #127 (cleared in #481). Removing it keeps that lockfile from re-acquiring esbuild and matches how the server is actually run.

## Verification

- `cd mcp && pnpm run typecheck` passes
- No dependency changes; lockfile untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)