### PR TITLE
docs: add voluntary query cuts to the SSI reply

### DIFF
--- a/docs/ssi-svar-2026-08-15.md
+++ b/docs/ssi-svar-2026-08-15.md
@@ -67,6 +67,24 @@ gar inga anrop alls ut fran nagon instans; anvandarna far cachad data. For
 annu - era per-stage-queries tar normalt 1-2 s och vi vill inte flappa mot
 en frisk server. Om ni vill ha en hard regel dar, sag en siffra.
 
+## Ytterligare atgarder utover era punkter
+
+Vi har ocksa genomfort fyra egna nedskarningar, driftsatta tillsammans med
+ovanstaende:
+
+- **Adaptiv vilofrekvens**: efter 5 tysta probe-cykler i rad glesas proben ut
+  till var 120:e sekund, efter 8 till var 300:e. Varje upptackt andring
+  aterstaller direkt till 60 s. En pagaende match ar inaktiv storre delen av
+  dagen (squadbyten, lunch, natt) - detta tar bort uppskattningsvis 50-80 %
+  av probe-volymen.
+- **24h-cache for historiska sokfonster**: 7-dagarsfonster som ligger helt i
+  det forflutna kan inte fa nya event och cachas nu i 24 timmar i stallet
+  for 1 timme. Upprepad bladdring i historiken kostar er darmed nara noll.
+- **Lokal soktraff forst**: textsokningar slas forst upp i var egen databas;
+  bara okanda matcher gar vidare till ert API.
+- **Lasande OG-lank-forhandsvisningar**: lankdelningar och botar kan inte
+  langre utlosa nagra anrop mot er - de laser enbart var cache.
+
 ## Rakneexempel, fore och efter
 
 Pagaende match, 18 stages, aktivt tittad:
@@ -76,9 +94,9 @@ Pagaende match, 18 stages, aktivt tittad:
   er den 15:e - tva anrop med flera ars datumintervall blev 156 parallella
   GetEvents pa 10 sekunder; nu ar intervallet hart begransat och
   fan-outen max 2 samtidiga).
-- Efter: 1 liten probe per minut + scorecard-hamtning enbart for stages dar
-  nagot hant, max 2 samtidiga anrop totalt, delad backoff om ni svarar
-  429/5xx.
+- Efter: 1 liten probe per minut under aktiv skjutning (var 2-5:e minut vid
+  inaktivitet) + scorecard-hamtning enbart for stages dar nagot hant, max 2
+  samtidiga anrop totalt, delad backoff om ni svarar 429/5xx.
 
 ## Tva fragor infor att vi slar pa updated_after
 


### PR DESCRIPTION
Adds a section covering the four self-initiated cuts (#503-#506, epic #510) to docs/ssi-svar-2026-08-15.md and updates the before/after numbers for the adaptive idle cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkeMxNQuCmXUTG6YCSuBJ