### PR TITLE
Trip the backoff when SSI rejects the API key

### DIFF
--- a/lib/graphql.ts
+++ b/lib/graphql.ts
@@ -230,6 +230,15 @@ async function executeQueryOnce<T>(
       const matchId = typeof variables?.id === "string" ? variables.id : null;
       reportError(`ssi-graphql-error:${operationName}`, new Error(msg), { ct, matchId, varsHash });
     }
+    // Key rejection is not retryable and not transient — every subsequent
+    // call will fail identically until a human changes something. SSI returns
+    // it as HTTP 200 with an errors array, so the 429/5xx branch above never
+    // sees it and the backoff never engaged: on 2026-08-22 (a Saturday, when
+    // SSI's key is disabled by design) we sent ~800 pointless requests, 670 in
+    // one hour. Trip the shared backoff so the whole fleet stops asking.
+    if (isApiKeyRejection(msg)) {
+      await recordUpstreamFailure(null);
+    }
     throw new Error(msg);
   }
 
@@ -266,6 +275,21 @@ async function executeQueryOnce<T>(
 // raw fields (handgun_div, rifle_div, etc.) are also available on the same
 // node — `get_division_display` is preferred and the others are kept only for
 // backward compatibility with entries cached before schema v8.
+/**
+ * Does this GraphQL error mean SSI rejected our `x-api-key` outright?
+ *
+ * Distinct from the JWT-expiry messages, which ARE transient and are handled
+ * by the force-refresh-and-retry path in `executeQuery`. A rejected API key
+ * stays rejected until a human acts, so it should open the backoff gate
+ * rather than be retried per request.
+ *
+ * The common cause is not a revoked key at all: SSI enables our key on
+ * weekdays only, so every weekend it reads as invalid.
+ */
+export function isApiKeyRejection(msg: string): boolean {
+  return /invalid api key/i.test(msg);
+}
+
 export const MATCH_QUERY = `
   query GetMatch($ct: Int!, $id: String!) {
     event(content_type: $ct, id: $id) {

--- a/tests/unit/upstream-backoff.test.ts
+++ b/tests/unit/upstream-backoff.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { isApiKeyRejection } from "@/lib/graphql";
 
 const cacheMock = vi.hoisted(() => ({
   get: vi.fn<(key: string) => Promise<string | null>>(),
@@ -113,5 +114,32 @@ describe("recordUpstreamSuccess (half-open reset)", () => {
     cacheMock.get.mockResolvedValue(null);
     await recordUpstreamSuccess();
     expect(cacheMock.del).not.toHaveBeenCalled();
+  });
+});
+
+// ─── API-key rejection is a circuit-breaker condition (2026-08-22) ──────────
+// SSI enables our key on weekdays only, so on weekends every call comes back
+// as HTTP 200 with an "Invalid API Key!" GraphQL error. That bypasses the
+// 429/5xx branch, so nothing tripped the backoff and prod sent ~800 pointless
+// requests in a day. The predicate below is what now opens the gate.
+
+describe("isApiKeyRejection", () => {
+  it("matches SSI's key-rejection message", () => {
+    expect(isApiKeyRejection("Invalid API Key!")).toBe(true);
+    expect(isApiKeyRejection("2026-08-20..2026-08-27: Invalid API Key!")).toBe(true);
+    expect(isApiKeyRejection("invalid api key")).toBe(true);
+  });
+
+  it("does NOT match the transient JWT messages", () => {
+    // These are retried successfully by executeQuery's force-refresh path;
+    // tripping the shared backoff on them would take the whole fleet down
+    // for a token refresh.
+    expect(isApiKeyRejection("Signature has expired")).toBe(false);
+    expect(isApiKeyRejection("User must be authenticated")).toBe(false);
+  });
+
+  it("does NOT match unrelated upstream errors", () => {
+    expect(isApiKeyRejection("Not allowed to view event")).toBe(false);
+    expect(isApiKeyRejection("Cannot resolve keyword 'ipscscorecard_set'")).toBe(false);
   });
 });


### PR DESCRIPTION
## What happened

SSI enables our API key **on weekdays only** — stated in their 2026-08-18 message ("funkar mån-fre"). Today is Saturday, so every upstream call returns:

```
{"error": "2026-08-20..2026-08-27: Invalid API Key!"}
```

Browse is fully broken for users (each request fans out ~10 date sub-windows, all of which fail, so the route 502s). Cached matches still serve.

## The bug this exposed

SSI returns key rejection as **HTTP 200 with a GraphQL errors array**, so it never reaches the `res.status === 429 || res.status >= 500` branch that arms the shared backoff. Nothing stopped us retrying.

Telemetry for today:

| hour UTC | upstream calls |
|---|---|
| 08 | **670** |
| 12 | 17 |
| 14 | 61 |
| 16 | 56 |

~800 requests, all failing identically, aimed at the partner whose outage we contributed to in August. Every one was avoidable.

## Fix

A rejected key is not transient — it stays rejected until a human or the calendar changes something. It now trips the shared Redis backoff exactly like a 429, so the first couple of failures gate the entire fleet instead of every request paying the same toll.

The transient JWT messages (`Signature has expired`, `User must be authenticated`) are explicitly excluded and tested: those are retried successfully by the force-refresh path in `executeQuery`, and tripping a fleet-wide hold-off on a routine token refresh would be a self-inflicted outage.

## Not addressed here

Two follow-ups worth separate discussion, filed as issues:

- Weekend degradation is user-visible as a 502 on browse. It should fall back to local search results with an explicit "live data unavailable" state.
- **IPSC matches happen at weekends.** A weekday-only key means the app cannot fetch live data precisely when it is used courtside — the product's whole purpose. Worth raising with SSI directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012x2vS5oBd7QgkeDhnWBVX8