### PR TITLE
Query cuts 1+2: adaptive idle probe cadence, 24h cache for past event windows

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { executeQuery, EVENTS_QUERY } from "@/lib/graphql";
-import { buildSubWindows } from "@/lib/events-windows";
+import { buildSubWindows, windowRevalidateSeconds } from "@/lib/events-windows";
 import { allSettledWithLimit } from "@/lib/concurrency";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { usageTelemetry, bucketCount } from "@/lib/usage-telemetry";
@@ -202,9 +202,16 @@ export async function GET(req: Request) {
           windows_used: windows.length,
         }));
       }
+      const todayYmd = new Date().toISOString().slice(0, 10);
       const settled = await allSettledWithLimit(
         windows.map((vars) => () =>
-          executeQuery<RawEventsData>(EVENTS_QUERY, vars, 3600, { timeoutMs: 8_000 }),
+          executeQuery<RawEventsData>(
+            EVENTS_QUERY,
+            vars,
+            // Fully-past windows are immutable — cache 24h instead of 1h (#504).
+            windowRevalidateSeconds(vars.starts_before, todayYmd),
+            { timeoutMs: 8_000 },
+          ),
         ),
         SUB_WINDOW_CONCURRENCY,
       );

--- a/lib/events-windows.ts
+++ b/lib/events-windows.ts
@@ -46,6 +46,18 @@ export const SUB_WINDOW_DAYS = 7;
 // multiple requests, which the per-IP/per-token rate limits then bound.
 export const MAX_SUB_WINDOWS = 10;
 
