### PR TITLE
Re-queue failed telemetry batches instead of dropping them

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -33,10 +33,23 @@ that the MCP toolset reaches must add `maybeTagAsMcp(req)` to keep this property
 ## Sinks (registered automatically per deploy target)
 
 - `console.info` -- always on. Picked up by Cloudflare Workers Logs and Docker stdout.
-- R2 NDJSON -- Cloudflare only, when the `TELEMETRY` binding is present (see `lib/telemetry-sinks-cf.ts`).
-  Per-isolate batching, flushed via `ctx.waitUntil()` to one object per request burst at
-  `cache-telemetry/YYYY-MM-DD/HHmmss-NNNN.ndjson`. Lifecycle rule on the bucket auto-deletes
-  after 30 days. Sampling controlled by `TELEMETRY_SAMPLE`.
+- R2 Parquet via Pipelines -- Cloudflare only, when the `TELEMETRY_PIPELINE` binding is present
+  (see `lib/telemetry-sinks-cf.ts`). Per-isolate batching, flushed via `ctx.waitUntil()`. The
+  Pipelines stream coalesces across isolates and writes one Parquet batch every 300s (or 5MB) to
+  `pipelines/cache-telemetry/YYYY-MM-DD/{uuid}.parquet`. Lifecycle rule on the bucket auto-deletes
+  after 30 days. Sampling controlled per domain by `TELEMETRY_SAMPLE_<DOMAIN>`.
+
+  Two things to know when reading this data:
+  - **The stream has no schema**, so each record is wrapped as `{value: <event json>}` -- and the
+    reader sees that wrapper twice. Extract fields with `value->>'$.value.<key>'`.
+  - **Batches land up to ~5 minutes late**, and in practice a query run immediately after
+    generating traffic can miss ~25 minutes of it. Use a wide `--since` when verifying something
+    you just did, or you will conclude the pipeline is broken when it is merely behind.
+
+  A failed `send()` re-queues its batch for the next flush rather than dropping it (#524): the
+  binding belongs to the request context that produced it, and background work can be executing
+  under a different one, which Workers rejects. Dropping would bias upstream counts downward --
+  the wrong direction for numbers we report to SSI.
 
 ## Adding a new domain
 

--- a/lib/telemetry-sinks-cf.ts
+++ b/lib/telemetry-sinks-cf.ts
@@ -28,6 +28,23 @@
 // buffer. The flush sends the whole buffer in one .send() call so a
 // burst becomes a single ingest call to the Pipelines stream.
 //
+// ── Why the flush re-queues on failure (#524) ────────────────────────
+// The binding is an I/O object owned by the request whose context
+// produced it. Background work (SWR refreshes via afterResponse, and
+// especially promises that missed ctx.waitUntil and run orphaned) can
+// emit telemetry while a *different* request is the active context, and
+// Workers then rejects the send with "Cannot perform I/O on behalf of a
+// different request". Measured against prod 2026-08-20: ~2 failures per
+// 42 events during a concurrent burst, each silently dropping the whole
+// batch.
+//
+// Two mitigations, both here: resolve the binding inside the flush (so
+// it comes from the context actually executing the send, not the one
+// that scheduled it), and put events BACK in the buffer when a send
+// fails so the next flush retries them. Losing telemetry biases our
+// upstream numbers downward, which is the wrong direction when those
+// numbers are what we report to SSI.
+//
 // ── Sampling ─────────────────────────────────────────────────────────
 // Per-domain sample rate, controlled by env vars TELEMETRY_SAMPLE_<DOMAIN>
 // (a number between 0 and 1, e.g. 0.1 = keep 10%). Defaults below favour
@@ -79,19 +96,32 @@ function getDomainRate(domain: string): number {
   return DEFAULT_RATES[domain] ?? FALLBACK_RATE;
 }
 
+/** Cap on the per-isolate buffer. Only reached when sends keep failing;
+ *  trims oldest-first so a persistent outage costs the stalest events
+ *  rather than unbounded isolate memory. */
+const MAX_BUFFERED_EVENTS = 500;
+
 const buffer: EnrichedEvent[] = [];
 let flushScheduled = false;
 
 const pipelineSink: TelemetrySink = (ev) => {
   if (!keepEvent(ev)) return;
-  const pipeline = getPipelineBinding();
-  if (!pipeline) return;
+  // Presence check only — the binding used for the send is resolved inside
+  // the flush, from whichever context actually runs it.
+  if (!getPipelineBinding()) return;
 
   buffer.push(ev);
+  trimBuffer();
   if (flushScheduled) return;
   flushScheduled = true;
-  afterResponse(flushBuffer(pipeline));
+  afterResponse(flushBuffer());
 };
+
+function trimBuffer(): void {
+  if (buffer.length > MAX_BUFFERED_EVENTS) {
+    buffer.splice(0, buffer.length - MAX_BUFFERED_EVENTS);
+  }
+}
 
 function getPipelineBinding(): PipelineBinding | null {
   try {
@@ -102,17 +132,34 @@ function getPipelineBinding(): PipelineBinding | null {
   }
 }
 
-async function flushBuffer(pipeline: PipelineBinding): Promise<void> {
+async function flushBuffer(): Promise<void> {
   const events = buffer.splice(0);
   flushScheduled = false;
   if (events.length === 0) return;
+
+  // Resolve here, not at schedule time: the send must use the binding of
+  // the context that is executing it (#524).
+  const pipeline = getPipelineBinding();
+  if (!pipeline) {
+    requeue(events);
+    return;
+  }
+
   const records = events.map((ev) => ({ value: ev }));
   try {
     await pipeline.send(records);
   } catch (err) {
-    // One warning per flush — telemetry must never break the request path.
-    console.warn("[telemetry] Pipelines send failed:", err);
+    // Re-queue rather than drop; the next flush runs in a fresh context.
+    // Telemetry must never break the request path, so this only warns.
+    requeue(events);
+    console.warn(`[telemetry] Pipelines send failed, re-queued ${events.length} event(s):`, err);
   }
+}
+
+/** Put a failed batch back at the front of the buffer for the next flush. */
+function requeue(events: EnrichedEvent[]): void {
+  buffer.unshift(...events);
+  trimBuffer();
 }
 
 function keepEvent(ev: EnrichedEvent): boolean {
@@ -124,5 +171,14 @@ function keepEvent(ev: EnrichedEvent): boolean {
 
 export const extraSinks: TelemetrySink[] = [pipelineSink];
 
-// Test-only — exported for unit tests of the sampler.
-export const _internal = { keepEvent, getDomainRate, DEFAULT_RATES };
+// Test-only — exported for unit tests of the sampler and the flush/re-queue
+// path. `buffer` is the live array; tests must reset it between cases.
+export const _internal = {
+  keepEvent,
+  getDomainRate,
+  DEFAULT_RATES,
+  buffer,
+  flushBuffer,
+  pipelineSink,
+  MAX_BUFFERED_EVENTS,
+};

--- a/tests/unit/telemetry-sinks-cf.test.ts
+++ b/tests/unit/telemetry-sinks-cf.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { EnrichedEvent } from "@/lib/telemetry";
+
+// The Pipelines binding is reached through getCloudflareContext(); the sink
+// resolves it per flush, so the mock env is what each test swaps.
+const sendMock = vi.hoisted(() => vi.fn<(records: unknown[]) => Promise<unknown>>());
+const envMock = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: () => ({ env: envMock.value }),
+}));
+// Run background work inline so a flush completes within the test.
+vi.mock("@/lib/background-impl", () => ({
+  afterResponse: (p: Promise<unknown>) => {
+    void p.catch(() => {});
+  },
+}));
+
+import { _internal } from "@/lib/telemetry-sinks-cf";
+
+const { buffer, flushBuffer, pipelineSink } = _internal;
+
+function event(op: string): EnrichedEvent {
+  return { ts: "2026-08-20T05:00:00.000Z", domain: "upstream", op } as EnrichedEvent;
+}
+
+beforeEach(() => {
+  buffer.length = 0;
+  sendMock.mockReset().mockResolvedValue(undefined);
+  envMock.value = { TELEMETRY_PIPELINE: { send: sendMock } };
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("pipeline sink flush", () => {
+  it("sends buffered events wrapped as {value: event}", async () => {
+    buffer.push(event("a"), event("b"));
+    await flushBuffer();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const records = sendMock.mock.calls[0][0] as Array<{ value: EnrichedEvent }>;
+    expect(records.map((r) => r.value.op)).toEqual(["a", "b"]);
+    expect(buffer).toHaveLength(0);
+  });
+
+  it("is a no-op when nothing is buffered", async () => {
+    await flushBuffer();
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("#524 — events survive a failed send", () => {
+  it("re-queues the batch instead of dropping it", async () => {
+    sendMock.mockRejectedValueOnce(
+      new Error("Cannot perform I/O on behalf of a different request"),
+    );
+    buffer.push(event("a"), event("b"));
+
+    await flushBuffer();
+    // Dropped before the fix; now still pending.
+    expect(buffer.map((e) => e.op)).toEqual(["a", "b"]);
+
+    // Next flush runs in a healthy context and delivers them.
+    await flushBuffer();
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    const records = sendMock.mock.calls[1][0] as Array<{ value: EnrichedEvent }>;
+    expect(records.map((r) => r.value.op)).toEqual(["a", "b"]);
+    expect(buffer).toHaveLength(0);
+  });
+
+  it("re-queued events keep their order ahead of newer ones", async () => {
+    sendMock.mockRejectedValueOnce(new Error("boom"));
+    buffer.push(event("old"));
+    await flushBuffer();
+
+    buffer.push(event("new"));
+    await flushBuffer();
+
+    const records = sendMock.mock.calls[1][0] as Array<{ value: EnrichedEvent }>;
+    expect(records.map((r) => r.value.op)).toEqual(["old", "new"]);
+  });
+
+  it("re-queues when the binding is missing at flush time", async () => {
+    buffer.push(event("a"));
+    envMock.value = {}; // context without the binding
+    await flushBuffer();
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(buffer.map((e) => e.op)).toEqual(["a"]);
+  });
+
+  it("never lets a persistent outage grow the buffer without bound", async () => {
+    sendMock.mockRejectedValue(new Error("still broken"));
+    const total = _internal.MAX_BUFFERED_EVENTS + 50;
+    for (let i = 0; i < total; i++) pipelineSink(event(`e${i}`));
+    // Let every failed send settle and re-queue.
+    await new Promise((r) => setTimeout(r, 0));
+    await flushBuffer();
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Bounded ...
+    expect(buffer.length).toBeLessThanOrEqual(_internal.MAX_BUFFERED_EVENTS);
+    // ... but still retaining events rather than dropping the lot, which is
+    // the whole point: a broken sink must not silently undercount.
+    expect(buffer.length).toBeGreaterThan(0);
+  });
+
+  it("a failed send never throws into the caller", async () => {
+    sendMock.mockRejectedValue(new Error("boom"));
+    buffer.push(event("a"));
+    await expect(flushBuffer()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #524.

Under concurrent load ~5% of telemetry events were lost (2 of 42, measured against prod 2026-08-20 while reproducing the #521 fan-out hang):

```
[telemetry] Pipelines send failed: Error: Cannot perform I/O on behalf of a
different request. (I/O type: SpanParent)
```

## Cause

The Pipelines binding is an I/O object owned by the request context that produced it. `pipelineSink` resolved it at *schedule* time and handed it to a flush that runs later. Background work -- SWR refreshes via `afterResponse`, and especially promises that missed `ctx.waitUntil` and run orphaned -- can emit telemetry while a *different* request is the active context. Workers rejects that send, and the old code logged a warning and discarded the entire batch.

## Fix

- Resolve the binding **inside** the flush, so the send uses the context actually executing it.
- **Re-queue** a failed batch at the front of the buffer for the next flush instead of dropping it. Bounded at 500 events, trimmed oldest-first, so a sustained outage cannot grow isolate memory without limit.

Why it matters beyond tidiness: lost events *undercount* our upstream calls, making our load look lighter than it is. That is the wrong direction for numbers we are about to report to SSI.

## Tests

New `tests/unit/telemetry-sinks-cf.test.ts` (7 cases) covering the failure path directly: re-queue on send failure, re-queue when the binding is missing, ordering of retried events ahead of newer ones, the memory bound under a persistent outage, and that a failed send never throws into the caller. Full suite: 1941 passing.

## Docs

`docs/telemetry.md` still described an NDJSON sink and a `TELEMETRY` binding; it has been Parquet-via-Pipelines for a while. Corrected, and added the two gotchas that actually cost time this week -- the doubly-wrapped `value` column (`value->>'$.value.<key>'`) and the delivery lag that makes a fresh `--since 2h` query look empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012x2vS5oBd7QgkeDhnWBVX8