### PR TITLE
Fix completed-match pin loop forcing an upstream refetch per view

### DIFF
--- a/lib/match-data.ts
+++ b/lib/match-data.ts
@@ -3,7 +3,7 @@
 // in the match page server component.
 
 import { cache } from "react";
-import { cachedExecuteQuery, forceRefreshKey, gqlCacheKey, MATCH_QUERY, refreshCachedMatchQuery } from "@/lib/graphql";
+import { cachedExecuteQuery, forceRefreshKey, gqlCacheKey, MATCH_QUERY, maxProbeSkipAgeSeconds, refreshCachedMatchQuery } from "@/lib/graphql";
 import cacheAdapter from "@/lib/cache-impl";
 import { computeMatchFreshness, computeMatchScoringPct, computeMatchSwrTtl, isMatchComplete } from "@/lib/match-ttl";
 import { extractDivision } from "@/lib/divisions";
@@ -20,6 +20,47 @@ import { visibilityTelemetry } from "@/lib/visibility-telemetry";
 import { computeAccessReason } from "@/lib/access-reason";
 import { accessReasonTelemetry } from "@/lib/access-reason-telemetry";
 import type { MatchResponse, MatchOrganizer, StageInfo, CompetitorInfo, SquadInfo, Visibility } from "@/lib/types";
+
+/**
+ * Days after the match date beyond which cached completion data is pinnable
+ * without a confirming fetch. `isMatchComplete` already applies a hard time
+ * gate, so by this point scoring is final and a stale `scoring_progress` is
+ * not a risk worth one upstream refetch per view.
+ */
+const PIN_SETTLED_DAYS = 7;
+
+/**
+ * Can a cached-but-complete match be pinned as-is?
+ *
+ * Two ways to be sure the cached blob is not ceiling-stale:
+ *  - its last full fetch (`cachedAt`, preserved across probe-skip merges) is
+ *    younger than the probe's max-skip-age ceiling, or
+ *  - the match is old enough that nothing can change any more.
+ */
+export function isPinnableFromCache(
+  cachedAt: string,
+  daysSince: number,
+  ceilingSeconds: number,
+  nowMs: number = Date.now(),
+): boolean {
+  if (daysSince > PIN_SETTLED_DAYS) return true;
+  const ageSeconds = (nowMs - new Date(cachedAt).getTime()) / 1000;
+  return Number.isFinite(ageSeconds) && ageSeconds >= 0 && ageSeconds <= ceilingSeconds;
+}
+
+/**
+ * Let at most one view per match per window arm a confirming refresh, so a
+ * burst of viewers on the same completed match cannot each schedule a full
+ * re-expansion. Fails OPEN (returns true) if the cache is unavailable —
+ * losing the guard is better than never pinning at all.
+ */
+async function claimPinRefresh(ct: number, id: string): Promise<boolean> {
+  try {
+    return await cacheAdapter.setIfAbsent(`pin:refresh:${ct}:${id}`, "1", 300);
+  } catch {
+    return true;
+  }
+}
 
 // `computeMatchScoringPct` lives in lib/match-ttl.ts (alongside the other
 // scoring-state helpers); re-exported here for back-compat with existing
@@ -218,11 +259,24 @@ export async function fetchMatchData(
           // Persist completed match data to D1/SQLite for durable storage
           afterResponse(persistToMatchStore(matchKey, cached));
         }
-      } else {
-        // Completion inferred from CACHED data. With the probe-driven refresh
-        // that data can be up to the max-skip-age ceiling old — pinning it
-        // would freeze a stale scoring_progress permanently. Force one fresh
-        // full fetch; the next request pins from confirmed-fresh data.
+      } else if (isPinnableFromCache(cachedAt, daysSince, maxProbeSkipAgeSeconds())) {
+        // Cached, but demonstrably not ceiling-stale (see helper) — pin it.
+        const cached = await cacheAdapter.get(matchKey);
+        if (cached) {
+          await cacheAdapter.persist(matchKey);
+          afterResponse(persistToMatchStore(matchKey, cached));
+        }
+      } else if (await claimPinRefresh(ctNum, id)) {
+        // Completion inferred from CACHED data that could be up to the
+        // max-skip-age ceiling old; pinning it would freeze a stale
+        // scoring_progress permanently. Force one fresh full fetch — the
+        // next view sees a young `cachedAt` and pins via the branch above.
+        //
+        // Guarded by claimPinRefresh: this used to re-arm on EVERY view,
+        // and because a cache read always reports a `cachedAt` the "next
+        // request pins from fresh data" assumption never held — the branch
+        // re-fired forever. Measured 2026-08-20: 126 forced refreshes and
+        // 95 upstream GetMatch calls from 127 views of 4 completed matches.
         await cacheAdapter.set(forceRefreshKey(ctNum, id), "1", 300);
         afterResponse(
           refreshCachedMatchQuery<RawMatchData>(

--- a/tests/unit/match-pinning.test.ts
+++ b/tests/unit/match-pinning.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { isPinnableFromCache } from "@/lib/match-data";
 import {
   computeMatchTtl,
   computeMatchSwrTtl,
@@ -296,5 +297,49 @@ describe("safety: re-pinning is idempotent", () => {
       expect(pins(98, 4)).toBe(true);
       expect(pins(0, 0, { status: "cs" })).toBe(true);
     }
+  });
+});
+
+// ─── Pin-apply convergence (#526) ────────────────────────────────────────────
+// isMatchComplete decides *whether* a match is done; these cover what the
+// apply branch then does with a CACHED completed match. The original code
+// forced a confirming refetch on every such view and never converged, because
+// a cache read always reports a `cachedAt` — measured against prod
+// 2026-08-20: 126 forced refreshes and 95 upstream GetMatch calls from 127
+// views of 4 completed matches.
+
+describe("pin-apply: cached completed matches must converge", () => {
+  const CEILING = 900;
+  const now = Date.parse("2026-08-20T12:00:00Z");
+  const iso = (secondsAgo: number) => new Date(now - secondsAgo * 1000).toISOString();
+
+  it("pins when the last full fetch is inside the probe ceiling", () => {
+    expect(isPinnableFromCache(iso(60), 1, CEILING, now)).toBe(true);
+    expect(isPinnableFromCache(iso(CEILING - 1), 1, CEILING, now)).toBe(true);
+  });
+
+  it("does NOT pin ceiling-stale data for a recently finished match", () => {
+    // This is the case the confirming refetch exists for: scoring_progress
+    // could still be stale, so pinning would freeze it permanently.
+    expect(isPinnableFromCache(iso(CEILING + 1), 1, CEILING, now)).toBe(false);
+    expect(isPinnableFromCache(iso(6 * 3600), 2, CEILING, now)).toBe(false);
+  });
+
+  it("pins settled matches regardless of cache age", () => {
+    // Past the settle window nothing can change, so an old cachedAt is not a
+    // reason to spend an upstream fetch. This is what stops the loop for the
+    // historical matches that make up most views.
+    expect(isPinnableFromCache(iso(30 * 24 * 3600), 8, CEILING, now)).toBe(true);
+    expect(isPinnableFromCache(iso(365 * 24 * 3600), 200, CEILING, now)).toBe(true);
+  });
+
+  it("holds the 7-day settle boundary", () => {
+    expect(isPinnableFromCache(iso(6 * 3600), 7, CEILING, now)).toBe(false);
+    expect(isPinnableFromCache(iso(6 * 3600), 7.001, CEILING, now)).toBe(true);
+  });
+
+  it("treats an unparseable or future cachedAt as not pinnable", () => {
+    expect(isPinnableFromCache("not-a-date", 1, CEILING, now)).toBe(false);
+    expect(isPinnableFromCache(iso(-60), 1, CEILING, now)).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #526.

## The bug

Every cache-hit view of a completed match set the force-refresh sentinel and scheduled a full `GetMatch` re-expansion. The comment claimed *"the next request pins from confirmed-fresh data"* — but a cache read **always** reports a `cachedAt`, so the `!cachedAt` pin branch was unreachable after a background refresh and the forced path re-fired forever.

Measured against prod `f5863ce` (12 pollers, 4 completed matches, 10 min):

| | |
|---|---|
| match views | 127 |
| `forced-refresh` outcomes | **126** |
| upstream `GetMatch` calls | **95** |

## Why it surfaced only now

The scheduling loop has been there all along, but the Workers runtime was **cancelling** those background refreshes — 27 cancellations in the previous run — so they never reached SSI. Fixing the fan-out hang (#527) let them complete, converting a silent scheduling loop into real upstream load. That is precisely the repeated heavy re-expansion SSI complained about on 2026-08-15, so this blocks the Phase 3 test.

Worth noting the irony: the hang was masking this, and the earlier 11-upstream-call measurement I was pleased about was flattered by requests dying before they could hit SSI.

## Fix

- **Pin directly when the cached blob demonstrably is not ceiling-stale**: either its last full fetch is inside the probe max-skip-age window, or the match is more than `PIN_SETTLED_DAYS` (7) old so nothing can change. This is what makes it converge, and it covers the historical matches that make up most views.
- **Guard the remaining confirming refetch** with a 300s single-claim key, so a burst of viewers on one match cannot each schedule a full re-expansion. Fails open — a cache outage must not prevent pinning altogether.

The confirming refetch still happens where it genuinely matters: a match that finished in the last few days whose cached data could carry stale `scoring_progress`. That was the original reason for this branch and it is preserved.

## Tests

`isPinnableFromCache` is pure (takes `nowMs` and the ceiling as arguments), so the convergence rules are covered without mocking: inside/outside the ceiling, the 7-day settle boundary, settled matches with very old cache entries, and unparseable or future timestamps. 1948 tests passing.

Verification after deploy: re-run the identical load test and expect upstream `GetMatch` to fall from 95 toward the low tens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012x2vS5oBd7QgkeDhnWBVX8