+/** Next fetch-cache revalidate (seconds) for one sub-window. A window whose
+ *  `starts_before` is entirely in the past cannot gain new events — cache it
+ *  24h instead of 1h (#504). Compare on YYYY-MM-DD strings. Edge case: a
+ *  match added retroactively to a past week appears up to a day late in
+ *  browse; text search is unaffected. */
+export const PAST_WINDOW_REVALIDATE_SECONDS = 86_400;
+export const UPCOMING_WINDOW_REVALIDATE_SECONDS = 3_600;
+
+export function windowRevalidateSeconds(startsBefore: string, todayYmd: string): number {
+  return startsBefore < todayYmd ? PAST_WINDOW_REVALIDATE_SECONDS : UPCOMING_WINDOW_REVALIDATE_SECONDS;
+}
+
 export interface SubWindowsResult {
   windows: Array<Record<string, string>>;
   /** True when the requested range exceeded the cap and was truncated. */

--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -20,6 +20,7 @@ import {
   recordUpstreamFailure,
   recordUpstreamSuccess,
 } from "@/lib/upstream-backoff";
+import { shouldProbeNow, recordProbeOutcome } from "@/lib/probe-cadence";
 
 /**
  * Check if the current request is an admin-authenticated request
@@ -626,6 +627,17 @@ export async function refreshCachedMatchQuery<T>(
   let prevUpstreamUpdatedIso: string | null = null;
 
   try {
+    // Adaptive idle cadence (#503): during an idle hold-off, skip the probe
+    // entirely — just keep the cache entry alive.
+    if (!(await shouldProbeNow(match.ct, match.id))) {
+      probeOutcome = "skip";
+      if (ttlSeconds !== null) {
+        try { await cache.expire(cacheKey, ttlSeconds); } catch { /* self-heals */ }
+        try { await cache.expire(sidecarKey, ttlSeconds); } catch { /* harmless */ }
+      }
+      return;
+    }
+
     let prevState: ProbeState | null = null;
     try {
       const raw = await cache.get(sidecarKey);
@@ -686,6 +698,7 @@ export async function refreshCachedMatchQuery<T>(
       // scorecard saves), so merge that into the cached blob first —
       // scoring_pct drives TTL/completion decisions for every consumer.
       probeOutcome = "skip";
+      await recordProbeOutcome(match.ct, match.id, false);
       await mergeProbeScoringIntoMatchEntry(cacheKey, ev.stages ?? null, ttlSeconds);
       if (ttlSeconds !== null) {
         try {
@@ -708,6 +721,7 @@ export async function refreshCachedMatchQuery<T>(
     // does not tick when scorecards land, so probeOutcome was never
     // "changed" for that keyType — and removing it keeps the contract clear.
     probeOutcome = prevState ? "changed" : "first-seen";
+    await recordProbeOutcome(match.ct, match.id, true);
 
     await fullRefresh<T>(cacheKey, query, variables, ttlSeconds);
     try {

--- a/lib/probe-cadence.ts
+++ b/lib/probe-cadence.ts
@@ -1,0 +1,75 @@
+// Adaptive idle cadence for the per-match sync probe (#503).
+//
+// Live matches spend most of their wall-clock idle (squad rotations, lunch,
+// overnight in status "on"). Probing every 60s all that time is our dominant
+// steady-state upstream cost. After IDLE_STREAK consecutive no-change cycles
+// the probe holds off 120s; after DEEP_IDLE_STREAK cycles, 300s. Any detected
+// change deletes the state, snapping straight back to the 60s base cadence.
+//
+// State is one Redis key per match, best-effort in both directions: cache
+// down -> probe as normal (fail open). Both the match-key and scorecards-key
+// refreshes report outcomes each cycle; a 30s bump guard counts them as one.
+
+import cache from "@/lib/cache-impl";
+
+const IDLE_STREAK = 5;            // ~5 quiet minutes at the 60s base cadence
+const IDLE_DELAY_SECONDS = 120;
+const DEEP_IDLE_STREAK = 8;
+const DEEP_IDLE_DELAY_SECONDS = 300;
+const BUMP_GUARD_MS = 30_000;
+const STATE_TTL_SECONDS = 3600;
+
+export function probeCadenceKey(ct: number, id: string): string {
+  return `probe:idle:${ct}:${id}`;
+}
+
+interface IdleState {
+  streak: number;
+  lastBumpAtIso: string;
+  notBeforeIso: string | null;
+}
+
+async function readState(key: string): Promise<IdleState | null> {
+  try {
+    const raw = await cache.get(key);
+    return raw ? (JSON.parse(raw) as IdleState) : null;
+  } catch {
+    return null; // fail open
+  }
+}
+
+/** False while an idle hold-off window is active — skip the probe, just
+ *  extend TTLs. Fail-open: no state or cache trouble means "probe". */
+export async function shouldProbeNow(ct: number, id: string): Promise<boolean> {
+  const state = await readState(probeCadenceKey(ct, id));
+  if (!state?.notBeforeIso) return true;
+  return new Date(state.notBeforeIso).getTime() <= Date.now();
+}
+
+/** Report a probe cycle's outcome. Change -> reset to base cadence.
+ *  No change -> extend the quiet streak (once per cycle) and set the
+ *  hold-off when past the idle thresholds. */
+export async function recordProbeOutcome(ct: number, id: string, changed: boolean): Promise<void> {
+  const key = probeCadenceKey(ct, id);
+  try {
+    if (changed) {
+      await cache.del(key);
+      return;
+    }
+    const prev = await readState(key);
+    if (prev && Date.now() - new Date(prev.lastBumpAtIso).getTime() < BUMP_GUARD_MS) {
+      return; // the other cache key's refresh already counted this cycle
+    }
+    const streak = (prev?.streak ?? 0) + 1;
+    const delaySeconds =
+      streak >= DEEP_IDLE_STREAK ? DEEP_IDLE_DELAY_SECONDS
+        : streak >= IDLE_STREAK ? IDLE_DELAY_SECONDS
+        : null;
+    const state: IdleState = {
+      streak,
+      lastBumpAtIso: new Date().toISOString(),
+      notBeforeIso: delaySeconds ? new Date(Date.now() + delaySeconds * 1000).toISOString() : null,
+    };
+    await cache.set(key, JSON.stringify(state), STATE_TTL_SECONDS);
+  } catch { /* best-effort */ }
+}

--- a/lib/scorecards-archive.ts
+++ b/lib/scorecards-archive.ts
@@ -38,6 +38,7 @@ import {
   type ProbeStageData,
 } from "@/lib/graphql";
 import { markUpstreamDegraded } from "@/lib/upstream-status";
+import { shouldProbeNow, recordProbeOutcome } from "@/lib/probe-cadence";
 import type {
   RawScorecardsData,
   RawStage,
@@ -238,6 +239,17 @@ export async function refreshScorecardsIncremental(
 
     const forced = await isForceRefreshRequested(ct, matchId);
 
+    // Adaptive idle cadence (#503): during a hold-off window from consecutive
+    // quiet cycles, skip even the probe — just keep the cache alive.
+    if (!forced && !(await shouldProbeNow(ct, matchId))) {
+      outcome = "skip";
+      if (ttlSeconds !== null) {
+        try { await cache.expire(cacheKey, ttlSeconds); } catch { /* self-heals */ }
+        try { await cache.expire(sidecarKey, sidecarTtl(ttlSeconds)); } catch { /* harmless */ }
+      }
+      return;
+    }
+
     let probeStages: ProbeStageData[] | null = null;
     if (!forced) {
       try {
@@ -288,6 +300,7 @@ export async function refreshScorecardsIncremental(
 
     if (changed.length === 0 && removedIds.length === 0) {
       // Nothing moved — extend TTLs only; no rewrite (avoids cachedAt/D1 churn).
+      await recordProbeOutcome(ct, matchId, false);
       outcome = "skip";
       if (ttlSeconds !== null) {
         try { await cache.expire(cacheKey, ttlSeconds); } catch { /* self-heals */ }
@@ -318,6 +331,7 @@ export async function refreshScorecardsIncremental(
       lastFullSyncAt: sidecar.lastFullSyncAt,
     }, ttlSeconds);
 
+    await recordProbeOutcome(ct, matchId, true);
     if (newStageSeen) {
       // The match overview's stage list doesn't know this stage yet — force
       // its next refresh cycle to do a clean full refetch.

--- a/tests/unit/events-windows.test.ts
+++ b/tests/unit/events-windows.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildSubWindows, MAX_SUB_WINDOWS, SUB_WINDOW_DAYS } from "@/lib/events-windows";
+import { buildSubWindows, windowRevalidateSeconds, MAX_SUB_WINDOWS, SUB_WINDOW_DAYS } from "@/lib/events-windows";
 
 describe("buildSubWindows", () => {
   it("splits a one-month range into 7-day windows", () => {
@@ -43,5 +43,16 @@ describe("buildSubWindows", () => {
   it("returns no windows for an empty or inverted range", () => {
     expect(buildSubWindows("2026-08-10", "2026-08-10", {}).windows).toHaveLength(0);
     expect(buildSubWindows("2026-08-10", "2026-08-01", {}).windows).toHaveLength(0);
+  });
+});
+
+describe("windowRevalidateSeconds", () => {
+  it("caches fully-past windows for 24h", () => {
+    expect(windowRevalidateSeconds("2026-08-01", "2026-08-15")).toBe(86_400);
+  });
+
+  it("keeps 1h cache for windows ending today or later", () => {
+    expect(windowRevalidateSeconds("2026-08-15", "2026-08-15")).toBe(3_600);
+    expect(windowRevalidateSeconds("2026-09-01", "2026-08-15")).toBe(3_600);
   });
 });

--- a/tests/unit/probe-cadence.test.ts
+++ b/tests/unit/probe-cadence.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const cacheMock = vi.hoisted(() => ({
+  get: vi.fn<(key: string) => Promise<string | null>>(),
+  set: vi.fn<(key: string, val: string, ttl: number | null) => Promise<void>>(),
+  del: vi.fn<(key: string) => Promise<void>>(),
+  expire: vi.fn(),
+  persist: vi.fn(),
+  setIfAbsent: vi.fn(),
+}));
+vi.mock("@/lib/cache-impl", () => ({ default: cacheMock }));
+
+import { shouldProbeNow, recordProbeOutcome, probeCadenceKey } from "@/lib/probe-cadence";
+
+const KEY = probeCadenceKey(22, "26547");
+
+beforeEach(() => {
+  Object.values(cacheMock).forEach((fn) => fn.mockReset());
+  cacheMock.set.mockResolvedValue(undefined);
+  cacheMock.del.mockResolvedValue(undefined);
+});
+
+function state(streak: number, lastBumpMsAgo: number, notBeforeMsFromNow: number | null) {
+  return JSON.stringify({
+    streak,
+    lastBumpAtIso: new Date(Date.now() - lastBumpMsAgo).toISOString(),
+    notBeforeIso: notBeforeMsFromNow === null ? null : new Date(Date.now() + notBeforeMsFromNow).toISOString(),
+  });
+}
+
+describe("shouldProbeNow", () => {
+  it("probes when no idle state exists", async () => {
+    cacheMock.get.mockResolvedValue(null);
+    expect(await shouldProbeNow(22, "26547")).toBe(true);
+  });
+
+  it("holds off while notBefore is in the future", async () => {
+    cacheMock.get.mockResolvedValue(state(6, 60_000, 90_000));
+    expect(await shouldProbeNow(22, "26547")).toBe(false);
+  });
+
+  it("probes again once notBefore has passed", async () => {
+    cacheMock.get.mockResolvedValue(state(6, 200_000, -1_000));
+    expect(await shouldProbeNow(22, "26547")).toBe(true);
+  });
+
+  it("fails open when the cache is down", async () => {
+    cacheMock.get.mockRejectedValue(new Error("down"));
+    expect(await shouldProbeNow(22, "26547")).toBe(true);
+  });
+});
+
+describe("recordProbeOutcome", () => {
+  it("a change clears the idle state (snap back to base cadence)", async () => {
+    await recordProbeOutcome(22, "26547", true);
+    expect(cacheMock.del).toHaveBeenCalledWith(KEY);
+  });
+
+  it("quiet cycles below the threshold track the streak without a hold-off", async () => {
+    cacheMock.get.mockResolvedValue(state(2, 60_000, null));
+    await recordProbeOutcome(22, "26547", false);
+    const written = JSON.parse(cacheMock.set.mock.calls[0][1] as string);
+    expect(written.streak).toBe(3);
+    expect(written.notBeforeIso).toBeNull();
+  });
+
+  it("the 5th quiet cycle starts a ~120s hold-off", async () => {
+    cacheMock.get.mockResolvedValue(state(4, 60_000, null));
+    await recordProbeOutcome(22, "26547", false);
+    const written = JSON.parse(cacheMock.set.mock.calls[0][1] as string);
+    expect(written.streak).toBe(5);
+    const holdMs = new Date(written.notBeforeIso).getTime() - Date.now();
+    expect(holdMs).toBeGreaterThan(100_000);
+    expect(holdMs).toBeLessThan(130_000);
+  });
+
+  it("the 8th quiet cycle deepens the hold-off to ~300s", async () => {
+    cacheMock.get.mockResolvedValue(state(7, 200_000, null));
+    await recordProbeOutcome(22, "26547", false);
+    const written = JSON.parse(cacheMock.set.mock.calls[0][1] as string);
+    expect(written.streak).toBe(8);
+    const holdMs = new Date(written.notBeforeIso).getTime() - Date.now();
+    expect(holdMs).toBeGreaterThan(280_000);
+    expect(holdMs).toBeLessThan(320_000);
+  });
+
+  it("does not double-count when both cache keys report within one cycle", async () => {
+    cacheMock.get.mockResolvedValue(state(3, 5_000, null)); // bumped 5s ago
+    await recordProbeOutcome(22, "26547", false);
+    expect(cacheMock.set).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Implements the top two items of the query-cuts epic #510.

Closes #503, closes #504.

**Adaptive idle cadence** (`lib/probe-cadence.ts`): 5 consecutive quiet probe cycles -> 120s hold-off; 8 -> 300s; any change snaps back to the 60s base. Hold-off cycles skip even the probe and just extend cache TTLs. Fail-open on cache trouble; a 30s bump guard counts the match-key and scorecards-key refreshes as one cycle. User effect: after a scoring lull, the first new score can take up to 2-5 min to surface; active scoring is unchanged.

**Immutable past windows** (`lib/events-windows.ts`): browse sub-windows whose `starts_before` is fully in the past get a 24h Next fetch-cache revalidate instead of 1h. Edge case: a retroactively added past match appears up to a day late in browse; text search unaffected.

1918 tests green (11 new, TDD), zero lint/typecheck warnings. Prod is still paused (`SSI_UPSTREAM_PAUSED`), so this rides along in the Monday unpause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkeMxNQuCmXUTG6YCSuBJ