### PR TITLE
docs: commit next 16.3 auto-generated agent-rules block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,3 +347,13 @@ Two targets selected by `DEPLOY_TARGET`:
 
 See `docs/deployment.md` for the full setup steps (one-time D1 setup, secrets, bare-server
 deploys without Docker Compose).
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->


### PR DESCRIPTION
next 16.3.0 (merged in #490) writes a managed <!-- nextjs-agent-rules --> block into CLAUDE.md on every `next dev` run. Committing it (as next's docs recommend) stops it showing up as a perpetual uncommitted change on dev machines. The block content is exactly what `next dev` generated — not hand-written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkeMxNQuCmXUTG6YCSuBJ