### PR TITLE
chore(schema): accept SSI snapshot drift (spotter-teams + is_already_logged renames)

### DIFF
--- a/scripts/ssi-schema-snapshot.json
+++ b/scripts/ssi-schema-snapshot.json
@@ -885,17 +885,17 @@
       "args": []
     },
     {
+      "name": "allow_spotter_shooter_teams",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
       "name": "allow_team_self_management",
       "type": "Boolean!",
       "args": []
     },
     {
       "name": "allow_teams",
-      "type": "Boolean!",
-      "args": []
-    },
-    {
-      "name": "allows_spotter_shooter_teams",
       "type": "Boolean!",
       "args": []
     },
@@ -2015,17 +2015,17 @@
       "args": []
     },
     {
+      "name": "allow_spotter_shooter_teams",
+      "type": "Boolean!",
+      "args": []
+    },
+    {
       "name": "allow_team_self_management",
       "type": "Boolean!",
       "args": []
     },
     {
       "name": "allow_teams",
-      "type": "Boolean!",
-      "args": []
-    },
-    {
-      "name": "allows_spotter_shooter_teams",
       "type": "Boolean!",
       "args": []
     },
@@ -4665,7 +4665,7 @@
       "args": []
     },
     {
-      "name": "is_alread_logged",
+      "name": "is_already_logged",
       "type": "Boolean!",
       "args": []
     },


### PR DESCRIPTION
## Summary
The weekly `Check SSI Schema Drift` run failed on 2026-08-17 (and this is a distinct drift from last week's #483). SSI renamed three fields upstream, apparently continuing a typo-cleanup wave:

- `allows_spotter_shooter_teams` -> `allow_spotter_shooter_teams` on `EventInterface` and `IpscMatchNode`
- `is_alread_logged` -> `is_already_logged` on `IpscCompetitorNode`

None of these fields are referenced by any query, type, or parser in this repo -- they only exist in `scripts/ssi-schema-snapshot.json`. No `CACHE_SCHEMA_VERSION` bump needed (no cached response shape changed; `SCORECARD_NODE_FIELDS` untouched).

## Verification
- `pnpm check:ssi-schema` -- no drift after accepting the snapshot
- `pnpm validate:ssi-queries` -- OK, 6 queries valid against snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)