### PR TITLE
chore(schema): accept SSI snapshot drift (does_*_get_results rename)

### DIFF
--- a/scripts/ssi-schema-snapshot.json
+++ b/scripts/ssi-schema-snapshot.json
@@ -1077,9 +1077,19 @@
       "args": []
     },
     {
-      "name": "does_current_user_get_result",
+      "name": "does_current_user_get_results",
       "type": "Boolean!",
       "args": []
+    },
+    {
+      "name": "does_shooter_get_results",
+      "type": "Boolean!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
     },
     {
       "name": "ends",
@@ -2207,9 +2217,19 @@
       "args": []
     },
     {
-      "name": "does_current_user_get_result",
+      "name": "does_current_user_get_results",
       "type": "Boolean!",
       "args": []
+    },
+    {
+      "name": "does_shooter_get_results",
+      "type": "Boolean!",
+      "args": [
+        {
+          "name": "id",
+          "type": "String!"
+        }
+      ]
     },
     {
       "name": "ends",


### PR DESCRIPTION
## Summary
The scheduled `Check SSI Schema Drift` run ([31367357629](https://github.com/mandakan/ssi-scoreboard/actions/runs/31367357629)) flagged drift on `EventInterface` and `IpscMatchNode`:

- `does_current_user_get_result` renamed to `does_current_user_get_results` (plural)
- new field `does_shooter_get_results(id: String!): Boolean!`

Neither field is referenced by any query in `lib/graphql.ts`, any type in `lib/types.ts`, or any parser -- the old name existed only in the snapshot. Results-access gating uses `is_live_scores_accessible`, which is unchanged. So this is a pure snapshot refresh: no query updates, no `CACHE_SCHEMA_VERSION` bump, no /api/v1 contract impact.

## Verification
- `pnpm check:ssi-schema` -- no drift against the new snapshot
- `pnpm validate:ssi-queries` -- 5/5 queries valid
- Snapshot diff contains exactly the two field changes, nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code)