### PR TITLE
Query cuts 3+4: local-first event search, read-only OG path

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { executeQuery, EVENTS_QUERY } from "@/lib/graphql";
 import { buildSubWindows, windowRevalidateSeconds } from "@/lib/events-windows";
+import { searchLocalEvents } from "@/lib/local-event-search";
 import { allSettledWithLimit } from "@/lib/concurrency";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { usageTelemetry, bucketCount } from "@/lib/usage-telemetry";
@@ -149,8 +150,20 @@ export async function GET(req: Request) {
   const firearms = searchParams.get("firearms") ?? null;
 
   let rawEvents: RawEvent[];
+  let localSearchHit = false;
   try {
     if (q) {
+      // Local-first (#505): resolve the search from the D1 matches table +
+      // cached match blobs when possible — zero upstream. Empty result
+      // (unknown match, non-public, or un-hydratable) falls through to the
+      // upstream search unchanged.
+      const local = await searchLocalEvents(q, 60);
+      if (local.length > 0) {
+        localSearchHit = true;
+        rawEvents = local;
+      }
+    }
+    if (!localSearchHit && q) {
       // Text search: the API's search backend returns good results in one call.
       // 15s cap — search is interactive; no point making the user wait the
       // full 60s default if SSI is having a slow moment.
@@ -334,6 +347,7 @@ export async function GET(req: Request) {
   console.log(JSON.stringify({
     route: "events",
     has_query: q.length > 0,
+    local_search: localSearchHit,
     live_mode: liveMode,
     country: country ?? null,
     min_level: minLevel,

--- a/app/api/og/match/[ct]/[id]/route.tsx
+++ b/app/api/og/match/[ct]/[id]/route.tsx
@@ -1,8 +1,8 @@
 import { ImageResponse } from "next/og";
 import { fetchOgMatchData, type OgMatchData } from "@/lib/og-data";
-import { cachedExecuteQuery, gqlCacheKey, MATCH_QUERY } from "@/lib/graphql";
+import { readCachedScorecardsData } from "@/lib/og-read";
+import type { RawScorecardsData } from "@/lib/scorecard-data";
 import { parseRawScorecards } from "@/lib/scorecard-data";
-import { getMatchScorecards, type StageRef } from "@/lib/scorecards-archive";
 import {
   computeGroupRankings,
   computeConsistencyStats,
@@ -197,24 +197,10 @@ async function fetchOgCompareStatsImpl(
     // outer route already warmed it). Then run the per-stage archival fan-out
     // (#410). Caller already gates this whole function on isComplete, so the
     // archive's permanent-cache contract is correct.
-    const matchKey = gqlCacheKey("GetMatch", { ct: ctNum, id });
-    const { data: matchData } = await cachedExecuteQuery<{
-      event: { stages?: { id: string }[] } | null;
-    }>(matchKey, MATCH_QUERY, { ct: ctNum, id }, 30);
-    if (!matchData.event) return null;
-
-    const stageRefs: StageRef[] = (matchData.event.stages ?? []).map((s) => ({
-      ct: 24,
-      id: s.id,
-    }));
-    const { data } = await getMatchScorecards({
-      ct: ctNum,
-      matchId: id,
-      stages: stageRefs,
-      ttlSeconds: null,
-    });
-
-    if (!data.event) return null;
+    // Read-only (#506): the OG path must never fetch upstream or write
+    // permanent cache entries — Redis -> D1 -> null (generic card).
+    const data = await readCachedScorecardsData<RawScorecardsData>(ctNum, id);
+    if (!data?.event) return null;
 
     // Parse full scorecard data using the shared parser (same as compare route)
     const rawScorecards = parseRawScorecards(data);

--- a/lib/db-d1.ts
+++ b/lib/db-d1.ts
@@ -451,6 +451,23 @@ const db: AppDatabase = {
       .run();
   },
 
+  async searchMatches(query, limit = 20) {
+    const capped = Math.min(limit, 100);
+    const q = query.trim();
+    if (!q) return [];
+    const db = readDb();
+    const escaped = q.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+    const result = await db
+      .prepare(
+        `SELECT ct, match_id FROM matches
+         WHERE (name LIKE ? ESCAPE '\\' OR venue LIKE ? ESCAPE '\\')
+         ORDER BY date DESC LIMIT ?`,
+      )
+      .bind(`%${escaped}%`, `%${escaped}%`, capped)
+      .all<{ ct: number; match_id: string }>();
+    return result.results.map((r) => ({ ct: r.ct, matchId: r.match_id }));
+  },
+
   async getMatchesByRefs(matchRefs) {
     if (matchRefs.length === 0) return new Map<string, MatchRecord>();
     const db = readDb();

--- a/lib/db-sqlite.ts
+++ b/lib/db-sqlite.ts
@@ -415,6 +415,20 @@ export function createSqliteDatabase(
         );
     },
 
+    async searchMatches(query, limit = 20) {
+      const capped = Math.min(limit, 100);
+      const q = query.trim();
+      if (!q) return [];
+      const d = getDb();
+      const escaped = q.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+      const rows = d.prepare(
+        `SELECT ct, match_id FROM matches
+         WHERE (name LIKE ? ESCAPE '\\' OR venue LIKE ? ESCAPE '\\')
+         ORDER BY date DESC LIMIT ?`,
+      ).all(`%${escaped}%`, `%${escaped}%`, capped) as Array<{ ct: number; match_id: string }>;
+      return rows.map((r) => ({ ct: r.ct, matchId: r.match_id }));
+    },
+
     async getMatchesByRefs(matchRefs) {
       if (matchRefs.length === 0) return new Map<string, MatchRecord>();
       const d = getDb();

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -146,6 +146,11 @@ export interface AppDatabase {
    */
   getMatchesByRefs(matchRefs: string[]): Promise<Map<string, MatchRecord>>;
 
+  /** Case-insensitive substring search over match name/venue. Returns
+   *  (ct, matchId) refs newest-first — hydration from the match cache and
+   *  visibility filtering happen in lib/local-event-search.ts. */
+  searchMatches(query: string, limit?: number): Promise<Array<{ ct: number; matchId: string }>>;
+
   // ── Shooter suppressions (GDPR) ──────────────────────────────────────
 
   /** Check whether a shooter ID is suppressed (GDPR erasure). */

--- a/lib/local-event-search.ts
+++ b/lib/local-event-search.ts
@@ -1,0 +1,140 @@
+// Server-only — local-first event text search (#505, query-cuts epic #510).
+//
+// Searches the D1/SQLite `matches` domain table by name/venue, then hydrates
+// each hit from the cached GetMatch blob (Redis -> D1, zero upstream). Only
+// hits that hydrate into a COMPLETE, public event are returned; anything
+// missing or non-public is dropped, and an empty result tells the events
+// route to fall through to the upstream GetEvents search unchanged.
+
+import db from "@/lib/db-impl";
+import { gqlCacheKey } from "@/lib/graphql";
+import { getMatchDataWithFallback } from "@/lib/match-data-store";
+import { CACHE_SCHEMA_VERSION } from "@/lib/constants";
+import { classifyVisibility } from "@/lib/visibility";
+
+/** Raw event shape consumed by the events route pipeline (structural subset
+ *  of its RawEvent). All fields required by the mapper are present or the
+ *  hit is dropped. */
+export interface LocalRawEvent {
+  id: string;
+  get_content_type_key: number;
+  name: string;
+  venue: string | null;
+  starts: string;
+  ends: string | null;
+  status: string;
+  region: string;
+  get_full_rule_display: string;
+  get_full_level_display: string;
+  registration_starts: string | null;
+  registration_closes: string | null;
+  squadding_starts: string | null;
+  squadding_closes: string | null;
+  is_registration_possible: boolean;
+  is_squadding_possible: boolean;
+  max_competitors: number | null;
+  registration: string;
+  visibility?: string;
+  get_visibility_display?: string;
+}
+
+interface CachedMatchEvent {
+  name?: string | null;
+  venue?: string | null;
+  starts?: string | null;
+  ends?: string | null;
+  status?: string | null;
+  region?: string | null;
+  level?: number | string | null;
+  get_full_rule_display?: string | null;
+  visibility?: string | null;
+  get_visibility_display?: string | null;
+  registration?: string | null;
+  registration_starts?: string | null;
+  registration_closes?: string | null;
+  squadding_starts?: string | null;
+  squadding_closes?: string | null;
+  is_registration_possible?: boolean | null;
+  is_squadding_possible?: boolean | null;
+  max_competitors?: number | null;
+}
+
+const LEVEL_DISPLAY: Record<string, string> = {
+  "1": "Level I",
+  "2": "Level II",
+  "3": "Level III",
+  "4": "Level IV",
+  "5": "Level V",
+};
+
+/**
+ * Map a cached GetMatch event to the events-route raw shape. Returns null
+ * unless the event is complete AND publicly visible — never serve partial
+ * shapes or surface non-public matches from local search.
+ */
+export function cachedMatchEventToRawEvent(
+  ct: number,
+  matchId: string,
+  ev: CachedMatchEvent,
+): LocalRawEvent | null {
+  if (!ev.name || !ev.starts || !ev.status || !ev.region) return null;
+  if (!ev.visibility || classifyVisibility(ev.visibility) !== "public") return null;
+  const levelDisplay = ev.level != null ? LEVEL_DISPLAY[String(ev.level)] : undefined;
+  if (!levelDisplay || !ev.get_full_rule_display) return null;
+  return {
+    id: matchId,
+    get_content_type_key: ct,
+    name: ev.name,
+    venue: ev.venue ?? null,
+    starts: ev.starts,
+    ends: ev.ends ?? null,
+    status: ev.status,
+    region: ev.region,
+    get_full_rule_display: ev.get_full_rule_display,
+    get_full_level_display: levelDisplay,
+    registration_starts: ev.registration_starts ?? null,
+    registration_closes: ev.registration_closes ?? null,
+    squadding_starts: ev.squadding_starts ?? null,
+    squadding_closes: ev.squadding_closes ?? null,
+    is_registration_possible: ev.is_registration_possible ?? false,
+    is_squadding_possible: ev.is_squadding_possible ?? false,
+    max_competitors: ev.max_competitors ?? null,
+    registration: ev.registration ?? "cl",
+    visibility: ev.visibility,
+    get_visibility_display: ev.get_visibility_display ?? "",
+  };
+}
+
+/** Read + version-gate a cached GetMatch entry (Redis -> D1, no upstream). */
+export async function readCachedMatchEvent(
+  ct: number,
+  matchId: string,
+): Promise<CachedMatchEvent | null> {
+  try {
+    const raw = await getMatchDataWithFallback(gqlCacheKey("GetMatch", { ct, id: matchId }));
+    if (!raw) return null;
+    const entry = JSON.parse(raw) as { data?: { event?: CachedMatchEvent | null }; v?: number };
+    if (entry.v !== CACHE_SCHEMA_VERSION) return null;
+    return entry.data?.event ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Local-first search: name/venue substring over the matches table, hydrated
+ *  from the match cache. Empty array = caller should hit upstream. */
+export async function searchLocalEvents(query: string, limit = 20): Promise<LocalRawEvent[]> {
+  try {
+    const refs = await db.searchMatches(query, limit);
+    if (refs.length === 0) return [];
+    const hydrated = await Promise.all(
+      refs.map(async (r) => {
+        const ev = await readCachedMatchEvent(r.ct, r.matchId);
+        return ev ? cachedMatchEventToRawEvent(r.ct, r.matchId, ev) : null;
+      }),
+    );
+    return hydrated.filter((e): e is LocalRawEvent => e !== null);
+  } catch {
+    return []; // any local trouble -> upstream fallback
+  }
+}

--- a/lib/og-data.ts
+++ b/lib/og-data.ts
@@ -1,7 +1,8 @@
 // Server-only — fetches match/shooter metadata for OG images and page metadata.
 // Uses cached data (GraphQL cache for matches, Redis index for shooters).
 
-import { computeMatchScoringPct, fetchRawMatchData } from "@/lib/match-data";
+import { computeMatchScoringPct, type RawMatchData } from "@/lib/match-data";
+import { readCachedRawMatchData } from "@/lib/og-read";
 import { extractDivision } from "@/lib/divisions";
 import { decodeShooterId } from "@/lib/shooter-index";
 import cache from "@/lib/cache-impl";
@@ -70,9 +71,9 @@ async function fetchOgMatchDataImpl(
   if (isNaN(ctNum)) return null;
 
   try {
-    const { data } = await fetchRawMatchData(ctNum, id);
+    const data = await readCachedRawMatchData<RawMatchData>(ctNum, id);
 
-    if (!data.event) return null;
+    if (!data?.event) return null;
     const ev = data.event;
 
     const competitors: CompetitorInfo[] = (

--- a/lib/og-read.ts
+++ b/lib/og-read.ts
@@ -1,0 +1,37 @@
+// Server-only — read-only match data access for the OG/link-preview path
+// (#506, query-cuts epic #510). Bots and link unfurlers must NEVER trigger
+// upstream GraphQL fetches or cache writes: Redis -> D1 -> null, and a null
+// simply renders the generic OG card. This also removes the old permanent
+// (ttl=null) scorecards write the OG route used to make.
+
+import { gqlCacheKey } from "@/lib/graphql";
+import { getMatchDataWithFallback } from "@/lib/match-data-store";
+import { CACHE_SCHEMA_VERSION } from "@/lib/constants";
+
+async function readEntry<T>(cacheKey: string): Promise<T | null> {
+  try {
+    const raw = await getMatchDataWithFallback(cacheKey);
+    if (!raw) return null;
+    const entry = JSON.parse(raw) as { data?: T; v?: number };
+    if (entry.v !== CACHE_SCHEMA_VERSION || !entry.data) return null;
+    return entry.data;
+  } catch {
+    return null;
+  }
+}
+
+/** Cached GetMatch blob (typed by the caller's raw shape), or null. */
+export async function readCachedRawMatchData<T = { event: unknown }>(
+  ct: number,
+  matchId: string,
+): Promise<T | null> {
+  return readEntry<T>(gqlCacheKey("GetMatch", { ct, id: matchId }));
+}
+
+/** Cached GetMatchScorecards snapshot, or null. */
+export async function readCachedScorecardsData<T = { event: unknown }>(
+  ct: number,
+  matchId: string,
+): Promise<T | null> {
+  return readEntry<T>(gqlCacheKey("GetMatchScorecards", { ct, id: matchId }));
+}

--- a/tests/unit/local-event-search.test.ts
+++ b/tests/unit/local-event-search.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const dbMock = vi.hoisted(() => ({
+  searchMatches: vi.fn<(q: string, limit?: number) => Promise<Array<{ ct: number; matchId: string }>>>(),
+}));
+vi.mock("@/lib/db-impl", () => ({ default: dbMock }));
+
+const storeMock = vi.hoisted(() => ({
+  getMatchDataWithFallback: vi.fn<(key: string) => Promise<string | null>>(),
+}));
+vi.mock("@/lib/match-data-store", () => storeMock);
+
+import {
+  cachedMatchEventToRawEvent,
+  searchLocalEvents,
+} from "@/lib/local-event-search";
+import { CACHE_SCHEMA_VERSION } from "@/lib/constants";
+
+const FULL_EVENT = {
+  name: "SPSK Open 2026",
+  venue: "Sundsvall",
+  starts: "2026-08-01T09:00:00+02:00",
+  ends: "2026-08-02T17:00:00+02:00",
+  status: "cp",
+  region: "SWE",
+  level: 3,
+  get_full_rule_display: "IPSC Handgun",
+  visibility: "pub",
+  get_visibility_display: "Public, searchable",
+  registration: "cl",
+  is_registration_possible: false,
+  is_squadding_possible: false,
+  max_competitors: 200,
+};
+
+function entryFor(event: unknown, v = CACHE_SCHEMA_VERSION) {
+  return JSON.stringify({ data: { event }, cachedAt: "2026-08-10T00:00:00Z", v });
+}
+
+beforeEach(() => {
+  dbMock.searchMatches.mockReset();
+  storeMock.getMatchDataWithFallback.mockReset();
+});
+
+describe("cachedMatchEventToRawEvent", () => {
+  it("maps a complete public event, deriving the level display from the code", () => {
+    const raw = cachedMatchEventToRawEvent(22, "27190", FULL_EVENT);
+    expect(raw).not.toBeNull();
+    expect(raw!.id).toBe("27190");
+    expect(raw!.get_content_type_key).toBe(22);
+    expect(raw!.get_full_level_display).toBe("Level III");
+    expect(raw!.ends).toBe(FULL_EVENT.ends);
+  });
+
+  it("drops non-public matches (never surface club/unlisted from local search)", () => {
+    expect(cachedMatchEventToRawEvent(22, "1", { ...FULL_EVENT, visibility: "clb" })).toBeNull();
+    expect(cachedMatchEventToRawEvent(22, "1", { ...FULL_EVENT, visibility: undefined })).toBeNull();
+  });
+
+  it("drops incomplete events instead of serving partial shapes", () => {
+    expect(cachedMatchEventToRawEvent(22, "1", { ...FULL_EVENT, name: undefined })).toBeNull();
+    expect(cachedMatchEventToRawEvent(22, "1", { ...FULL_EVENT, starts: undefined })).toBeNull();
+    expect(cachedMatchEventToRawEvent(22, "1", { ...FULL_EVENT, level: 9 })).toBeNull();
+  });
+});
+
+describe("searchLocalEvents", () => {
+  it("returns hydrated public hits from the cached blobs", async () => {
+    dbMock.searchMatches.mockResolvedValue([{ ct: 22, matchId: "27190" }]);
+    storeMock.getMatchDataWithFallback.mockResolvedValue(entryFor(FULL_EVENT));
+    const out = await searchLocalEvents("spsk");
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe("SPSK Open 2026");
+  });
+
+  it("drops hits whose blob is missing or version-stale (caller falls through)", async () => {
+    dbMock.searchMatches.mockResolvedValue([
+      { ct: 22, matchId: "1" },
+      { ct: 22, matchId: "2" },
+    ]);
+    storeMock.getMatchDataWithFallback
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(entryFor(FULL_EVENT, CACHE_SCHEMA_VERSION - 1));
+    expect(await searchLocalEvents("x")).toEqual([]);
+  });
+
+  it("returns empty on db errors (upstream fallback, never a user error)", async () => {
+    dbMock.searchMatches.mockRejectedValue(new Error("d1 down"));
+    expect(await searchLocalEvents("x")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements items 3 and 4 of the query-cuts epic #510.

Closes #505, closes #506.

**Local-first event search**: text searches (`q` present) first hit the D1/SQLite `matches` domain table (new `AppDatabase.searchMatches`, LIKE over name/venue, D1 reads on replicas via `readDb()`), then hydrate each hit from the cached GetMatch blob (Redis -> D1 fallback, no upstream). Hits are served only when they hydrate into a complete event AND classify as publicly visible -- otherwise they are dropped and the route falls through to the upstream GetEvents search exactly as before. Coverage therefore = matches with a current-schema cached blob; unknown matches cost the same as today.

**Read-only OG path**: `lib/og-read.ts` gives og-data and the OG image route version-gated Redis->D1 reads with no upstream fetch and no cache writes. A total miss renders the generic OG card. This also fixes the pre-existing tripwire where the OG route passed `ttlSeconds: null` unconditionally and could permanently pin a mid-scoring scorecards snapshot.

1924 tests green (17 new), zero lint/typecheck warnings. No query changes (validate:ssi-queries untouched). No api-v1 contract changes. Prod remains paused; this rides the Monday unpause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkeMxNQuCmXUTG6YCSuBJ