### PR TITLE
feat: courtside grid, a minimal full-screen live view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@ Key directories:
 - `lib/db-impl.ts` -- re-exports SQLite adapter by default; CF builds override via webpack/turbopack alias
 - `lib/match-data-store.ts` -- tiered match data read/write helpers: `getMatchDataWithFallback()` (Redis -> D1 -> null), `persistToMatchStore()` (D1 write + Redis 24h drain), `parseMatchCacheKey()`
 - `lib/match-ttl.ts` -- pure `computeMatchTtl()` -- smart TTL tiers for pre/active/complete matches
+- `app/api/live-grid/route.ts` -- courtside grid data; **field-blind by contract** (see `docs/live-grid.md`)
+- `lib/live-grid.ts` -- pure projection from `RawScorecard[]` to the grid's cell map
+- `lib/live-grid-rows.ts` -- pure `resolveGridRows()` -- squad vs tracked row sources
+- `components/live-grid.tsx` -- full-screen live grid (default live view); cell + detail sheet alongside it
 - `lib/mcp-tools.ts` -- shared MCP tool registration (server-only, used by HTTP route + stdio server)
 - `lib/types.ts` -- single source of truth for all TypeScript interfaces
 - `lib/queries.ts` -- TanStack Query v5 hooks used by client components
@@ -236,6 +240,17 @@ Levers and overrides:
   always-refetch as well. Set via `wrangler secret put` for instant prod recovery without
   a code deploy.
 - `POST /api/admin/cache/force-refresh?ct=&id=` -- one-shot full refetch for both keys.
+
+## Courtside Grid -> `docs/live-grid.md`
+
+The default live view: one row per shooter, one column per stage, full-screen and
+mobile-first. **Its data contract is field-blind** -- every rendered value derives from a
+single shooter's own scorecard plus the stage list. No stage-winner HF, field median,
+division distribution, or ranking. That constraint exists so Phase 2 can swap the server
+from "project the cached whole-field snapshot" to "fetch just these shooters" without a
+client change; breaking it silently forecloses the only real upstream-load lever we have.
+`compareEnabled` must stay false while the grid shows (e2e-guarded). Do not add a second
+poll clock. See `docs/live-grid.md`.
 
 ## Telemetry -> `docs/telemetry.md`
 

--- a/app/api/live-grid/route.ts
+++ b/app/api/live-grid/route.ts
@@ -1,0 +1,300 @@
+import { NextResponse } from "next/server";
+import { MAX_LIVE_GRID_ROWS } from "@/lib/constants";
+import { reportError } from "@/lib/error-telemetry";
+import { checkRateLimit } from "@/lib/rate-limit";
+import {
+  cachedExecuteQuery,
+  gqlCacheKey,
+  MATCH_QUERY,
+  refreshCachedMatchQuery,
+} from "@/lib/graphql";
+import { getMatchScorecards } from "@/lib/scorecards-archive";
+import cache from "@/lib/cache-impl";
+import {
+  computeMatchFreshness,
+  computeMatchSwrTtl,
+  isMatchComplete,
+} from "@/lib/match-ttl";
+import { withJitter } from "@/lib/jitter";
+import { persistToMatchStore } from "@/lib/match-data-store";
+import { computeMatchScoringPct } from "@/lib/match-data";
+import { isUpstreamDegraded } from "@/lib/upstream-status";
+import { isSsiUpstreamPaused } from "@/lib/upstream-pause";
+import { afterResponse } from "@/lib/background-impl";
+import { extractDivision } from "@/lib/divisions";
+import { decodeShooterId } from "@/lib/shooter-index";
+import { parseRawScorecards, type RawScorecardsData } from "@/lib/scorecard-data";
+import { buildLiveGridCells } from "@/lib/live-grid";
+import { maybeTagAsMcp } from "@/lib/telemetry-context";
+import type {
+  LiveGridResponse,
+  LiveGridShooter,
+  LiveGridStage,
+} from "@/lib/types";
+
+interface RawCompetitor {
+  id: string;
+  first_name?: string;
+  last_name?: string;
+  number?: string;
+  club?: string | null;
+  get_division_display?: string | null;
+  handgun_div?: string | null;
+  get_handgun_div_display?: string | null;
+  shoots_handgun_major?: boolean | null;
+  shooter?: { id: string } | null;
+}
+
+// Distinct from compare's RawMatchData: the grid needs `squads` (for each
+// shooter's squad label) and none of the stage geometry fields.
+interface RawMatchData {
+  event: {
+    starts?: string | null;
+    status?: string | null;
+    results?: string | null;
+    is_live_scores_accessible?: boolean | null;
+    stages?: {
+      id: string;
+      number: number;
+      name: string;
+      max_points: number;
+      scoring_progress?: { scored?: number | null; total?: number | null } | null;
+    }[];
+    competitors_approved_w_wo_results_not_dnf?: RawCompetitor[];
+    squads?: { id: string; number?: number | null; get_squad_display?: string | null;
+               competitors?: { id: string }[] }[];
+  } | null;
+}
+
+/**
+ * GET /api/live-grid?ct=&id=&competitor_ids=
+ *
+ * Field-blind by contract. Every value returned here comes from one shooter's
+ * own scorecard plus the stage list. Adding a stage-winner HF, field median,
+ * or ranking would break the Phase 2 swap described in
+ * docs/superpowers/specs/2026-08-23-live-grid-design.md -- at which point this
+ * route stops reading the whole-field snapshot and fetches per competitor
+ * instead, with no client change.
+ *
+ * Cache, TTL and stale-while-revalidate handling deliberately mirrors
+ * app/api/compare/route.ts rather than inventing a variant, and introduces no
+ * second poll clock.
+ */
+export async function GET(req: Request) {
+  maybeTagAsMcp(req);
+  const rl = await checkRateLimit(req, {
+    prefix: "live-grid",
+    // Higher than compare's 30: the response is a fraction of the size and
+    // costs no field-wide compute.
+    limit: 60,
+    windowSeconds: 60,
+  });
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": String(rl.retryAfter) } },
+    );
+  }
+
+  const { searchParams } = new URL(req.url);
+  const ct = searchParams.get("ct");
+  const id = searchParams.get("id");
+  const idsParam = searchParams.get("competitor_ids");
+
+  if (!ct || !id || !idsParam) {
+    return NextResponse.json(
+      { error: "Required params: ct, id, competitor_ids" },
+      { status: 400 },
+    );
+  }
+
+  const ctNum = parseInt(ct, 10);
+  if (isNaN(ctNum)) {
+    return NextResponse.json({ error: "Invalid content_type" }, { status: 400 });
+  }
+
+  const competitorIds = idsParam
+    .split(",")
+    .map((s) => parseInt(s.trim(), 10))
+    .filter((n) => !isNaN(n));
+
+  if (competitorIds.length === 0 || competitorIds.length > MAX_LIVE_GRID_ROWS) {
+    return NextResponse.json(
+      { error: `Between 1 and ${MAX_LIVE_GRID_ROWS} competitor_ids required` },
+      { status: 400 },
+    );
+  }
+
+  // ── Match metadata (drives TTL, and supplies stages/competitors/squads) ────
+  const matchKey = gqlCacheKey("GetMatch", { ct: ctNum, id });
+  let matchData: RawMatchData;
+  let matchCachedAt: string | null;
+  try {
+    ({ data: matchData, cachedAt: matchCachedAt } =
+      await cachedExecuteQuery<RawMatchData>(
+        matchKey,
+        MATCH_QUERY,
+        { ct: ctNum, id },
+        30,
+      ));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Upstream error";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+
+  const scoringPct = computeMatchScoringPct(matchData.event);
+  const matchDate = matchData.event?.starts ? new Date(matchData.event.starts) : null;
+  const daysSince = matchDate ? (Date.now() - matchDate.getTime()) / 86_400_000 : 0;
+  const signals = {
+    status: matchData.event?.status ?? null,
+    resultsPublished: matchData.event?.results === "all",
+  };
+  const isComplete = isMatchComplete(scoringPct, daysSince, signals);
+  const dataTtl = computeMatchSwrTtl(
+    scoringPct,
+    daysSince,
+    matchData.event?.starts ?? null,
+    signals,
+  );
+
+  try {
+    if (dataTtl === null) {
+      // Pin only when the completion inputs came from a fresh upstream fetch.
+      if (!matchCachedAt) {
+        const raw = await cache.get(matchKey);
+        if (raw) {
+          await cache.persist(matchKey);
+          afterResponse(persistToMatchStore(matchKey, raw));
+        }
+      }
+    } else if (!matchCachedAt) {
+      await cache.expire(matchKey, dataTtl);
+    }
+  } catch (err) {
+    reportError("live-grid.match-ttl-apply", err, { matchKey });
+  }
+
+  const matchFreshness = computeMatchFreshness(
+    scoringPct,
+    daysSince,
+    matchData.event?.starts ?? null,
+    signals,
+  );
+  if (matchCachedAt && dataTtl != null && matchFreshness != null) {
+    const age = (Date.now() - new Date(matchCachedAt).getTime()) / 1000;
+    if (age > withJitter(matchFreshness)) {
+      afterResponse(
+        refreshCachedMatchQuery<RawMatchData>(
+          matchKey,
+          MATCH_QUERY,
+          { ct: ctNum, id },
+          dataTtl,
+          { ct: ctNum, id },
+        ),
+      );
+    }
+  }
+
+  const stages: LiveGridStage[] = (matchData.event?.stages ?? []).map((s) => ({
+    stage_id: parseInt(s.id, 10),
+    stage_num: s.number,
+    name: s.name,
+    max_points: s.max_points ?? 0,
+  }));
+
+  // competitorId -> squad label, from the already-cached match response.
+  const squadByCompetitor = new Map<number, string>();
+  for (const sq of matchData.event?.squads ?? []) {
+    const label = sq.get_squad_display || (sq.number != null ? String(sq.number) : null);
+    if (!label) continue;
+    for (const c of sq.competitors ?? []) {
+      squadByCompetitor.set(parseInt(c.id, 10), label);
+    }
+  }
+
+  const requested = new Set(competitorIds);
+  const shooters: LiveGridShooter[] = (
+    matchData.event?.competitors_approved_w_wo_results_not_dnf ?? []
+  )
+    .map((c) => ({ raw: c, id: parseInt(c.id, 10) }))
+    .filter(({ id: cid }) => requested.has(cid))
+    .map(({ raw, id: cid }) => ({
+      id: cid,
+      shooterId: decodeShooterId(raw.shooter?.id),
+      name: [raw.first_name, raw.last_name].filter(Boolean).join(" ") || "Unknown",
+      competitor_number: raw.number ?? "",
+      division: extractDivision(raw),
+      squad: squadByCompetitor.get(cid) ?? null,
+    }))
+    // Preserve the caller's row order -- resolveGridRows puts "me" first.
+    .sort((a, b) => competitorIds.indexOf(a.id) - competitorIds.indexOf(b.id));
+
+  const cacheInfo: LiveGridResponse["cacheInfo"] = { cachedAt: matchCachedAt };
+  if (isSsiUpstreamPaused()) cacheInfo.upstreamPaused = true;
+
+  // Live match whose organizer has not published scores: SSI returns empty
+  // scorecards, so short-circuit rather than fetching them.
+  if (!isComplete && matchData.event?.is_live_scores_accessible !== true) {
+    return NextResponse.json({
+      match_id: parseInt(id, 10),
+      stages,
+      shooters,
+      cells: Object.fromEntries(competitorIds.map((cid) => [cid, {}])),
+      cacheInfo,
+      scorecardsRestricted: true,
+    } satisfies LiveGridResponse);
+  }
+
+  // ── Scorecards ────────────────────────────────────────────────────────────
+  const stageRefs = (matchData.event?.stages ?? []).map((s) => ({
+    ct: 24,
+    id: s.id,
+  }));
+  let scorecardsData: RawScorecardsData;
+  let scorecardsCachedAt: string | null;
+  try {
+    ({ data: scorecardsData, cachedAt: scorecardsCachedAt } =
+      await getMatchScorecards({
+        ct: ctNum,
+        matchId: id,
+        stages: stageRefs,
+        ttlSeconds: isComplete ? null : dataTtl,
+        freshnessSeconds: isComplete ? null : matchFreshness,
+      }));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Upstream error";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+
+  const rawScorecards = parseRawScorecards(scorecardsData);
+  const cells = buildLiveGridCells(rawScorecards, competitorIds);
+
+  cacheInfo.scorecardsCachedAt = scorecardsCachedAt;
+  let lastScorecardAt: string | null = null;
+  for (const sc of rawScorecards) {
+    if (
+      sc.scorecard_created &&
+      (!lastScorecardAt || sc.scorecard_created > lastScorecardAt)
+    ) {
+      lastScorecardAt = sc.scorecard_created;
+    }
+  }
+  if (lastScorecardAt) cacheInfo.lastScorecardAt = lastScorecardAt;
+  if (cacheInfo.cachedAt && (await isUpstreamDegraded())) {
+    cacheInfo.upstreamDegraded = true;
+  }
+
+  // SSI hides per-shot detail on Level I matches: non-zero scoring but an
+  // empty scorecards array.
+  const scorecardsRestricted =
+    scoringPct > 0 && rawScorecards.length === 0 && stages.length > 0;
+
+  return NextResponse.json({
+    match_id: parseInt(id, 10),
+    stages,
+    shooters,
+    cells,
+    cacheInfo,
+    ...(scorecardsRestricted ? { scorecardsRestricted: true } : {}),
+  } satisfies LiveGridResponse);
+}

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -23,7 +23,7 @@ import { UpstreamDegradedBanner } from "@/components/upstream-degraded-banner";
 import { LoadingBar } from "@/components/loading-bar";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Loader2, AlertCircle, ArrowLeft, RefreshCw, ChevronDown, ChevronUp, HelpCircle, ExternalLink, Info, ArrowUpDown, Undo2, XCircle } from "lucide-react";
+import { Loader2, AlertCircle, ArrowLeft, RefreshCw, ChevronDown, ChevronUp, HelpCircle, ExternalLink, Info, ArrowUpDown, Undo2, XCircle, LayoutGrid } from "lucide-react";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import {
   Popover,
@@ -41,12 +41,17 @@ import {
   saveModeOverride,
   getModeOverrideSnapshot,
   subscribeMode,
+  saveLiveViewPreference,
+  getLiveViewPreference,
+  type LiveView,
 } from "@/lib/competition-store";
 import { getMyIdentity, getTrackedShooters } from "@/lib/shooter-identity";
 import { useMyIdentity } from "@/lib/hooks/use-my-identity";
 import { useTrackedShooters } from "@/lib/hooks/use-tracked-shooters";
 import { MAX_COMPETITORS } from "@/lib/constants";
 import { PreMatchView } from "@/components/pre-match-view";
+import { LiveGrid } from "@/components/live-grid";
+import { resolveGridRows, type GridRowSource } from "@/lib/live-grid-rows";
 import { StageTimesExport } from "@/components/stage-times-export";
 import { computeFocusAreas } from "@/lib/coaching-rules";
 
@@ -137,8 +142,25 @@ export default function MatchPageClient() {
   const [showCoachingView, setShowCoachingView] = useState(false);
   const [showSimulator, setShowSimulator] = useState(false);
   const [showManage, setShowManage] = useState(false);
+
   const params = useParams<{ ct: string; id: string }>();
   const { ct, id } = params;
+
+  // Live surface: the courtside grid is the default, with the deep
+  // comparison table one tap away. See
+  // docs/superpowers/specs/2026-08-23-live-grid-design.md.
+  const [liveView, setLiveViewState] = useState<LiveView>("grid");
+  const [gridSource, setGridSource] = useState<GridRowSource>("squad");
+  useEffect(() => {
+    setLiveViewState(getLiveViewPreference(ct, id));
+  }, [ct, id]);
+  const setLiveView = useCallback(
+    (view: LiveView) => {
+      setLiveViewState(view);
+      saveLiveViewPreference(ct, id, view);
+    },
+    [ct, id],
+  );
   const searchParams = useSearchParams();
   const router = useRouter();
 
@@ -288,9 +310,13 @@ export default function MatchPageClient() {
   const liveScoresAccessible =
     matchQuery.data?.is_live_scores_accessible === true;
   const compareMode: CompareMode = effectiveMode === "coaching" ? "coaching" : "live";
+  // The grid is field-blind by design, so while it is showing we must NOT
+  // fire the compare query -- that would pull the whole-field snapshot and
+  // throw away the entire point of the view.
+  const gridShowing = effectiveMode === "live" && liveView === "grid";
   const compareEnabled =
     effectiveMode === "coaching" ||
-    (effectiveMode === "live" && liveScoresAccessible);
+    (effectiveMode === "live" && liveScoresAccessible && !gridShowing);
   const compareQuery = useCompareQuery(
     ct,
     id,
@@ -391,6 +417,24 @@ export default function MatchPageClient() {
   }, [ct, id, matchQuery.data, router]);
 
   // Tracked-in-match indicator: how many tracked/identity shooters are in this match.
+  // Rows for the courtside grid. Squad and tracked both resolve from the
+  // already-cached GetMatch response, so switching source costs nothing
+  // upstream.
+  const gridRows = useMemo(
+    () =>
+      matchQuery.data
+        ? resolveGridRows({
+            source: gridSource,
+            competitors: matchQuery.data.competitors,
+            squads: matchQuery.data.squads,
+            myShooterId: identity?.shooterId ?? null,
+            trackedShooterIds: trackedIds,
+            fallback: selectedIds,
+          })
+        : EMPTY_IDS,
+    [matchQuery.data, gridSource, identity, trackedIds, selectedIds],
+  );
+
   const trackedInMatch = useMemo(() => {
     if (!matchQuery.data) return null;
     const map = new Map(
@@ -962,12 +1006,38 @@ export default function MatchPageClient() {
         </div>
       )}
 
+      {/* Courtside grid — the default live surface. Full-screen, one row per
+          shooter, one column per stage, and field-blind by contract. The deep
+          comparison table stays one tap away via onExit. */}
+      {gridShowing && match.is_live_scores_accessible && gridRows.length > 0 && (
+        <LiveGrid
+          ct={ct}
+          id={id}
+          shooters={gridRows}
+          matchName={match.name}
+          myShooterId={identity?.shooterId ?? null}
+          source={gridSource}
+          onSourceChange={setGridSource}
+          onExit={() => setLiveView("table")}
+        />
+      )}
+
       {/* Comparison views — rendered for completed matches (coaching mode)
           and for live matches whose organizer has enabled live scorecard access. */}
       {(effectiveMode === "coaching" ||
-        (effectiveMode === "live" && match.is_live_scores_accessible)) &&
+        (effectiveMode === "live" && match.is_live_scores_accessible && !gridShowing)) &&
         selectedIds.length > 0 && (
         <div className="space-y-6">
+          {effectiveMode === "live" && match.is_live_scores_accessible && (
+            <button
+              type="button"
+              onClick={() => setLiveView("grid")}
+              className="inline-flex min-h-11 items-center gap-1.5 rounded-md border px-3 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <LayoutGrid className="h-4 w-4" aria-hidden="true" />
+              Back to courtside grid
+            </button>
+          )}
           {effectiveMode === "live" &&
             match.is_live_scores_accessible &&
             match.results_status !== "all" && (

--- a/app/match/[ct]/[id]/match-page-client.tsx
+++ b/app/match/[ct]/[id]/match-page-client.tsx
@@ -314,9 +314,14 @@ export default function MatchPageClient() {
   // fire the compare query -- that would pull the whole-field snapshot and
   // throw away the entire point of the view.
   const gridShowing = effectiveMode === "live" && liveView === "grid";
+  // Gate on matchQuery.data: autoMode falls back to "coaching" until the
+  // match response lands, so without this the page fires a whole-field
+  // compare request on every load -- including live matches showing the
+  // grid, where it is exactly the fetch we are trying not to make.
   const compareEnabled =
-    effectiveMode === "coaching" ||
-    (effectiveMode === "live" && liveScoresAccessible && !gridShowing);
+    Boolean(matchQuery.data) &&
+    (effectiveMode === "coaching" ||
+      (effectiveMode === "live" && liveScoresAccessible && !gridShowing));
   const compareQuery = useCompareQuery(
     ct,
     id,

--- a/components/hit-zone-bar.tsx
+++ b/components/hit-zone-bar.tsx
@@ -21,7 +21,9 @@ interface HitZoneBarProps {
 //
 // Color + pattern pairing — pattern carries the same information as color so the
 // bar remains readable under deuteranopia/protanopia and in grayscale print.
-const BAR_SEGMENTS = [
+// Exported so the live grid's cell-scale bar reuses these exact values
+// rather than re-picking them. Changing a colour here changes it there.
+export const BAR_SEGMENTS = [
   { key: "a" as const, fill: "#22c55e", patternKind: "solid" as const },
   { key: "c" as const, fill: "#facc15", patternKind: "diag-light" as const },
   { key: "d" as const, fill: "#fb923c", patternKind: "diag-dense" as const },
@@ -35,15 +37,15 @@ const BAR_HEIGHT = 12;
 // collapse to "shape × N".
 const PENALTY_PIP_THRESHOLD = 3;
 
-type PenaltyKind = "m" | "ns" | "p";
+export type PenaltyKind = "m" | "ns" | "p";
 
-interface PenaltyDef {
+export interface PenaltyDef {
   key: PenaltyKind;
   label: string; // text used in tooltip / aria
   shape: "square" | "triangle" | "diamond";
 }
 
-const PENALTY_DEFS: PenaltyDef[] = [
+export const PENALTY_DEFS: PenaltyDef[] = [
   { key: "m", label: "M", shape: "square" },
   { key: "ns", label: "NS", shape: "triangle" },
   { key: "p", label: "P", shape: "diamond" },

--- a/components/live-grid-cell.tsx
+++ b/components/live-grid-cell.tsx
@@ -1,0 +1,199 @@
+import { BAR_SEGMENTS, PENALTY_DEFS } from "@/components/hit-zone-bar";
+import type { LiveGridCell } from "@/lib/types";
+
+/**
+ * One cell of the courtside grid -- proposal C, "quiet by default".
+ *
+ * A stage where points were dropped draws the A/C/D bar plus penalty pips.
+ * A clean run draws a single circle and "ALL A" instead: an all-alpha stage
+ * is the best thing that can appear on the page, so it earns a positive mark
+ * rather than an absence. Drawing nothing would make "clean" and "no data"
+ * look identical.
+ *
+ * Circle is load-bearing for WCAG 1.4.1 -- it is the one shape neither the
+ * bar (rectangle) nor the penalty pips (square, triangle, diamond) use, so
+ * the marker separates under greyscale and CVD. The full breakdown is also
+ * in the cell's aria-label, so nothing rests on colour alone.
+ *
+ * See docs/superpowers/specs/2026-08-23-live-grid-design.md.
+ */
+export function LiveGridCellView({ cell }: { cell: LiveGridCell }) {
+  if (cell.status === "pending" || cell.status === "not_fired") {
+    return (
+      <span
+        className="text-muted-foreground text-[13px]"
+        role="img"
+        aria-label="Not shot yet"
+      >
+        &mdash;
+      </span>
+    );
+  }
+
+  if (cell.status === "dq") {
+    return (
+      <>
+        <span className="text-[11px] font-bold tracking-wide text-destructive">
+          DQ
+        </span>
+        <span className="text-[10px] text-muted-foreground">&mdash;</span>
+      </>
+    );
+  }
+
+  const a = cell.a ?? 0;
+  const c = cell.c ?? 0;
+  const d = cell.d ?? 0;
+  const m = cell.m ?? 0;
+  const ns = cell.ns ?? 0;
+  const p = cell.p ?? 0;
+
+  if (cell.status === "zeroed") {
+    return (
+      <>
+        <span className="text-[11px] font-bold tracking-wide text-destructive">
+          ZERO
+        </span>
+        <span className="text-[10px] text-muted-foreground tabular-nums">
+          {cell.time != null ? cell.time.toFixed(2) : "—"}
+        </span>
+        <PenaltyPips m={m} ns={ns} p={p} />
+      </>
+    );
+  }
+
+  const isClean = c + d + m + ns + p === 0;
+  const breakdown =
+    `${a}A ${c}C ${d}D` +
+    (m ? ` ${m}M` : "") +
+    (ns ? ` ${ns}NS` : "") +
+    (p ? ` ${p}P` : "");
+
+  return (
+    <>
+      <span className="text-[15px] font-semibold leading-none tracking-tight tabular-nums">
+        {cell.hf != null ? cell.hf.toFixed(2) : "—"}
+      </span>
+      <span className="text-[10px] text-muted-foreground tabular-nums">
+        {cell.time != null ? cell.time.toFixed(2) : "—"}
+      </span>
+      {isClean ? (
+        <span
+          role="img"
+          aria-label="All alpha, clean stage"
+          className="flex h-[7px] items-center gap-1"
+        >
+          <span
+            aria-hidden="true"
+            className="h-[7px] w-[7px] shrink-0 rounded-full"
+            style={{ background: ZONE_A }}
+          />
+          <span
+            aria-hidden="true"
+            className="text-[8.5px] font-bold uppercase tracking-wider"
+            style={{ color: ZONE_A }}
+          >
+            All A
+          </span>
+        </span>
+      ) : (
+        <>
+          <ZoneBar a={a} c={c} d={d} label={breakdown} />
+          <PenaltyPips m={m} ns={ns} p={p} />
+        </>
+      )}
+    </>
+  );
+}
+
+const ZONE_A = BAR_SEGMENTS[0].fill;
+
+// Cell-scale version of hit-zone-bar's SVG. Same fills, same ordering, same
+// pattern semantics -- but 5px tall and tooltip-free, because a hover
+// tooltip is useless on a phone. Exact counts live in the aria-label and in
+// the detail sheet behind a tap.
+function ZoneBar({
+  a,
+  c,
+  d,
+  label,
+}: {
+  a: number;
+  c: number;
+  d: number;
+  label: string;
+}) {
+  const total = a + c + d;
+  if (total === 0) return null;
+  const counts: Record<string, number> = { a, c, d };
+  return (
+    <span
+      role="img"
+      aria-label={label}
+      className="flex h-[5px] w-full overflow-hidden rounded-[1px]"
+      style={{ background: "var(--border)" }}
+    >
+      {BAR_SEGMENTS.map(({ key, fill, patternKind }) => {
+        const n = counts[key];
+        if (!n) return null;
+        return (
+          <span
+            key={key}
+            className="block h-full"
+            style={{
+              flex: n,
+              background: fill,
+              backgroundImage: HATCH[patternKind],
+            }}
+          />
+        );
+      })}
+    </span>
+  );
+}
+
+// Mirrors hit-zone-bar's solid / diag-light / diag-dense vocabulary.
+const HATCH: Record<string, string | undefined> = {
+  solid: undefined,
+  "diag-light":
+    "repeating-linear-gradient(45deg, oklch(0 0 0 / 34%) 0 1px, transparent 1px 3px)",
+  "diag-dense":
+    "repeating-linear-gradient(45deg, oklch(0 0 0 / 34%) 0 1.5px, transparent 1.5px 3px)",
+};
+
+const PIP_SHAPE: Record<string, string> = {
+  square: "1px",
+  triangle: "polygon(50% 0, 100% 100%, 0 100%)",
+  diamond: "polygon(50% 0, 100% 50%, 50% 100%, 0 50%)",
+};
+
+function PenaltyPips({ m, ns, p }: { m: number; ns: number; p: number }) {
+  const counts: Record<string, number> = { m, ns, p };
+  const visible = PENALTY_DEFS.filter((def) => counts[def.key] > 0);
+  if (visible.length === 0) return null;
+
+  const text = visible
+    .map((def) => `${def.label === "NS" ? "N" : def.label}${counts[def.key]}`)
+    .join(" ");
+
+  return (
+    <span className="flex items-center gap-[3px]">
+      {visible.map((def) => (
+        <span
+          key={def.key}
+          aria-hidden="true"
+          className="h-[7px] w-[7px] shrink-0"
+          style={{
+            background: "var(--destructive)",
+            ...(def.shape === "square"
+              ? { borderRadius: PIP_SHAPE.square }
+              : { clipPath: PIP_SHAPE[def.shape] }),
+          }}
+        />
+      ))}
+      <span className="text-[9px] font-bold tracking-tight text-destructive">
+        {text}
+      </span>
+    </span>
+  );
+}

--- a/components/live-grid-sheet.tsx
+++ b/components/live-grid-sheet.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { X } from "lucide-react";
+import { PENALTY_DEFS } from "@/components/hit-zone-bar";
+import { BAR_SEGMENTS } from "@/components/hit-zone-bar";
+import type {
+  LiveGridCell,
+  LiveGridShooter,
+  LiveGridStage,
+} from "@/lib/types";
+
+// Points a single hit or penalty costs against an all-alpha run.
+//
+// TODO(major-scoring): these are Minor values (A5/C3/D1). Major is A5/C4/D2,
+// which changes charlie from -2 to -1 and delta from -4 to -3. The scorecard
+// response does not currently carry the competitor's power factor into this
+// component, so the section is labelled "minor" rather than silently
+// presenting Minor numbers as universal.
+const COST = { c: 2, d: 4, m: 15, ns: 10, p: 10 } as const;
+
+interface ZoneRow {
+  key: string;
+  label: string;
+  count: number;
+  cost: number;
+  swatch: { fill: string; shape: "bar" | "square" | "triangle" | "diamond" };
+}
+
+export interface LiveGridSheetProps {
+  open: boolean;
+  cell: LiveGridCell;
+  shooter: LiveGridShooter;
+  stage: LiveGridStage;
+  onClose: () => void;
+}
+
+/**
+ * Scorecard detail for one cell.
+ *
+ * Every figure derives from this shooter's own card plus the stage's
+ * max_points. This is where field context would be most tempting to add --
+ * "you were 87% of the stage winner" -- and it must not be, because that
+ * would reintroduce the whole-field dependency the grid exists to avoid.
+ */
+export function LiveGridSheet({
+  open,
+  cell,
+  shooter,
+  stage,
+  onClose,
+}: LiveGridSheetProps) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    closeRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="absolute inset-0 z-20 flex items-end bg-black/45"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Scorecard detail for ${shooter.name}, stage ${stage.stage_num}`}
+        className="flex w-full flex-col gap-3 rounded-t-lg border-t bg-card p-4 pb-[max(1rem,env(safe-area-inset-bottom))] text-card-foreground"
+      >
+        <span
+          aria-hidden="true"
+          className="mx-auto h-1 w-8 rounded-full bg-border"
+        />
+
+        <div className="flex items-start gap-2.5">
+          <div className="min-w-0 flex-1">
+            <b className="block text-[15px] font-semibold tracking-tight">
+              {shooter.name}
+            </b>
+            <span className="text-[11.5px] text-muted-foreground">
+              Stage {stage.stage_num} &middot; {stage.name}
+              {shooter.division ? ` · ${shooter.division}` : ""}
+            </span>
+          </div>
+          <button
+            ref={closeRef}
+            type="button"
+            onClick={onClose}
+            aria-label="Close detail"
+            className="grid h-11 w-11 shrink-0 place-items-center rounded-md border text-muted-foreground"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        <SheetBody cell={cell} stage={stage} />
+      </div>
+    </div>
+  );
+}
+
+function SheetBody({
+  cell,
+  stage,
+}: {
+  cell: LiveGridCell;
+  stage: LiveGridStage;
+}) {
+  if (cell.status === "pending" || cell.status === "not_fired") {
+    return (
+      <p className="text-[13px] text-muted-foreground">
+        Not shot yet.
+      </p>
+    );
+  }
+  if (cell.status === "dq") {
+    return (
+      <p className="text-[13px] font-semibold text-destructive">
+        Disqualified. No score recorded for this stage.
+      </p>
+    );
+  }
+  if (cell.status === "zeroed") {
+    return (
+      <p className="text-[13px] font-semibold text-destructive">
+        Stage zeroed. Time {cell.time?.toFixed(2) ?? "—"}s, but no points count.
+      </p>
+    );
+  }
+
+  const a = cell.a ?? 0;
+  const c = cell.c ?? 0;
+  const d = cell.d ?? 0;
+  const m = cell.m ?? 0;
+  const ns = cell.ns ?? 0;
+  const p = cell.p ?? 0;
+
+  const hitLoss = c * COST.c + d * COST.d + m * 5;
+  const penLoss = (m + ns) * 10 + p * COST.p;
+  const dropped = hitLoss + penLoss;
+  const cleanHf = cell.time ? stage.max_points / cell.time : null;
+  const gain = cleanHf != null && cell.hf != null ? cleanHf - cell.hf : null;
+
+  const rows: ZoneRow[] = ([
+    { key: "a", label: "alpha", count: a, cost: 0,
+      swatch: { fill: BAR_SEGMENTS[0].fill, shape: "bar" as const } },
+    { key: "c", label: "charlie", count: c, cost: COST.c,
+      swatch: { fill: BAR_SEGMENTS[1].fill, shape: "bar" as const } },
+    { key: "d", label: "delta", count: d, cost: COST.d,
+      swatch: { fill: BAR_SEGMENTS[2].fill, shape: "bar" as const } },
+    { key: "m", label: "miss", count: m, cost: COST.m,
+      swatch: { fill: "var(--destructive)", shape: shapeFor("m") } },
+    { key: "ns", label: "no-shoot", count: ns, cost: COST.ns,
+      swatch: { fill: "var(--destructive)", shape: shapeFor("ns") } },
+    { key: "p", label: "procedural", count: p, cost: COST.p,
+      swatch: { fill: "var(--destructive)", shape: shapeFor("p") } },
+  ] satisfies ZoneRow[]).filter((r) => r.count > 0);
+
+  return (
+    <>
+      <div className="grid grid-cols-3 gap-2">
+        <Metric label="Hit factor" value={cell.hf?.toFixed(4) ?? "—"} />
+        <Metric label="Time" value={cell.time?.toFixed(2) ?? "—"} />
+        <Metric
+          label="Points"
+          value={cell.points != null ? String(cell.points) : "—"}
+          suffix={`/${stage.max_points}`}
+        />
+      </div>
+
+      <ul className="divide-y overflow-hidden rounded-md border">
+        {rows.map((r) => (
+          <li key={r.key} className="flex items-center gap-2 px-2.5 py-1.5">
+            <Swatch swatch={r.swatch} />
+            <b className="min-w-[1.4em] font-mono text-[13px] font-semibold tabular-nums">
+              {r.count}
+            </b>
+            <span className="flex-1 text-[12px] text-muted-foreground">
+              {r.label}
+            </span>
+            <span
+              className={
+                r.cost > 0
+                  ? "font-mono text-[12px] font-semibold text-destructive"
+                  : "font-mono text-[12px] text-muted-foreground"
+              }
+            >
+              {r.cost > 0 ? `−${r.cost * r.count}` : "0"}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {dropped > 0 ? (
+        <div className="flex items-center gap-3 rounded-md bg-muted px-3 py-2.5">
+          <div className="min-w-0 flex-1">
+            <b className="block text-[13px] font-semibold">
+              −{dropped} points dropped (minor)
+            </b>
+            <span className="text-[11px] text-muted-foreground">
+              {hitLoss} on target
+              {penLoss ? `, ${penLoss} to penalties` : ""}
+            </span>
+          </div>
+          {cleanHf != null && gain != null && (
+            <div className="flex flex-col items-end">
+              <b className="font-mono text-[17px] font-semibold tracking-tight text-[var(--perf-green)] tabular-nums">
+                {cleanHf.toFixed(2)}
+              </b>
+              <span className="text-[11px] text-muted-foreground">
+                HF if clean (+{gain.toFixed(2)})
+              </span>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="rounded-md bg-muted px-3 py-2.5">
+          <b className="block text-[13px] font-semibold text-[var(--perf-green)]">
+            Clean stage
+          </b>
+          <span className="text-[11px] text-muted-foreground">
+            Every shot an alpha. Nothing left on the table.
+          </span>
+        </div>
+      )}
+
+      <p className="border-t pt-2.5 text-[11px] leading-relaxed text-muted-foreground">
+        Stage max {stage.max_points} points. Every figure here comes from this
+        shooter&rsquo;s own scorecard &mdash; no stage winner, no field median,
+        no ranking.
+      </p>
+    </>
+  );
+}
+
+function shapeFor(key: string): ZoneRow["swatch"]["shape"] {
+  return PENALTY_DEFS.find((d) => d.key === key)?.shape ?? "square";
+}
+
+function Swatch({ swatch }: { swatch: ZoneRow["swatch"] }) {
+  const clip =
+    swatch.shape === "triangle"
+      ? "polygon(50% 0, 100% 100%, 0 100%)"
+      : swatch.shape === "diamond"
+        ? "polygon(50% 0, 100% 50%, 50% 100%, 0 50%)"
+        : undefined;
+  return (
+    <span
+      aria-hidden="true"
+      className="h-2.5 w-2.5 shrink-0 rounded-[1px]"
+      style={{ background: swatch.fill, clipPath: clip }}
+    />
+  );
+}
+
+function Metric({
+  label,
+  value,
+  suffix,
+}: {
+  label: string;
+  value: string;
+  suffix?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-[9.5px] uppercase tracking-wider text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="m-0 font-mono text-[16px] font-semibold tracking-tight tabular-nums">
+        {value}
+        {suffix && (
+          <span className="text-[11px] font-medium text-muted-foreground">
+            {suffix}
+          </span>
+        )}
+      </dd>
+    </div>
+  );
+}

--- a/components/live-grid.tsx
+++ b/components/live-grid.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { BarChart3 } from "lucide-react";
+import { LiveGridCellView } from "@/components/live-grid-cell";
+import { LiveGridSheet } from "@/components/live-grid-sheet";
+import { computeLiveEdgeStageId } from "@/lib/live-grid";
+import type { GridRowSource } from "@/lib/live-grid-rows";
+import { useLiveGridQuery } from "@/lib/queries";
+import { cn } from "@/lib/utils";
+import type { LiveGridCell, LiveGridStage } from "@/lib/types";
+
+const PENDING_CELL: LiveGridCell = {
+  hf: null, time: null, points: null,
+  a: null, c: null, d: null, m: null, ns: null, p: null,
+  status: "pending", created: null,
+};
+
+export interface LiveGridProps {
+  ct: string;
+  id: string;
+  /** Competitor IDs, already resolved by resolveGridRows. */
+  shooters: number[];
+  matchName: string;
+  myShooterId?: number | null;
+  source: GridRowSource;
+  onSourceChange: (source: GridRowSource) => void;
+  /** Switches to the deep comparison table. */
+  onExit: () => void;
+}
+
+/**
+ * The courtside grid: one row per shooter, one column per stage, filling the
+ * viewport. See docs/superpowers/specs/2026-08-23-live-grid-design.md.
+ */
+export function LiveGrid({
+  ct,
+  id,
+  shooters,
+  matchName,
+  myShooterId = null,
+  source,
+  onSourceChange,
+  onExit,
+}: LiveGridProps) {
+  const query = useLiveGridQuery(ct, id, shooters);
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const didAutoScroll = useRef(false);
+  const [openCell, setOpenCell] = useState<{ row: number; stage: number } | null>(
+    null,
+  );
+
+  const data = query.data;
+  const stages = useMemo(() => data?.stages ?? [], [data]);
+  const cells = useMemo(() => data?.cells ?? {}, [data]);
+
+  const liveEdgeStageId = useMemo(
+    () => computeLiveEdgeStageId(cells, stages),
+    [cells, stages],
+  );
+
+  // Lock body scroll while the grid owns the viewport.
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
+  const jumpTo = useCallback(
+    (stageId: number, behavior: ScrollBehavior = "smooth") => {
+      const scroller = scrollerRef.current;
+      if (!scroller) return;
+      const target = scroller.querySelector<HTMLElement>(
+        `[data-stage-col="${stageId}"]`,
+      );
+      const nameCol = scroller.querySelector<HTMLElement>("[data-name-col]");
+      if (!target) return;
+      const offset = nameCol?.getBoundingClientRect().width ?? 0;
+      const left = Math.max(0, target.offsetLeft - offset);
+      // scrollTo is absent in jsdom and in a few older mobile browsers;
+      // assigning scrollLeft works everywhere and just skips the animation.
+      if (typeof scroller.scrollTo === "function") {
+        scroller.scrollTo({ left, behavior });
+      } else {
+        scroller.scrollLeft = left;
+      }
+    },
+    [],
+  );
+
+  // Open scrolled to the stage they just shot -- once, not on every refetch.
+  useEffect(() => {
+    if (didAutoScroll.current || liveEdgeStageId == null) return;
+    didAutoScroll.current = true;
+    jumpTo(liveEdgeStageId, "auto");
+  }, [liveEdgeStageId, jumpTo]);
+
+  const shooterById = useMemo(
+    () => new Map((data?.shooters ?? []).map((s) => [s.id, s])),
+    [data],
+  );
+
+  const stageState = useCallback(
+    (stage: LiveGridStage): "done" | "live" | "todo" => {
+      if (stage.stage_id === liveEdgeStageId) return "live";
+      const rows = data?.shooters ?? [];
+      if (rows.length === 0) return "todo";
+      const allScored = rows.every(
+        (s) => cells[s.id]?.[stage.stage_id]?.created != null,
+      );
+      return allScored ? "done" : "todo";
+    },
+    [cells, data, liveEdgeStageId],
+  );
+
+  const active =
+    openCell != null
+      ? {
+          shooter: shooterById.get(openCell.row),
+          stage: stages.find((s) => s.stage_id === openCell.stage),
+          cell: cells[openCell.row]?.[openCell.stage] ?? PENDING_CELL,
+        }
+      : null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex h-[100dvh] flex-col bg-background">
+      {/* Title bar */}
+      <div className="flex flex-none items-center gap-2.5 border-b bg-card px-3 py-2 pt-[max(0.5rem,env(safe-area-inset-top))]">
+        <span
+          aria-hidden="true"
+          className="h-[7px] w-[7px] shrink-0 rounded-full bg-[var(--perf-green)]"
+        />
+        <span className="flex min-w-0 flex-1 flex-col">
+          <b className="truncate text-[13px] font-semibold tracking-tight">
+            {matchName}
+          </b>
+          <span className="text-[10.5px] text-muted-foreground">
+            {source === "squad" ? "My squad" : "Tracked"} &middot;{" "}
+            {query.isFetching ? "updating…" : `${shooters.length} shooters`}
+          </span>
+        </span>
+        <button
+          type="button"
+          onClick={onExit}
+          className="flex h-11 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-[11.5px] font-medium text-muted-foreground"
+        >
+          <BarChart3 className="h-3.5 w-3.5" aria-hidden="true" />
+          Full analysis
+        </button>
+      </div>
+
+      {/* Row source */}
+      <div className="flex flex-none items-center gap-1.5 bg-card px-3 pb-1 pt-2">
+        {(["squad", "tracked"] as const).map((s) => (
+          <button
+            key={s}
+            type="button"
+            aria-pressed={source === s}
+            onClick={() => onSourceChange(s)}
+            className={cn(
+              "min-h-0 rounded-full border px-3 py-1.5 text-[11.5px] font-medium",
+              source === s
+                ? "border-foreground bg-foreground text-background"
+                : "text-muted-foreground",
+            )}
+          >
+            {s === "squad" ? "My squad" : "Tracked"}
+          </button>
+        ))}
+      </div>
+
+      {/* Stage rail */}
+      <div className="flex flex-none items-center gap-[3px] border-b bg-card px-3 py-1.5">
+        {stages.map((stage) => {
+          const state = stageState(stage);
+          return (
+            <button
+              key={stage.stage_id}
+              type="button"
+              onClick={() => jumpTo(stage.stage_id)}
+              aria-label={`Jump to stage ${stage.stage_num}`}
+              className="grid h-5 flex-1 place-items-center bg-transparent p-0"
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "block w-full rounded-sm",
+                  state === "live"
+                    ? "h-[5px] bg-foreground"
+                    : state === "done"
+                      ? "h-[3px] bg-[var(--perf-green)]"
+                      : "h-[3px] bg-border",
+                )}
+              />
+            </button>
+          );
+        })}
+        <small className="ml-1.5 whitespace-nowrap font-mono text-[9.5px] tracking-wide text-muted-foreground">
+          {stages.filter((s) => stageState(s) === "done").length}/{stages.length}
+        </small>
+      </div>
+
+      {/* Grid */}
+      <div
+        ref={scrollerRef}
+        data-live-grid-scroller
+        className="min-h-0 flex-1 overflow-auto bg-muted [scroll-snap-type:x_proximity] [overscroll-behavior-x:contain]"
+      >
+        <table className="border-separate border-spacing-0 font-mono tabular-nums">
+          <thead>
+            <tr>
+              <th
+                scope="col"
+                data-name-col
+                className="sticky left-0 top-0 z-40 w-[94px] min-w-[94px] border-b border-r bg-card px-2 py-1.5 text-left text-[10px] font-semibold tracking-widest text-muted-foreground"
+              >
+                SHOOTER
+              </th>
+              {stages.map((stage) => (
+                <th
+                  key={stage.stage_id}
+                  scope="col"
+                  className={cn(
+                    "sticky top-0 z-30 border-b border-r bg-card px-1 py-1.5 text-center text-[10px] font-semibold tracking-wide",
+                    stage.stage_id === liveEdgeStageId
+                      ? "text-foreground"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  S{stage.stage_num}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {(data?.shooters ?? []).map((shooter) => (
+              <tr key={shooter.id}>
+                <th
+                  scope="row"
+                  data-name-col
+                  className="sticky left-0 z-20 w-[94px] min-w-[94px] border-b border-r bg-card px-2 py-1.5 text-left shadow-[3px_0_6px_-4px_rgba(0,0,0,0.28)]"
+                >
+                  <span className="block truncate font-sans text-[11.5px] font-semibold tracking-tight text-foreground">
+                    {shortName(shooter.name)}
+                    {shooter.shooterId != null &&
+                      shooter.shooterId === myShooterId && (
+                        <span className="ml-1.5 inline-flex items-center rounded-sm bg-primary/10 px-1 py-px align-middle font-sans text-[8.5px] font-medium uppercase tracking-wide text-primary">
+                          You
+                        </span>
+                      )}
+                  </span>
+                  <span className="block text-[9.5px] tracking-wide text-muted-foreground">
+                    {shooter.division ?? "—"} &middot; {shooter.competitor_number}
+                  </span>
+                </th>
+                {stages.map((stage) => {
+                  const cell =
+                    cells[shooter.id]?.[stage.stage_id] ?? PENDING_CELL;
+                  return (
+                    <td
+                      key={stage.stage_id}
+                      data-stage-col={stage.stage_id}
+                      className="border-b border-r bg-card p-0 [scroll-snap-align:start]"
+                    >
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setOpenCell({ row: shooter.id, stage: stage.stage_id })
+                        }
+                        aria-label={`${shooter.name}, stage ${stage.stage_num}`}
+                        className="flex min-h-11 w-full min-w-[74px] flex-col gap-0.5 bg-transparent px-1.5 py-1.5 text-left font-mono tabular-nums"
+                      >
+                        <LiveGridCellView cell={cell} />
+                      </button>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {active?.shooter && active.stage && (
+        <LiveGridSheet
+          open
+          cell={active.cell}
+          shooter={active.shooter}
+          stage={active.stage}
+          onClose={() => setOpenCell(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+// "Mathias Axell" -> "Mathias A." so a 94px column holds a real name.
+function shortName(full: string): string {
+  const parts = full.trim().split(/\s+/);
+  if (parts.length < 2) return full;
+  return `${parts[0]} ${parts[parts.length - 1].charAt(0)}.`;
+}

--- a/docs/live-grid.md
+++ b/docs/live-grid.md
@@ -1,0 +1,117 @@
+# Courtside Grid -- the live view
+
+One row per shooter, one column per stage, full-screen on a phone. The default
+surface for `effectiveMode === "live"`. The comparison table and coaching
+analysis stay one tap away behind "Full analysis".
+
+Design doc: `docs/superpowers/specs/2026-08-23-live-grid-design.md`.
+
+## The contract (read this before changing anything)
+
+**Every field the grid renders is derivable from a single shooter's own
+scorecard, plus the stage list.**
+
+No `group_leader_hf`. No `overall_leader_hf`. No `field_median_hf`. No
+`divisionDistributions`. No rankings, archetypes, or fingerprints.
+
+This is not minimalism for its own sake. Today `/api/live-grid` projects the
+already-cached whole-field snapshot, so the constraint costs nothing. Its
+purpose is Phase 2: SSI exposes a per-competitor scorecard path, and the
+moment the grid needs one competitor's data to render another's cell, that
+swap stops being a server-only change.
+
+If you are about to add "you were 87% of the stage winner" to the detail
+sheet -- that is the field dependency. Put it in the comparison table instead.
+
+## Files
+
+| File | Responsibility |
+|---|---|
+| `lib/live-grid.ts` | `buildLiveGridCells()`, `computeLiveEdgeStageId()` -- pure projection |
+| `lib/live-grid-rows.ts` | `resolveGridRows()` -- squad vs tracked row sources |
+| `app/api/live-grid/route.ts` | Cache reads, then projection. Imports nothing from `compare/logic` |
+| `components/live-grid.tsx` | Full-screen shell, rail, sticky-column table |
+| `components/live-grid-cell.tsx` | The cell -- quiet by default |
+| `components/live-grid-sheet.tsx` | Tap-through scorecard detail |
+
+## Rows
+
+`resolveGridRows()` maps a `GridRowSource` to competitor IDs:
+
+- `"squad"` -- everyone in the squad the user's identity belongs to
+- `"tracked"` -- the user's identity plus starred shooters present in this match
+
+Both resolve from the already-cached `GetMatch` response
+(`squads[].competitorIds`, `competitors[].shooterId`), so switching source
+costs nothing upstream. Falls back to the existing competitor selection when
+the source resolves to nothing. The user's own row is sorted first. Capped at
+`MAX_LIVE_GRID_ROWS` (20), separate from `MAX_COMPETITORS` (12) because a
+squad can exceed 14.
+
+## The cell
+
+Hit factor, time, then the zone story -- but only when there is one.
+
+- **Points dropped** -- A/C/D proportional bar reusing `BAR_SEGMENTS` from
+  `hit-zone-bar.tsx`, plus M/NS/P shape pips with counts.
+- **Clean run** -- a green circle and `ALL A`. The circle is the one shape
+  neither the bar (rectangle) nor the pips (square, triangle, diamond) use,
+  so it separates under greyscale and CVD without relying on colour. Exact
+  counts also ride in the cell's `aria-label`.
+- **Not scored** -- `DQ`, `ZERO`, or an em dash.
+
+An all-alpha run is the best thing that can appear on the page, so it gets a
+positive mark. Drawing nothing would make "clean" and "no data" identical.
+
+`ns` maps from SSI's `penalty` field (`lib/scorecard-data.ts`). `c` already
+folds B-zone into C.
+
+### Known gap: Major scoring
+
+The detail sheet's points-dropped arithmetic assumes **Minor** (A5/C3/D1) and
+is labelled `(minor)` for that reason. Major is A5/C4/D2. See
+`TODO(major-scoring)` in `components/live-grid-sheet.tsx`.
+
+## Refresh
+
+`useLiveGridQuery` reuses the same 30s cadence the live comparison already
+runs at. **Do not add a second poll clock.** The server's freshness window
+(`computeMatchFreshness`) is what bounds upstream traffic; a second cadence on
+the same match raises refresh frequency, which is the opposite of why this
+view exists.
+
+While the grid is showing, `compareEnabled` is false in
+`match-page-client.tsx`. If compare fires alongside the grid it pulls the
+whole-field snapshot anyway and the saving is gone. There is an e2e assertion
+guarding this (`tests/e2e/live-grid.spec.ts`).
+
+## Phase 2 -- per-competitor fetching (not yet built)
+
+SSI exposes, and we have never used:
+
+```
+RootQuery.competitor_scorecards(content_type, id, updated_after) -> [ScoreCardInterface!]!
+RootQuery.competitor_scorecards_count(content_type, id) -> Int!
+IpscCompetitorNode.scorecards(updated_after) / .scorecards_count / .latest_scorecard_update
+```
+
+Behind `LIVE_GRID_PER_COMPETITOR=on`, watermarked by
+`latest_scorecard_update` like the existing stage sidecar, cached per
+competitor (`sc:comp:{ct}:{compId}`) so overlapping squad-watchers share keys.
+
+**Gated on `scripts/spike-competitor-scorecards.ts`,** which has not run --
+SSI's API key is enabled on weekdays only. Three questions, in priority order:
+
+1. Does GraphQL **alias-batching** of N competitors in one request work? This
+   is the load question. 14 competitor requests is *worse* than 12 stage
+   requests on request count, and request count is what caused the
+   2026-08-15 outage. Payload shrinks either way; request count does not.
+2. Does the root `competitor_scorecards` resolver work at all? The sibling
+   root `competitor(content_type, id)` returns 404 in practice
+   (`lib/graphql.ts`).
+3. Does it respect `is_live_scores_accessible`?
+
+**Phase 1 delivers no upstream reduction.** It delivers the view, the
+contract, and courtside testing. Measure Phase 2 the way the 2026-08-20 run
+was measured (234 client requests -> 25 upstream calls) rather than asserting
+the improvement.

--- a/docs/superpowers/plans/2026-08-23-live-grid-phase-1.md
+++ b/docs/superpowers/plans/2026-08-23-live-grid-phase-1.md
@@ -1,0 +1,1060 @@
+# Courtside Grid (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a full-screen, one-row-per-shooter, one-column-per-stage live view that becomes the default for `effectiveMode === "live"`, backed by an endpoint whose every field derives from a single shooter's own scorecard.
+
+**Architecture:** A pure projection function turns the already-cached `RawScorecard[]` into a narrow `LiveGridResponse`. A thin route wires cache reads to that function. Client components render a sticky-column grid with snap-scrolling stage columns and a tap-through detail sheet. Nothing computes across the field, which is what lets Phase 2 swap the data source server-side without touching the client.
+
+**Tech Stack:** Next.js 16 Route Handlers, TanStack Query v5, Tailwind v4, shadcn/ui, Vitest + React Testing Library, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-live-grid-design.md`
+
+## Global Constraints
+
+- `pnpm -w run lint`, `pnpm -w run typecheck`, `pnpm -w test` must all produce **zero** errors and zero warnings before any commit.
+- Mobile-first. Design at **390px**. No horizontal page overflow at any width. Minimum **44x44px** touch targets.
+- **Zero new design tokens.** Use `--background`, `--card`, `--foreground`, `--muted-foreground`, `--border`, `--primary`, `--destructive`, `--perf-red`, `--perf-amber`, `--perf-green`, and the four zone literals already in `components/hit-zone-bar.tsx`.
+- CSS variables are complete OKLCH values. Use `var(--token)` directly in inline styles. **Never** `hsl(var(--token))`.
+- All interfaces live in `lib/types.ts`. No inline types in components.
+- WCAG 2.1 AA. Colour is never the sole carrier of information (SC 1.4.1).
+- `lib/graphql.ts` is server-only. Never import it from a client component.
+- **Do not bump `CACHE_SCHEMA_VERSION`.** Phase 1 reads the existing cached shape and adds no fields to it.
+- **Do not introduce a second poll clock.** Reuse `computeMatchFreshness`.
+- `ns` maps from SSI's `penalty` field. `c_hits` already combines B-zone and C-zone (`lib/scorecard-data.ts:92`).
+
+---
+
+### Task 1: Types and the pure projection
+
+**Files:**
+- Modify: `lib/types.ts` (append near the other response interfaces)
+- Create: `lib/live-grid.ts`
+- Test: `tests/unit/live-grid.test.ts`
+
+**Interfaces:**
+- Consumes: `RawScorecard` from `@/app/api/compare/logic`, `CompetitorInfo` and `CacheInfo` from `@/lib/types`.
+- Produces: `LiveGridCell`, `LiveGridStage`, `LiveGridShooter`, `LiveGridResponse` (all exported from `lib/types.ts`); `buildLiveGridCells(scorecards: RawScorecard[], competitorIds: number[]): Record<number, Record<number, LiveGridCell>>` and `computeLiveEdgeStageId(cells, stages): number | null` (both exported from `lib/live-grid.ts`).
+
+- [ ] **Step 1: Add the types to `lib/types.ts`**
+
+```ts
+/** One shooter's result on one stage. Every field derives from that
+ *  shooter's own scorecard -- no field-wide context. See
+ *  docs/superpowers/specs/2026-08-23-live-grid-design.md. */
+export interface LiveGridCell {
+  hf: number | null;
+  time: number | null;
+  points: number | null;
+  a: number | null;
+  /** B-zone is already folded into C by parseRawScorecards. */
+  c: number | null;
+  d: number | null;
+  m: number | null;
+  /** From SSI's `penalty` field. */
+  ns: number | null;
+  p: number | null;
+  status: "scored" | "dq" | "zeroed" | "not_fired" | "incomplete" | "pending";
+  /** Scorecard creation timestamp; drives live-edge detection. */
+  created: string | null;
+}
+
+export interface LiveGridStage {
+  stage_id: number;
+  stage_num: number;
+  name: string;
+  max_points: number;
+}
+
+export interface LiveGridShooter {
+  id: number;
+  shooterId: number | null;
+  name: string;
+  competitor_number: string;
+  division: string | null;
+  squad: string | null;
+}
+
+export interface LiveGridResponse {
+  match_id: number;
+  stages: LiveGridStage[];
+  shooters: LiveGridShooter[];
+  /** cells[competitorId][stageId] */
+  cells: Record<number, Record<number, LiveGridCell>>;
+  cacheInfo: CacheInfo;
+  scorecardsRestricted?: boolean;
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+```ts
+// tests/unit/live-grid.test.ts
+import { describe, expect, it } from "vitest";
+import { buildLiveGridCells, computeLiveEdgeStageId } from "@/lib/live-grid";
+import type { RawScorecard } from "@/app/api/compare/logic";
+import type { LiveGridStage } from "@/lib/types";
+
+function card(over: Partial<RawScorecard> = {}): RawScorecard {
+  return {
+    competitor_id: 1, competitor_division: "Production",
+    stage_id: 10, stage_number: 1, stage_name: "Cold Start",
+    max_points: 60, points: 55, hit_factor: 5.5, time: 10,
+    dq: false, zeroed: false, dnf: false, incomplete: false,
+    a_hits: 10, c_hits: 2, d_hits: 0,
+    miss_count: 0, no_shoots: 0, procedurals: 0,
+    scorecard_created: "2026-08-23T09:00:00Z",
+    ...over,
+  };
+}
+
+const STAGES: LiveGridStage[] = [
+  { stage_id: 10, stage_num: 1, name: "Cold Start", max_points: 60 },
+  { stage_id: 11, stage_num: 2, name: "Doubles", max_points: 40 },
+];
+
+describe("buildLiveGridCells", () => {
+  it("keys cells by competitor then stage", () => {
+    const cells = buildLiveGridCells([card()], [1]);
+    expect(cells[1][10].hf).toBe(5.5);
+    expect(cells[1][10].status).toBe("scored");
+  });
+
+  it("ignores competitors that were not requested", () => {
+    const cells = buildLiveGridCells([card(), card({ competitor_id: 99 })], [1]);
+    expect(cells[99]).toBeUndefined();
+  });
+
+  it("maps no_shoots to ns and keeps B+C folded in c", () => {
+    const cells = buildLiveGridCells([card({ no_shoots: 2, c_hits: 3 })], [1]);
+    expect(cells[1][10].ns).toBe(2);
+    expect(cells[1][10].c).toBe(3);
+  });
+
+  it("classifies dq, zeroed, not_fired and incomplete ahead of scored", () => {
+    const s = (o: Partial<RawScorecard>) =>
+      buildLiveGridCells([card(o)], [1])[1][10].status;
+    expect(s({ dq: true })).toBe("dq");
+    expect(s({ zeroed: true })).toBe("zeroed");
+    expect(s({ dnf: true })).toBe("not_fired");
+    expect(s({ incomplete: true })).toBe("incomplete");
+  });
+
+  it("prefers dq over every other flag", () => {
+    const cells = buildLiveGridCells([card({ dq: true, zeroed: true, dnf: true })], [1]);
+    expect(cells[1][10].status).toBe("dq");
+  });
+
+  it("returns an empty map for a competitor with no cards", () => {
+    expect(buildLiveGridCells([], [1])).toEqual({ 1: {} });
+  });
+});
+
+describe("computeLiveEdgeStageId", () => {
+  it("picks the stage holding the newest scorecard", () => {
+    const cells = buildLiveGridCells(
+      [
+        card({ stage_id: 10, scorecard_created: "2026-08-23T09:00:00Z" }),
+        card({ stage_id: 11, stage_number: 2, scorecard_created: "2026-08-23T11:00:00Z" }),
+      ],
+      [1],
+    );
+    expect(computeLiveEdgeStageId(cells, STAGES)).toBe(11);
+  });
+
+  it("returns the first stage when nothing has been scored", () => {
+    expect(computeLiveEdgeStageId({ 1: {} }, STAGES)).toBe(10);
+  });
+
+  it("returns null when there are no stages", () => {
+    expect(computeLiveEdgeStageId({}, [])).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests and verify they fail**
+
+Run: `pnpm -w test -- tests/unit/live-grid.test.ts`
+Expected: FAIL, cannot resolve `@/lib/live-grid`.
+
+- [ ] **Step 4: Implement `lib/live-grid.ts`**
+
+```ts
+import type { RawScorecard } from "@/app/api/compare/logic";
+import type { LiveGridCell, LiveGridStage } from "@/lib/types";
+
+/**
+ * Project raw scorecards into the live grid's cell map.
+ *
+ * Deliberately field-blind: every value comes from the shooter's own card.
+ * Nothing here may consult other competitors -- that invariant is what lets
+ * the Phase 2 per-competitor fetch drop in without a client change.
+ */
+export function buildLiveGridCells(
+  scorecards: RawScorecard[],
+  competitorIds: number[],
+): Record<number, Record<number, LiveGridCell>> {
+  const wanted = new Set(competitorIds);
+  const out: Record<number, Record<number, LiveGridCell>> = {};
+  for (const id of competitorIds) out[id] = {};
+
+  for (const sc of scorecards) {
+    if (!wanted.has(sc.competitor_id)) continue;
+    out[sc.competitor_id][sc.stage_id] = {
+      hf: sc.hit_factor,
+      time: sc.time,
+      points: sc.points,
+      a: sc.a_hits,
+      c: sc.c_hits,
+      d: sc.d_hits,
+      m: sc.miss_count,
+      ns: sc.no_shoots,
+      p: sc.procedurals,
+      status: classify(sc),
+      created: sc.scorecard_created ?? null,
+    };
+  }
+  return out;
+}
+
+// Order matters: a DQ'd card can also carry zeroed/dnf flags, and DQ is the
+// one the shooter needs to see.
+function classify(sc: RawScorecard): LiveGridCell["status"] {
+  if (sc.dq) return "dq";
+  if (sc.zeroed) return "zeroed";
+  if (sc.dnf) return "not_fired";
+  if (sc.incomplete) return "incomplete";
+  return "scored";
+}
+
+/**
+ * The stage the visible shooters most recently produced a scorecard on.
+ * The grid opens scrolled here, because it is the stage they just shot.
+ * Falls back to the first stage so a pre-scoring match still lands somewhere.
+ */
+export function computeLiveEdgeStageId(
+  cells: Record<number, Record<number, LiveGridCell>>,
+  stages: LiveGridStage[],
+): number | null {
+  if (stages.length === 0) return null;
+  let bestStage: number | null = null;
+  let bestAt = "";
+  for (const byStage of Object.values(cells)) {
+    for (const [stageId, cell] of Object.entries(byStage)) {
+      if (!cell.created) continue;
+      if (cell.created > bestAt) {
+        bestAt = cell.created;
+        bestStage = Number(stageId);
+      }
+    }
+  }
+  return bestStage ?? stages[0].stage_id;
+}
+```
+
+- [ ] **Step 5: Run the tests and verify they pass**
+
+Run: `pnpm -w test -- tests/unit/live-grid.test.ts`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 6: Run the full gate**
+
+Run: `pnpm -w run lint && pnpm -w run typecheck && pnpm -w test`
+Expected: zero errors, zero warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/types.ts lib/live-grid.ts tests/unit/live-grid.test.ts
+git commit -m "feat(live-grid): field-blind projection from raw scorecards"
+```
+
+---
+
+### Task 2: The `/api/live-grid` route
+
+**Files:**
+- Create: `app/api/live-grid/route.ts`
+- Test: `tests/unit/live-grid-route.test.ts`
+
+**Interfaces:**
+- Consumes: `buildLiveGridCells` from Task 1; `getMatchScorecards` from `@/lib/scorecards-archive`; `parseRawScorecards` from `@/lib/scorecard-data`; `cachedExecuteQuery`, `gqlCacheKey`, `MATCH_QUERY` from `@/lib/graphql`.
+- Produces: `GET /api/live-grid?ct=&id=&competitor_ids=` returning `LiveGridResponse`.
+
+Read `app/api/compare/route.ts:77-250` first. This route mirrors its cache and freshness handling but stops before `computeGroupRankings`.
+
+- [ ] **Step 1: Add the row cap constant**
+
+In `lib/constants.ts`, below `MAX_COMPETITORS`:
+
+```ts
+/** Live grid rows. Higher than MAX_COMPETITORS because a squad can exceed 14
+ *  and the grid's per-row cost is one scorecard slice, not a field-wide compute. */
+export const MAX_LIVE_GRID_ROWS = 20;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+```ts
+// tests/unit/live-grid-route.test.ts
+import { describe, expect, it } from "vitest";
+import { GET } from "@/app/api/live-grid/route";
+
+async function call(qs: string) {
+  const res = await GET(new Request(`http://localhost/api/live-grid?${qs}`));
+  return { status: res.status, body: await res.json() };
+}
+
+describe("GET /api/live-grid validation", () => {
+  it("400s without ct", async () => {
+    expect((await call("id=1&competitor_ids=1")).status).toBe(400);
+  });
+
+  it("400s without competitor_ids", async () => {
+    expect((await call("ct=22&id=1")).status).toBe(400);
+  });
+
+  it("400s on a non-numeric ct", async () => {
+    expect((await call("ct=abc&id=1&competitor_ids=1")).status).toBe(400);
+  });
+
+  it("400s past MAX_LIVE_GRID_ROWS", async () => {
+    const ids = Array.from({ length: 21 }, (_, i) => i + 1).join(",");
+    expect((await call(`ct=22&id=1&competitor_ids=${ids}`)).status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests and verify they fail**
+
+Run: `pnpm -w test -- tests/unit/live-grid-route.test.ts`
+Expected: FAIL, cannot resolve `@/app/api/live-grid/route`.
+
+- [ ] **Step 4: Implement the route**
+
+Mirror `app/api/compare/route.ts` for the cache/TTL/SWR/short-circuit blocks, then diverge. Required behaviour, in order:
+
+1. `maybeTagAsMcp(req)`, then `checkRateLimit(req, { prefix: "live-grid", limit: 60, windowSeconds: 60 })`. The limit is higher than compare's 30 because the response is far cheaper.
+2. Validate `ct`, `id`, `competitor_ids`. Reject empty or `> MAX_LIVE_GRID_ROWS` with 400.
+3. Fetch match metadata exactly as `compare/route.ts:122-186` does, including the `computeMatchSwrTtl` / `cache.persist` / `refreshCachedMatchQuery` handling. Copy it; do not invent a variant.
+4. If `!isComplete && !matchData.event?.is_live_scores_accessible`, return a `LiveGridResponse` with empty `stages`/`shooters`/`cells` and `scorecardsRestricted: true`.
+5. `getMatchScorecards({ ct, matchId, stages, ttlSeconds, freshnessSeconds })` with the same arguments compare uses.
+6. `parseRawScorecards(scorecardsData)`, then `buildLiveGridCells(raw, competitorIds)`.
+7. Build `stages` from `matchData.event.stages` and `shooters` from `competitors_approved_w_wo_results_not_dnf` filtered to `competitorIds`, resolving `squad` from `matchData.event.squads`.
+8. Set `cacheInfo` with `cachedAt`, `scorecardsCachedAt`, `lastScorecardAt`, plus `upstreamDegraded` / `upstreamPaused` exactly as compare does.
+
+**Do not call** `computeGroupRankings`, `computeMatchPointTotals`, `computeFieldPPSDistribution`, or any other function from `app/api/compare/logic.ts` besides the `RawScorecard` type. Add this comment above the handler:
+
+```ts
+// Field-blind by contract. Every value returned here comes from one
+// shooter's own scorecard plus the stage list. Adding a stage-winner HF,
+// field median, or ranking would break the Phase 2 swap described in
+// docs/superpowers/specs/2026-08-23-live-grid-design.md.
+```
+
+- [ ] **Step 5: Run the tests and verify they pass**
+
+Run: `pnpm -w test -- tests/unit/live-grid-route.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 6: Verify no field-wide compute leaked in**
+
+Run: `grep -n "computeGroupRankings\|computeMatchPointTotals\|computeFieldPPS\|divisionDistributions" app/api/live-grid/route.ts`
+Expected: no output.
+
+- [ ] **Step 7: Run the full gate, then commit**
+
+```bash
+pnpm -w run lint && pnpm -w run typecheck && pnpm -w test
+git add app/api/live-grid/route.ts tests/unit/live-grid-route.test.ts lib/constants.ts
+git commit -m "feat(live-grid): add /api/live-grid endpoint"
+```
+
+---
+
+### Task 3: The cell
+
+**Files:**
+- Create: `components/live-grid-cell.tsx`
+- Test: `tests/components/live-grid-cell.test.tsx`
+
+**Interfaces:**
+- Consumes: `LiveGridCell` from `@/lib/types`.
+- Produces: `<LiveGridCellView cell={...} />`, a default export-free named export.
+
+This is proposal C from the spec: the zone bar draws only when points were dropped, and a clean run gets a circle plus `ALL A`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// tests/components/live-grid-cell.test.tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LiveGridCellView } from "@/components/live-grid-cell";
+import type { LiveGridCell } from "@/lib/types";
+
+function cell(over: Partial<LiveGridCell> = {}): LiveGridCell {
+  return {
+    hf: 5.42, time: 16.42, points: 89,
+    a: 16, c: 0, d: 0, m: 0, ns: 0, p: 0,
+    status: "scored", created: "2026-08-23T09:00:00Z",
+    ...over,
+  };
+}
+
+describe("LiveGridCellView", () => {
+  it("shows hit factor and time for a scored run", () => {
+    render(<LiveGridCellView cell={cell()} />);
+    expect(screen.getByText("5.42")).toBeInTheDocument();
+    expect(screen.getByText("16.42")).toBeInTheDocument();
+  });
+
+  it("marks an all-alpha run with an accessible clean label", () => {
+    render(<LiveGridCellView cell={cell()} />);
+    expect(screen.getByLabelText("All alpha, clean stage")).toBeInTheDocument();
+  });
+
+  it("drops the clean marker as soon as a single charlie appears", () => {
+    render(<LiveGridCellView cell={cell({ c: 1 })} />);
+    expect(screen.queryByLabelText("All alpha, clean stage")).not.toBeInTheDocument();
+  });
+
+  it("drops the clean marker for a penalty even with all alphas", () => {
+    render(<LiveGridCellView cell={cell({ ns: 1 })} />);
+    expect(screen.queryByLabelText("All alpha, clean stage")).not.toBeInTheDocument();
+  });
+
+  it("renders DQ instead of a score", () => {
+    render(<LiveGridCellView cell={cell({ status: "dq" })} />);
+    expect(screen.getByText("DQ")).toBeInTheDocument();
+    expect(screen.queryByText("5.42")).not.toBeInTheDocument();
+  });
+
+  it("renders ZERO with the time still visible", () => {
+    render(<LiveGridCellView cell={cell({ status: "zeroed" })} />);
+    expect(screen.getByText("ZERO")).toBeInTheDocument();
+    expect(screen.getByText("16.42")).toBeInTheDocument();
+  });
+
+  it("renders a pending placeholder when the stage is not yet shot", () => {
+    render(<LiveGridCellView cell={cell({ status: "pending", hf: null, time: null })} />);
+    expect(screen.getByLabelText("Not shot yet")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pnpm -w test -- tests/components/live-grid-cell.test.tsx`
+Expected: FAIL, cannot resolve `@/components/live-grid-cell`.
+
+- [ ] **Step 3: Implement the cell**
+
+Rules the implementation must satisfy:
+- `isClean = (c ?? 0) + (d ?? 0) + (m ?? 0) + (ns ?? 0) + (p ?? 0) === 0` and `status === "scored"`.
+- Clean renders a 7px `rounded-full` span in `--zone-a` plus the text `ALL A`, wrapped in `role="img" aria-label="All alpha, clean stage"`. Circle is load-bearing: it is the one shape the zone bar (rectangle) and penalty pips (square, triangle, diamond) do not use, so the marker survives greyscale and CVD.
+- Not clean renders the A/C/D proportional bar with the same pattern fills and the same hex literals as `components/hit-zone-bar.tsx`, plus penalty pips with counts.
+- Hit factor `toFixed(2)`, time `toFixed(2)`, both `tabular-nums` and `font-mono`.
+- `status` of `"pending"` / `"not_fired"` renders an em dash with `aria-label="Not shot yet"`.
+
+Reuse the pattern-fill CSS approach from `hit-zone-bar.tsx` rather than reinventing it.
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `pnpm -w test -- tests/components/live-grid-cell.test.tsx`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Run the full gate, then commit**
+
+```bash
+pnpm -w run lint && pnpm -w run typecheck && pnpm -w test
+git add components/live-grid-cell.tsx tests/components/live-grid-cell.test.tsx
+git commit -m "feat(live-grid): quiet-by-default cell with all-alpha marker"
+```
+
+---
+
+### Task 4: The detail sheet
+
+**Files:**
+- Create: `components/live-grid-sheet.tsx`
+- Test: `tests/components/live-grid-sheet.test.tsx`
+
+**Interfaces:**
+- Consumes: `LiveGridCell`, `LiveGridStage`, `LiveGridShooter` from `@/lib/types`.
+- Produces: `<LiveGridSheet cell shooter stage open onClose />`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// tests/components/live-grid-sheet.test.tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LiveGridSheet } from "@/components/live-grid-sheet";
+import type { LiveGridCell, LiveGridShooter, LiveGridStage } from "@/lib/types";
+
+const SHOOTER: LiveGridShooter = {
+  id: 1, shooterId: 500, name: "Mathias Axell",
+  competitor_number: "118", division: "Production", squad: "4",
+};
+const STAGE: LiveGridStage = {
+  stage_id: 10, stage_num: 4, name: "Steel Alley", max_points: 60,
+};
+function cell(over: Partial<LiveGridCell> = {}): LiveGridCell {
+  return {
+    hf: 5.42, time: 16.42, points: 48,
+    a: 8, c: 2, d: 1, m: 0, ns: 1, p: 0,
+    status: "scored", created: "2026-08-23T09:00:00Z", ...over,
+  };
+}
+
+describe("LiveGridSheet", () => {
+  it("names the shooter and the stage", () => {
+    render(<LiveGridSheet open cell={cell()} shooter={SHOOTER} stage={STAGE} onClose={vi.fn()} />);
+    expect(screen.getByText("Mathias Axell")).toBeInTheDocument();
+    expect(screen.getByText(/Steel Alley/)).toBeInTheDocument();
+  });
+
+  it("shows points against the stage max", () => {
+    render(<LiveGridSheet open cell={cell()} shooter={SHOOTER} stage={STAGE} onClose={vi.fn()} />);
+    expect(screen.getByText("48")).toBeInTheDocument();
+    expect(screen.getByText("/60")).toBeInTheDocument();
+  });
+
+  it("lists no-shoots as their own row", () => {
+    render(<LiveGridSheet open cell={cell()} shooter={SHOOTER} stage={STAGE} onClose={vi.fn()} />);
+    expect(screen.getByText("no-shoot")).toBeInTheDocument();
+  });
+
+  it("omits zero-count zones", () => {
+    render(<LiveGridSheet open cell={cell({ p: 0 })} shooter={SHOOTER} stage={STAGE} onClose={vi.fn()} />);
+    expect(screen.queryByText("procedural")).not.toBeInTheDocument();
+  });
+
+  it("celebrates a clean stage instead of showing a drop", () => {
+    render(
+      <LiveGridSheet open shooter={SHOOTER} stage={STAGE} onClose={vi.fn()}
+        cell={cell({ a: 12, c: 0, d: 0, m: 0, ns: 0, p: 0, points: 60 })} />,
+    );
+    expect(screen.getByText("Clean stage")).toBeInTheDocument();
+  });
+
+  it("is a modal dialog", () => {
+    render(<LiveGridSheet open cell={cell()} shooter={SHOOTER} stage={STAGE} onClose={vi.fn()} />);
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pnpm -w test -- tests/components/live-grid-sheet.test.tsx`
+Expected: FAIL, cannot resolve `@/components/live-grid-sheet`.
+
+- [ ] **Step 3: Implement the sheet**
+
+Content, all derived from `cell` plus `stage.max_points`:
+- Header: shooter name, `Stage {stage_num} - {name} - {division}`, close button.
+- Three metrics: hit factor `toFixed(4)`, time `toFixed(2)`, `points` with a muted `/{max_points}`.
+- Zone rows, omitting any zero count: alpha, charlie (`-2` each), delta (`-4` each), miss (`-15` each), no-shoot (`-10` each), procedural (`-10` each). Each row carries the same shape marker as the cell, so the row is not colour-only.
+- Points-dropped summary: `hitLoss = c*2 + d*4 + m*5`, `penLoss = (m + ns)*10 + p*10`. When the sum is zero, render `Clean stage` instead.
+- `HF if clean` = `stage.max_points / time`.
+- Footer stating the figures come from this shooter's own scorecard.
+
+Use `role="dialog" aria-modal="true"`, and return focus to the invoking cell on close.
+
+Note the scoring constants assume Minor (A5/C3/D1). Add a `TODO(major-scoring)` comment: Major is A5/C4/D2, which changes `hitLoss`. Out of scope for Phase 1, but do not silently present Minor numbers as universal -- label the section `Points dropped (minor)` until Major is handled.
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `pnpm -w test -- tests/components/live-grid-sheet.test.tsx`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Run the full gate, then commit**
+
+```bash
+pnpm -w run lint && pnpm -w run typecheck && pnpm -w test
+git add components/live-grid-sheet.tsx tests/components/live-grid-sheet.test.tsx
+git commit -m "feat(live-grid): scorecard detail sheet"
+```
+
+---
+
+### Task 5a: Resolving which shooters fill the rows
+
+**Files:**
+- Create: `lib/live-grid-rows.ts`
+- Test: `tests/unit/live-grid-rows.test.ts`
+
+**Interfaces:**
+- Consumes: `CompetitorInfo`, `SquadInfo` from `@/lib/types`; `MAX_LIVE_GRID_ROWS` from `@/lib/constants`.
+- Produces: `type GridRowSource = "squad" | "tracked"` and
+  `resolveGridRows(args: { source: GridRowSource; competitors: CompetitorInfo[]; squads: SquadInfo[]; myShooterId: number | null; trackedShooterIds: Set<number>; fallback: number[] }): number[]`.
+
+The spec says rows come from `squads[].competitorIds` or the tracked shooter IDs, both free from the cached `GetMatch`. That resolution is pure and fiddly, so it gets its own tested function rather than living inline in the component.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { resolveGridRows } from "@/lib/live-grid-rows";
+import type { CompetitorInfo, SquadInfo } from "@/lib/types";
+
+const comp = (id: number, shooterId: number | null): CompetitorInfo => ({
+  id, shooterId, name: `C${id}`, competitor_number: String(id),
+  club: null, division: "Production", region: null,
+  region_display: null, category: null, ics_alias: null, license: null,
+});
+const COMPETITORS = [comp(1, 500), comp(2, 501), comp(3, 502), comp(4, null)];
+const SQUADS: SquadInfo[] = [
+  { id: 90, number: 4, display: "Squad 4", competitorIds: [1, 2, 3] } as SquadInfo,
+  { id: 91, number: 5, display: "Squad 5", competitorIds: [4] } as SquadInfo,
+];
+
+describe("resolveGridRows", () => {
+  it("returns my squad-mates when source is squad", () => {
+    expect(
+      resolveGridRows({ source: "squad", competitors: COMPETITORS, squads: SQUADS,
+        myShooterId: 500, trackedShooterIds: new Set(), fallback: [] }),
+    ).toEqual([1, 2, 3]);
+  });
+
+  it("falls back to the existing selection when I am in no squad", () => {
+    expect(
+      resolveGridRows({ source: "squad", competitors: COMPETITORS, squads: SQUADS,
+        myShooterId: 999, trackedShooterIds: new Set(), fallback: [2, 3] }),
+    ).toEqual([2, 3]);
+  });
+
+  it("maps tracked shooter IDs to this match's competitor IDs", () => {
+    expect(
+      resolveGridRows({ source: "tracked", competitors: COMPETITORS, squads: SQUADS,
+        myShooterId: 500, trackedShooterIds: new Set([502]), fallback: [] }),
+    ).toEqual([1, 3]);
+  });
+
+  it("drops tracked shooters who are not in this match", () => {
+    expect(
+      resolveGridRows({ source: "tracked", competitors: COMPETITORS, squads: SQUADS,
+        myShooterId: null, trackedShooterIds: new Set([501, 8888]), fallback: [] }),
+    ).toEqual([2]);
+  });
+
+  it("never exceeds MAX_LIVE_GRID_ROWS", () => {
+    const many = Array.from({ length: 30 }, (_, i) => comp(i + 1, i + 1));
+    const squad = [{ id: 1, number: 1, display: "S1",
+      competitorIds: many.map((c) => c.id) } as SquadInfo];
+    expect(
+      resolveGridRows({ source: "squad", competitors: many, squads: squad,
+        myShooterId: 1, trackedShooterIds: new Set(), fallback: [] }),
+    ).toHaveLength(20);
+  });
+
+  it("puts me first so my row is the one already on screen", () => {
+    const rows = resolveGridRows({ source: "tracked", competitors: COMPETITORS,
+      squads: SQUADS, myShooterId: 502, trackedShooterIds: new Set([500]), fallback: [] });
+    expect(rows[0]).toBe(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pnpm -w test -- tests/unit/live-grid-rows.test.ts`
+Expected: FAIL, cannot resolve `@/lib/live-grid-rows`.
+
+- [ ] **Step 3: Implement `lib/live-grid-rows.ts`**
+
+```ts
+import { MAX_LIVE_GRID_ROWS } from "@/lib/constants";
+import type { CompetitorInfo, SquadInfo } from "@/lib/types";
+
+export type GridRowSource = "squad" | "tracked";
+
+export interface ResolveGridRowsArgs {
+  source: GridRowSource;
+  competitors: CompetitorInfo[];
+  squads: SquadInfo[];
+  myShooterId: number | null;
+  trackedShooterIds: Set<number>;
+  /** The user's existing competitor selection, used when the chosen
+   *  source resolves to nothing (no squad, or nothing tracked here). */
+  fallback: number[];
+}
+
+export function resolveGridRows(args: ResolveGridRowsArgs): number[] {
+  const { source, competitors, squads, myShooterId, trackedShooterIds, fallback } = args;
+
+  const myCompetitorId =
+    myShooterId == null
+      ? null
+      : competitors.find((c) => c.shooterId === myShooterId)?.id ?? null;
+
+  let ids: number[];
+  if (source === "squad") {
+    const squad =
+      myCompetitorId == null
+        ? undefined
+        : squads.find((s) => s.competitorIds.includes(myCompetitorId));
+    ids = squad ? [...squad.competitorIds] : [];
+  } else {
+    const wanted = new Set(trackedShooterIds);
+    if (myShooterId != null) wanted.add(myShooterId);
+    ids = competitors.filter((c) => c.shooterId != null && wanted.has(c.shooterId)).map((c) => c.id);
+  }
+
+  if (ids.length === 0) ids = [...fallback];
+
+  // My own row leads, so it is the one already on screen before any scrolling.
+  if (myCompetitorId != null && ids.includes(myCompetitorId)) {
+    ids = [myCompetitorId, ...ids.filter((id) => id !== myCompetitorId)];
+  }
+  return ids.slice(0, MAX_LIVE_GRID_ROWS);
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `pnpm -w test -- tests/unit/live-grid-rows.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Run the full gate, then commit**
+
+```bash
+pnpm -w run lint && pnpm -w run typecheck && pnpm -w test
+git add lib/live-grid-rows.ts tests/unit/live-grid-rows.test.ts
+git commit -m "feat(live-grid): resolve squad and tracked row sources"
+```
+
+**Before implementing:** confirm the real field names on `SquadInfo` at `lib/types.ts:63-68`. The fixtures above use `id`, `number`, `display`, `competitorIds` with a `as SquadInfo` cast; if the actual shape differs, fix the fixtures rather than casting around it.
+
+---
+
+### Task 5: Data access and the grid shell
+
+**Files:**
+- Modify: `lib/api.ts` (add `fetchLiveGrid`)
+- Modify: `lib/queries.ts` (add `useLiveGridQuery`)
+- Create: `components/live-grid.tsx`
+- Test: `tests/components/live-grid.test.tsx`
+
+**Interfaces:**
+- Consumes: `LiveGridCellView` (Task 3), `LiveGridSheet` (Task 4), `LiveGridResponse` and `computeLiveEdgeStageId` (Task 1), `resolveGridRows` (Task 5a).
+- Produces:
+
+```ts
+interface LiveGridProps {
+  ct: string;
+  id: string;
+  shooters: number[];           // competitor IDs, already resolved
+  matchName: string;
+  myShooterId?: number | null;
+  source: GridRowSource;        // from Task 5a
+  onSourceChange: (s: GridRowSource) => void;
+  onExit: () => void;           // switches to the deep comparison table
+}
+export function LiveGrid(props: LiveGridProps): React.ReactElement;
+```
+
+- [ ] **Step 1: Add `fetchLiveGrid` to `lib/api.ts`**
+
+Follow the shape of the existing `fetchCompare`:
+
+```ts
+export async function fetchLiveGrid(
+  ct: string, id: string, competitorIds: number[],
+): Promise<LiveGridResponse> {
+  const params = new URLSearchParams({ ct, id, competitor_ids: competitorIds.join(",") });
+  const res = await fetch(`/api/live-grid?${params}`);
+  if (!res.ok) throw new Error("Failed to load live grid");
+  return res.json() as Promise<LiveGridResponse>;
+}
+```
+
+- [ ] **Step 2: Add `useLiveGridQuery` to `lib/queries.ts`**
+
+```ts
+export function useLiveGridQuery(ct: string, id: string, competitorIds: number[]) {
+  return useQuery<LiveGridResponse, Error>({
+    queryKey: ["live-grid", ct, id, [...competitorIds].sort((a, b) => a - b)],
+    queryFn: () => fetchLiveGrid(ct, id, competitorIds),
+    // Same 30s cadence the live comparison already uses. Deliberately NOT a
+    // new clock -- the server's freshness window is what actually bounds
+    // upstream traffic, and a second cadence would raise refresh frequency.
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
+    enabled: Boolean(ct && id && competitorIds.length > 0),
+  });
+}
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+```tsx
+// tests/components/live-grid.test.tsx
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LiveGrid } from "@/components/live-grid";
+import type { LiveGridResponse } from "@/lib/types";
+
+vi.mock("@/lib/queries", () => ({
+  useLiveGridQuery: () => ({ data: FIXTURE, isLoading: false, isFetching: false, error: null }),
+}));
+
+const FIXTURE: LiveGridResponse = {
+  match_id: 1,
+  stages: [
+    { stage_id: 10, stage_num: 1, name: "Cold Start", max_points: 60 },
+    { stage_id: 11, stage_num: 2, name: "Doubles", max_points: 40 },
+  ],
+  shooters: [
+    { id: 1, shooterId: 500, name: "Mathias Axell", competitor_number: "118",
+      division: "Production", squad: "4" },
+    { id: 2, shooterId: 501, name: "Jonas Berg", competitor_number: "042",
+      division: "Open", squad: "4" },
+  ],
+  cells: {
+    1: { 10: { hf: 5.42, time: 16.42, points: 55, a: 11, c: 0, d: 0, m: 0, ns: 0, p: 0,
+               status: "scored", created: "2026-08-23T09:00:00Z" } },
+    2: {},
+  },
+  cacheInfo: { cachedAt: null },
+};
+
+describe("LiveGrid", () => {
+  it("renders one row per shooter", () => {
+    render(<LiveGrid ct="22" id="1" shooters={[1, 2]} onExit={vi.fn()} />);
+    expect(screen.getByRole("rowheader", { name: /Mathias/ })).toBeInTheDocument();
+    expect(screen.getByRole("rowheader", { name: /Jonas/ })).toBeInTheDocument();
+  });
+
+  it("renders one column header per stage", () => {
+    render(<LiveGrid ct="22" id="1" shooters={[1, 2]} onExit={vi.fn()} />);
+    expect(screen.getByRole("columnheader", { name: "S1" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "S2" })).toBeInTheDocument();
+  });
+
+  it("gives every stage a labelled rail jump button", () => {
+    render(<LiveGrid ct="22" id="1" shooters={[1, 2]} onExit={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Jump to stage 1" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Jump to stage 2" })).toBeInTheDocument();
+  });
+
+  it("marks the identity shooter with a You badge", () => {
+    render(<LiveGrid ct="22" id="1" shooters={[1, 2]} myShooterId={500} onExit={vi.fn()} />);
+    const row = screen.getByRole("rowheader", { name: /Mathias/ });
+    expect(within(row).getByText(/you/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 4: Run the tests and verify they fail**
+
+Run: `pnpm -w test -- tests/components/live-grid.test.tsx`
+Expected: FAIL, cannot resolve `@/components/live-grid`.
+
+- [ ] **Step 5: Implement the grid**
+
+Structure, matching the approved prototype:
+- Root `fixed inset-0 h-[100dvh] flex flex-col bg-background`, with `env(safe-area-inset-*)` padding on the top bar and bottom edge. Lock body scroll while mounted and restore on unmount.
+- Title bar: match name, source label, freshness dot using `--perf-green`, close button calling `onExit`.
+- Source toggle: My squad / Tracked, plus a row count.
+- Stage rail: one `<button aria-label="Jump to stage N">` per stage. `--perf-green` when every visible shooter has a card, `--foreground` for the live edge from `computeLiveEdgeStageId`, `--border` otherwise.
+- Scroller: `overflow-auto` with `scroll-snap-type: x proximity`, `overscroll-behavior-x: contain`.
+- A real `<table>`: `<th scope="col">` per stage, `<th scope="row">` per shooter with `position: sticky; left: 0`. Cells are `<button>` wrapping `<LiveGridCellView>`.
+- Identity shooter gets the badge copied from `components/competitor-picker.tsx:148` (`bg-primary/10 text-primary`, uppercase).
+- On mount, scroll the live-edge column into view.
+
+**Touch targets:** the cell button must reach 44x44px even though the visual cell is shorter. Set `min-height: 2.75rem` on the button, and verify with the E2E check in Task 7. Do not shrink it below the floor to fit more stages.
+
+- [ ] **Step 6: Run the tests and verify they pass**
+
+Run: `pnpm -w test -- tests/components/live-grid.test.tsx`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 7: Run the full gate, then commit**
+
+```bash
+pnpm -w run lint && pnpm -w run typecheck && pnpm -w test
+git add lib/api.ts lib/queries.ts components/live-grid.tsx tests/components/live-grid.test.tsx
+git commit -m "feat(live-grid): full-screen grid shell"
+```
+
+---
+
+### Task 6: Make it the default live view
+
+**Files:**
+- Modify: `app/match/[ct]/[id]/match-page-client.tsx:965-980` (the comparison-views block)
+- Modify: `lib/competition-store.ts` (add live-view preference)
+
+**Interfaces:**
+- Consumes: `<LiveGrid>` from Task 5.
+- Produces: `saveLiveViewPreference(ct, id, view)` and `getLiveViewPreference(ct, id)` where `view` is `"grid" | "table"`.
+
+- [ ] **Step 1: Add the preference helpers to `lib/competition-store.ts`**
+
+Follow the existing `saveModeOverride` / `getModeOverride` pattern in that file exactly, including its localStorage key prefix and its SSR guard. Store `"grid" | "table"`, defaulting to `"grid"`.
+
+- [ ] **Step 1b: Resolve the rows**
+
+Hold `source` state (`GridRowSource`, default `"squad"`) in `match-page-client.tsx` and derive the row IDs:
+
+```tsx
+const gridRows = useMemo(
+  () =>
+    resolveGridRows({
+      source: gridSource,
+      competitors: match.competitors,
+      squads: match.squads,
+      myShooterId: identity?.shooterId ?? null,
+      trackedShooterIds: trackedIds,
+      fallback: selectedIds,
+    }),
+  [gridSource, match.competitors, match.squads, identity, trackedIds, selectedIds],
+);
+```
+
+- [ ] **Step 2: Render the grid as the live default**
+
+In the block at `match-page-client.tsx:967-969`, split the live branch:
+
+```tsx
+{effectiveMode === "live" && match.is_live_scores_accessible &&
+ liveView === "grid" && gridRows.length > 0 && (
+  <LiveGrid
+    ct={ct}
+    id={id}
+    shooters={gridRows}
+    myShooterId={identity?.shooterId ?? null}
+    matchName={match.name}
+    source={gridSource}
+    onSourceChange={setGridSource}
+    onExit={() => setLiveView("table")}
+  />
+)}
+```
+
+The existing comparison stack keeps rendering for `coaching`, and for `live` when `liveView === "table"`. Add a "Full analysis" button inside `<LiveGrid>`'s chrome that calls `onExit`, and a matching control on the table view to return to the grid.
+
+**Do not** delete or modify `components/comparison-table.tsx`. It stays the deep view.
+
+- [ ] **Step 3: Verify the grid is not fetching compare**
+
+The compare query must not fire while the grid is showing. Confirm `compareEnabled` at `match-page-client.tsx:291-293` is false when `effectiveMode === "live" && liveView === "grid"`, and adjust it if not.
+
+Run: `pnpm dev`, open a live match, and confirm in the network tab that `/api/compare` is not called while the grid is up.
+
+- [ ] **Step 4: Run the full gate, then commit**
+
+```bash
+pnpm -w run lint && pnpm -w run typecheck && pnpm -w test
+git add app/match/'[ct]'/'[id]'/match-page-client.tsx lib/competition-store.ts
+git commit -m "feat(live-grid): make the grid the default live view"
+```
+
+---
+
+### Task 7: E2E at 390px
+
+**Files:**
+- Create: `tests/e2e/live-grid.spec.ts`
+
+Follow the mocking approach in `tests/e2e/scoreboard.spec.ts` -- `route.fulfill()` on `/api/*`, no live key.
+
+- [ ] **Step 1: Write the spec**
+
+```ts
+import { expect, test } from "@playwright/test";
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+test.describe("live grid", () => {
+  test("does not overflow the page horizontally", async ({ page }) => {
+    // ...mock /api/match and /api/live-grid, then navigate
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+    expect(overflow).toBe(false);
+  });
+
+  test("every cell button meets the 44px touch floor", async ({ page }) => {
+    const boxes = await page.locator("table button").evaluateAll((els) =>
+      els.map((e) => e.getBoundingClientRect().height),
+    );
+    expect(Math.min(...boxes)).toBeGreaterThanOrEqual(44);
+  });
+
+  test("opens the detail sheet on cell tap and closes it", async ({ page }) => {
+    await page.locator("table button").first().click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByRole("button", { name: /close/i }).click();
+    await expect(page.getByRole("dialog")).toBeHidden();
+  });
+
+  test("rail jump scrolls the grid", async ({ page }) => {
+    const scroller = page.locator("[data-live-grid-scroller]");
+    const before = await scroller.evaluate((e) => e.scrollLeft);
+    await page.getByRole("button", { name: "Jump to stage 12" }).click();
+    await expect.poll(() => scroller.evaluate((e) => e.scrollLeft)).toBeGreaterThan(before);
+  });
+});
+```
+
+Add `data-live-grid-scroller` to the scroller element in `components/live-grid.tsx`.
+
+Fill in the `route.fulfill()` mocks using a 12-stage, 8-shooter fixture so the rail jump has somewhere to go.
+
+- [ ] **Step 2: Run the E2E suite**
+
+Run: `pnpm test:e2e -- tests/e2e/live-grid.spec.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 3: Run the full gate, then commit**
+
+```bash
+pnpm -w run lint && pnpm -w run typecheck && pnpm -w test && pnpm test:e2e
+git add tests/e2e/live-grid.spec.ts components/live-grid.tsx
+git commit -m "test(live-grid): mobile e2e coverage at 390px"
+```
+
+---
+
+### Task 8: Docs
+
+**Files:**
+- Modify: `CLAUDE.md` (key directories list)
+- Modify: `lib/releases.ts`
+- Create: `docs/live-grid.md`
+
+- [ ] **Step 1: Add the release entry**
+
+Prepend a `Release` entry to `RELEASES` in `lib/releases.ts` per `docs/whats-new.md`, with an ISO `id`, `date`, `sections`, and `screenshotScenes`. A user-visible `feat` needs both a Conventional Commit PR title and a `RELEASES` entry.
+
+- [ ] **Step 2: Write `docs/live-grid.md`**
+
+Cover: what the grid is, the field-blind contract and why it exists, the Phase 2 plan and its spike gate, and the row-source rules. Link back to the spec.
+
+- [ ] **Step 3: Add the new files to the `CLAUDE.md` key-directories list**
+
+Entries for `app/api/live-grid/route.ts`, `lib/live-grid.ts`, `components/live-grid.tsx`, plus a pointer to `docs/live-grid.md`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md lib/releases.ts docs/live-grid.md
+git commit -m "docs(live-grid): document the grid and its field-blind contract"
+```
+
+---
+
+## Deferred to Phase 2
+
+Gated on `scripts/spike-competitor-scorecards.ts`, which needs a weekday for SSI's API key:
+
+- `LIVE_GRID_PER_COMPETITOR=on` and the `competitor_scorecards` fetch path
+- Per-competitor cache keys (`sc:comp:{ct}:{compId}`) and watermarking
+- The before/after upstream measurement
+
+Phase 1 delivers no upstream reduction. It delivers the view, the contract, and courtside testing.

--- a/docs/superpowers/specs/2026-08-23-live-grid-design.md
+++ b/docs/superpowers/specs/2026-08-23-live-grid-design.md
@@ -1,0 +1,229 @@
+# Courtside Grid -- minimal live view
+
+Design doc. Status: approved 2026-08-23.
+
+Interactive prototype (real component, switchable cell variants, tap-through
+detail sheet): <https://claude.ai/code/artifact/b0b7f947-9617-4255-b542-2646110638e4>
+
+**The implementation plan that follows this spec covers Phase 1 only.** Phase 2
+is specified here for context but is gated on a spike that cannot run until
+SSI's API key is enabled on a weekday.
+
+## Problem
+
+The live view is the coaching view with the expensive analytics switched off.
+It renders `comparison-table.tsx` (2373 lines) inside a scrolling page, laid
+out stages-as-rows and competitors-as-columns, capped at
+`MAX_COMPETITORS = 12`.
+
+The stated pain is upstream load on SSI. Per 60s cycle a live match costs one
+`MatchSyncProbe` plus one `STAGE_SCORECARDS_QUERY` per changed stage, and each
+of those returns the **full field** for that stage. A 12-stage,
+300-competitor match under active shooting is roughly 12 requests and ~3600
+scorecard objects a minute, for as long as anyone has the page open.
+Refreshes are viewer-driven and single-flighted per match, so one viewer costs
+the same as two hundred.
+
+## Goal
+
+A full-screen, one-row-per-shooter, one-column-per-stage grid that is the
+default live experience, and whose data contract depends only on each
+shooter's own scorecard -- so the server can later fetch just those shooters
+instead of the whole field.
+
+## Non-goals
+
+- Rankings, stage-winner hit factor, field median, division distributions.
+  Their absence is the design constraint, not an omission.
+- Screen wake lock, offline persistence, a separate landscape layout.
+- Replacing the coaching view or the comparison table. Both stay.
+
+## Surface
+
+The grid owns `effectiveMode === "live"` when
+`match.is_live_scores_accessible` is true. A "Full analysis" control switches
+to the existing comparison stack; the choice persists per match in
+`lib/competition-store.ts` next to `modeOverride`.
+
+Presentation is `position: fixed; inset: 0; height: 100dvh`, body scroll
+locked, `env(safe-area-inset-*)` honoured. No site header, no footer, no
+`max-w-6xl`. Bands top to bottom:
+
+1. **Title bar** -- match name, row source, freshness dot (`--perf-green`),
+   close.
+2. **Source toggle** -- My squad / Tracked, plus a row count.
+3. **Stage rail** -- one segment per stage, all visible even though about four
+   columns fit. `--perf-green` = squad finished, `--foreground` = live edge,
+   `--border` = pending. Tap to jump.
+4. **Grid** -- shooter column pinned via `position: sticky; left: 0`, stage
+   columns `scroll-snap-align: start`. Opens scrolled to the live edge, which
+   is the newest stage with any result among the visible rows.
+
+Rows come from `MatchResponse.squads[].competitorIds` or the tracked shooter
+IDs, both already present in the cached `GetMatch`. Cap is a new
+`MAX_LIVE_GRID_ROWS = 20`, separate from `MAX_COMPETITORS = 12`, because a
+squad can exceed 14.
+
+## Cell
+
+Hit factor (15px, tabular), time (10px, muted), and then the zone story --
+but only when there is one.
+
+- **Points dropped** -- proportional A/C/D bar reusing `hit-zone-bar.tsx`
+  (pattern-filled, already CVD-cleared), plus M/NS/P shape pips with counts.
+- **Clean run** -- a 7px green circle and the label `ALL A`. Circle is the one
+  shape neither the bar (rectangle) nor the pips (square, triangle, diamond)
+  use, so it separates on shape alone under greyscale and CVD.
+- **Non-scored** -- `DQ`, `ZERO`, or an em dash for not-yet-shot.
+
+An all-alpha run is the best thing that can appear on the page, so it earns a
+positive mark. Drawing nothing would have made "clean" and "no data"
+identical.
+
+Column width is about 74px, which fits roughly four stages at 390px and about
+ten in landscape.
+
+## Detail sheet
+
+Tapping a cell opens a bottom sheet: hit factor to four decimals, time, points
+against stage max, a per-zone breakdown with what each zone cost, the
+points-dropped split (on-target vs penalties), the hit factor the run would
+have had if clean, and the scorecard timestamp.
+
+Every figure is derived from that shooter's card plus `max_points`. The sheet
+is where field context would be most tempting to add; it must not be.
+
+## Data contract
+
+`GET /api/live-grid?ct=&id=&competitor_ids=`
+
+```ts
+interface LiveGridCell {
+  hf: number | null;
+  time: number | null;
+  points: number | null;
+  a: number | null; c: number | null; d: number | null;
+  m: number | null; ns: number | null; p: number | null;
+  status: "scored" | "dq" | "zeroed" | "not_fired" | "incomplete" | "pending";
+  created: string | null;   // drives live-edge detection
+}
+
+interface LiveGridResponse {
+  match_id: number;
+  stages: { stage_id: number; stage_num: number; name: string; max_points: number }[];
+  shooters: { id: number; shooterId: number | null; name: string;
+              competitor_number: string; division: string | null; squad: string | null }[];
+  cells: Record<number, Record<number, LiveGridCell>>;  // [competitorId][stageId]
+  cacheInfo: CacheInfo;
+  scorecardsRestricted?: boolean;
+}
+```
+
+`ns` maps from SSI's `penalty` field, per `lib/scorecard-data.ts:96`.
+
+The invariant: **every field is derivable from one shooter's own scorecard.**
+No `group_leader_hf`, `overall_leader_hf`, `field_median_hf`,
+`divisionDistributions`, rankings, archetypes, or fingerprints. `max_points`
+comes from the stage list. Any within-grid relative measure is computed
+client-side from the rows already loaded.
+
+That invariant is what makes phase 2 a server-only change.
+
+## Phasing
+
+**Phase 1 -- project the cached snapshot.** The route reads the existing
+scorecards snapshot through `getMatchScorecards` and projects it down. It must
+not call `computeGroupRankings` or any field-wide compute. Ships without
+touching upstream, so it is not blocked on SSI's weekday-only API key.
+
+Phase 1 delivers no upstream reduction. It buys the view, the contract, and
+courtside testing.
+
+**Phase 2 -- per-competitor fetch, behind `LIVE_GRID_PER_COMPETITOR=on`.**
+SSI exposes an unused per-competitor path:
+
+```
+RootQuery.competitor_scorecards(content_type, id, updated_after) -> [ScoreCardInterface!]!
+RootQuery.competitor_scorecards_count(content_type, id) -> Int!
+IpscCompetitorNode.scorecards(updated_after) / .scorecards_count / .latest_scorecard_update
+```
+
+Watermarked by `latest_scorecard_update` exactly like the existing stage
+sidecar, cached per competitor (`sc:comp:{ct}:{compId}`) so overlapping
+squad-watchers share keys.
+
+### Phase 2 is gated on a spike
+
+`scripts/spike-competitor-scorecards.ts` is written but could not run --
+SSI returned `Invalid API Key!` because the key is enabled on weekdays only.
+It must answer three questions before phase 2 is planned:
+
+1. Does the root `competitor_scorecards` resolver work? The sibling root
+   `competitor(content_type, id)` returns 404 in practice
+   (`lib/graphql.ts:268`), so this cannot be assumed.
+2. Does GraphQL alias-batching of N competitors in one request work?
+   **This is the load question.** 14 competitor requests is worse than 12
+   stage requests on request count, which is what caused the 2026-08-15
+   outage. The payload win is real either way; the request-count win depends
+   entirely on batching.
+3. Does the path respect `is_live_scores_accessible`?
+
+If batching fails, phase 2 is only worthwhile when the watched-competitor set
+stays a small fraction of the field. Decide then, with numbers.
+
+## Refresh contract
+
+The grid reuses `computeMatchFreshness` unchanged and introduces **no second
+poll clock**. A separate clock on the same match would raise refresh frequency
+and defeat the purpose. Probe gating, single-flight locks, the upstream
+semaphore, and `SSI_UPSTREAM_PAUSED` all apply untouched.
+
+Instrument the same way as the 2026-08-20 measurement (234 client requests ->
+25 upstream calls) so the phase 2 before/after is measured, not asserted.
+
+## Design system
+
+**Zero new tokens.** Everything resolves to `--background`, `--card`,
+`--foreground`, `--muted-foreground`, `--border`, `--primary`,
+`--destructive`, and the `--perf-red` / `--perf-amber` / `--perf-green`
+triad, plus the four zone literals already in `hit-zone-bar.tsx`
+(`#22c55e`, `#facc15`, `#fb923c`, `#dc2626`). The rail's done and live states
+use `--perf-green` and `--foreground` rather than a new accent.
+
+"This is me" uses the shipped badge from `competitor-picker.tsx:148`
+(`bg-primary/10`, `text-primary`, uppercase), not a coloured name.
+
+## Accessibility
+
+- Grid is a real `<table>` with `<th scope="col">` per stage and
+  `<th scope="row">` per shooter.
+- Cells are `<button>` elements; the sheet is `role="dialog" aria-modal="true"`
+  and returns focus to the originating cell on close.
+- No information rests on colour alone: zone bar uses pattern fills, penalties
+  use distinct shapes, the clean marker uses a circle plus the text `ALL A`.
+- Touch targets meet the 44x44px floor from `globals.css`. Cells are visually
+  smaller than that, so the tap target must be padded to meet it -- verify.
+- Rail buttons carry `aria-label="Jump to stage N"`.
+
+## Testing
+
+- **Unit** -- the projection from raw scorecards to `LiveGridResponse`, as a
+  pure function, including DQ / zeroed / not-fired / incomplete and a
+  mid-scoring stage where some rows have no card.
+- **Component** -- cell renders the clean marker when and only when
+  `c + d + m + ns + p === 0`; renders the bar otherwise.
+- **E2E** -- Playwright at 390px: live-edge auto-scroll, rail jump, sheet open
+  and close, no horizontal page overflow.
+- Existing gates apply: `pnpm -w run lint`, `pnpm -w run typecheck`,
+  `pnpm -w test` all clean.
+
+## Open questions
+
+1. Does `ALL A` read as too shouty outdoors? The circle alone may carry it.
+   Answer courtside.
+2. `CACHE_SCHEMA_VERSION` does not move in phase 1 -- the route reads the
+   existing cached shape and adds no fields to it. Confirm during
+   implementation.
+3. Whether the grid should also serve `results_status === "all"` matches that
+   are complete but where the user still wants the compact view. Out of scope
+   for now.

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   ShooterDashboardResponse,
   ShooterSearchResult,
   BackfillProgress,
+  LiveGridResponse,
 } from "@/lib/types";
 
 export async function fetchMatch(ct: string, id: string): Promise<MatchResponse> {
@@ -172,6 +173,34 @@ export async function addMatchToShooter(
   if (!res.ok) {
     const body = await res.json().catch(() => ({ message: "Unknown error" }));
     throw new Error(body.message ?? `HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+/**
+ * Fetch the courtside live grid for a set of competitors.
+ *
+ * Deliberately narrow: the response carries only each shooter's own stage
+ * results, no field-wide context. See
+ * docs/superpowers/specs/2026-08-23-live-grid-design.md.
+ */
+export async function fetchLiveGrid(
+  ct: string,
+  id: string,
+  competitorIds: number[],
+): Promise<LiveGridResponse> {
+  if (competitorIds.length === 0) {
+    throw new Error("No competitor IDs provided");
+  }
+  const params = new URLSearchParams({
+    ct,
+    id,
+    competitor_ids: competitorIds.join(","),
+  });
+  const res = await fetch(`/api/live-grid?${params}`);
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Live grid fetch failed (${res.status}): ${body}`);
   }
   return res.json();
 }

--- a/lib/competition-store.ts
+++ b/lib/competition-store.ts
@@ -224,3 +224,44 @@ export function subscribeMode(onChange: () => void): () => void {
     window.removeEventListener("storage", onChange);
   };
 }
+
+// ---------------------------------------------------------------------------
+// Live view preference -- grid vs the deep comparison table
+// ---------------------------------------------------------------------------
+
+/** Which live surface the user last chose for a given match. */
+export type LiveView = "grid" | "table";
+
+function liveViewKey(ct: string, id: string): string {
+  return `ssi_liveview_${ct}_${id}`;
+}
+
+/**
+ * Persist the live surface choice. The grid is the default, so only an
+ * explicit switch to the deep table is worth remembering -- but both are
+ * stored so a later default change doesn't silently move people.
+ */
+export function saveLiveViewPreference(
+  ct: string,
+  id: string,
+  view: LiveView,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(liveViewKey(ct, id), view);
+  } catch {
+    // ignore
+  }
+}
+
+/** Read the live surface choice. Defaults to the grid. */
+export function getLiveViewPreference(ct: string, id: string): LiveView {
+  if (typeof window === "undefined") return "grid";
+  try {
+    return localStorage.getItem(liveViewKey(ct, id)) === "table"
+      ? "table"
+      : "grid";
+  } catch {
+    return "grid";
+  }
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -2,6 +2,11 @@
 
 export const MAX_COMPETITORS = 12;
 
+/** Live grid rows. Higher than MAX_COMPETITORS because a squad can exceed 14
+ *  and the grid's per-row cost is one scorecard slice, not a field-wide
+ *  compute. See docs/superpowers/specs/2026-08-23-live-grid-design.md. */
+export const MAX_LIVE_GRID_ROWS = 20;
+
 /**
  * Cache schema version — embedded in every cached GraphQL response.
  * Bump this (by 1) whenever the *shape* of a cached API response changes

--- a/lib/live-grid-rows.ts
+++ b/lib/live-grid-rows.ts
@@ -1,0 +1,65 @@
+import { MAX_LIVE_GRID_ROWS } from "@/lib/constants";
+import type { CompetitorInfo, SquadInfo } from "@/lib/types";
+
+/** Where the live grid's rows come from. Both resolve entirely from the
+ *  already-cached GetMatch response -- no extra upstream cost. */
+export type GridRowSource = "squad" | "tracked";
+
+export interface ResolveGridRowsArgs {
+  source: GridRowSource;
+  competitors: CompetitorInfo[];
+  squads: SquadInfo[];
+  myShooterId: number | null;
+  trackedShooterIds: Set<number>;
+  /** The user's existing competitor selection, used when the chosen source
+   *  resolves to nothing (they're in no squad, or track nobody here). */
+  fallback: number[];
+}
+
+/**
+ * Resolve which competitor IDs fill the grid's rows.
+ *
+ * Pure, so the fiddly bits -- shooterId to competitorId mapping, the
+ * fallback, the cap -- are testable without mounting the grid.
+ */
+export function resolveGridRows(args: ResolveGridRowsArgs): number[] {
+  const {
+    source,
+    competitors,
+    squads,
+    myShooterId,
+    trackedShooterIds,
+    fallback,
+  } = args;
+
+  const myCompetitorId =
+    myShooterId == null
+      ? null
+      : (competitors.find((c) => c.shooterId === myShooterId)?.id ?? null);
+
+  let ids: number[];
+  if (source === "squad") {
+    const squad =
+      myCompetitorId == null
+        ? undefined
+        : squads.find((s) => s.competitorIds.includes(myCompetitorId));
+    ids = squad ? [...squad.competitorIds] : [];
+  } else {
+    const wanted = new Set(trackedShooterIds);
+    if (myShooterId != null) wanted.add(myShooterId);
+    // shooterId can be null for competitors SSI hasn't linked to a profile;
+    // those can never match a tracked ID.
+    ids = competitors
+      .filter((c) => c.shooterId != null && wanted.has(c.shooterId))
+      .map((c) => c.id);
+  }
+
+  if (ids.length === 0) ids = [...fallback];
+
+  // My own row leads, so it's the one already on screen before any scrolling.
+  if (myCompetitorId != null && ids.includes(myCompetitorId)) {
+    ids = [myCompetitorId, ...ids.filter((id) => id !== myCompetitorId)];
+  }
+
+  return ids.slice(0, MAX_LIVE_GRID_ROWS);
+}

--- a/lib/live-grid.ts
+++ b/lib/live-grid.ts
@@ -1,0 +1,74 @@
+import type { RawScorecard } from "@/app/api/compare/logic";
+import type { LiveGridCell, LiveGridStage } from "@/lib/types";
+
+/**
+ * Project raw scorecards into the live grid's cell map.
+ *
+ * Deliberately field-blind: every value comes from the shooter's own card.
+ * Nothing here may consult other competitors -- that invariant is what lets
+ * the Phase 2 per-competitor fetch drop in without a client change. See
+ * docs/superpowers/specs/2026-08-23-live-grid-design.md.
+ */
+export function buildLiveGridCells(
+  scorecards: RawScorecard[],
+  competitorIds: number[],
+): Record<number, Record<number, LiveGridCell>> {
+  const wanted = new Set(competitorIds);
+  const out: Record<number, Record<number, LiveGridCell>> = {};
+  for (const id of competitorIds) out[id] = {};
+
+  for (const sc of scorecards) {
+    if (!wanted.has(sc.competitor_id)) continue;
+    out[sc.competitor_id][sc.stage_id] = {
+      hf: sc.hit_factor,
+      time: sc.time,
+      points: sc.points,
+      a: sc.a_hits,
+      c: sc.c_hits,
+      d: sc.d_hits,
+      m: sc.miss_count,
+      ns: sc.no_shoots,
+      p: sc.procedurals,
+      status: classify(sc),
+      created: sc.scorecard_created ?? null,
+    };
+  }
+  return out;
+}
+
+// Order matters: a DQ'd card can also carry zeroed/dnf flags, and DQ is the
+// one the shooter needs to see.
+function classify(sc: RawScorecard): LiveGridCell["status"] {
+  if (sc.dq) return "dq";
+  if (sc.zeroed) return "zeroed";
+  if (sc.dnf) return "not_fired";
+  if (sc.incomplete) return "incomplete";
+  return "scored";
+}
+
+/**
+ * The stage the visible shooters most recently produced a scorecard on.
+ *
+ * The grid opens scrolled here, because it is the stage they just shot.
+ * Falls back to the first stage so a pre-scoring match still lands somewhere.
+ */
+export function computeLiveEdgeStageId(
+  cells: Record<number, Record<number, LiveGridCell>>,
+  stages: LiveGridStage[],
+): number | null {
+  if (stages.length === 0) return null;
+
+  let bestStage: number | null = null;
+  let bestAt = "";
+  for (const byStage of Object.values(cells)) {
+    for (const [stageId, cell] of Object.entries(byStage)) {
+      if (!cell.created) continue;
+      // ISO-8601 UTC strings compare correctly lexicographically.
+      if (cell.created > bestAt) {
+        bestAt = cell.created;
+        bestStage = Number(stageId);
+      }
+    }
+  }
+  return bestStage ?? stages[0].stage_id;
+}

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1,8 +1,8 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { fetchMatch, fetchCompare, fetchEvents, fetchPopularMatches, fetchLiveMatches, fetchCoachingAvailability, fetchCoachingTip, fetchShooterDashboard, fetchShooterSearch, fetchUpstreamStatus, type UpstreamStatus } from "@/lib/api";
-import type { CompareMode, MatchResponse, CompareResponse, EventSummary, PopularMatch, CoachingTipResponse, CoachingAvailability, ShooterDashboardResponse, ShooterSearchResult, PreMatchWeatherResponse } from "@/lib/types";
+import { fetchMatch, fetchCompare, fetchLiveGrid, fetchEvents, fetchPopularMatches, fetchLiveMatches, fetchCoachingAvailability, fetchCoachingTip, fetchShooterDashboard, fetchShooterSearch, fetchUpstreamStatus, type UpstreamStatus } from "@/lib/api";
+import type { CompareMode, LiveGridResponse, MatchResponse, CompareResponse, EventSummary, PopularMatch, CoachingTipResponse, CoachingAvailability, ShooterDashboardResponse, ShooterSearchResult, PreMatchWeatherResponse } from "@/lib/types";
 import { matchQueryKey, compareQueryKey, coachingAvailabilityKey, coachingTipQueryKey } from "@/lib/query-keys";
 
 // Re-export so existing imports from lib/queries keep working.
@@ -205,5 +205,25 @@ export function useCoachingTipQuery(
     enabled: false, // manual trigger only — user opens popover
     staleTime: Infinity, // tips for completed matches never go stale
     retry: false,
+  });
+}
+
+export function useLiveGridQuery(
+  ct: string,
+  id: string,
+  competitorIds: number[],
+) {
+  return useQuery<LiveGridResponse, Error>({
+    // Sorted so re-ordering rows doesn't churn the cache key.
+    queryKey: ["live-grid", ct, id, [...competitorIds].sort((a, b) => a - b)],
+    queryFn: () => fetchLiveGrid(ct, id, competitorIds),
+    // Same 30s cadence the live comparison already uses. Deliberately NOT a
+    // new clock: the server's freshness window is what actually bounds
+    // upstream traffic, and a second cadence on the same match would raise
+    // refresh frequency -- the opposite of why this view exists.
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
+    enabled: Boolean(ct && id && competitorIds.length > 0),
   });
 }

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -11,11 +11,43 @@ import type { Release } from "@/lib/types";
  * differs from the value stored in localStorage("whats-new-seen-id").
  */
 /** The `id` of the newest release. Used by e2e tests to suppress the What's New dialog. */
-export const LATEST_RELEASE_ID = "2026-05-12-coaching-features";
+export const LATEST_RELEASE_ID = "2026-08-23-courtside-grid";
 
 export const RELEASES: Release[] = [
   {
     id: LATEST_RELEASE_ID,
+    date: "August 23, 2026",
+    title: "Courtside grid: the live view, rebuilt for a phone at the range",
+    // TODO: no "live-grid" scene exists in scripts/screenshot-match.ts yet.
+    // Omitted rather than pointed at an unrelated scene; add the scene and
+    // list it here before the release ships.
+    sections: [
+      {
+        heading: "A new live view",
+        items: [
+          "Live matches now open in a full-screen grid: one row per shooter, one column per stage. No page chrome, no scrolling past charts to find a score -- just the stage data, sized for one hand at 390px.",
+          "Rows come from your squad or your tracked shooters, switchable in one tap. Your own row leads, so it is on screen before you scroll anywhere.",
+          "The grid opens scrolled to the stage your squad just shot, and a rail across the top keeps every stage one tap away even when only four columns fit.",
+        ],
+      },
+      {
+        heading: "Reading a cell",
+        items: [
+          "Each cell carries hit factor, time, the A/C/D split, and any misses, no-shoots or procedurals.",
+          "A stage where you dropped points draws a hit-zone bar. A clean run instead shows a green circle and ALL A -- so a squad shooting well is a quiet column, and whatever went wrong is the only busy mark on screen.",
+          "Tap any cell for the full scorecard: points against stage max, what every zone and penalty cost you, and what your hit factor would have been on a clean run.",
+        ],
+      },
+      {
+        heading: "Full analysis is still there",
+        items: [
+          "The comparison table, charts and coaching analysis are one tap away behind Full analysis, and the app remembers which you last chose for each match.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "2026-05-12-coaching-features",
     date: "May 12, 2026",
     title: "Coaching features: peak stage, near achievements, self-comparison, and personalised brief",
     screenshotScenes: ["shooter-dashboard", "comparison-table"],

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1172,3 +1172,58 @@ export interface Release {
    */
   screenshotScenes?: string[];
 }
+
+// ─── Live grid (courtside view) ───────────────────────────────────────────────
+// One row per shooter, one column per stage. See
+// docs/superpowers/specs/2026-08-23-live-grid-design.md.
+//
+// CONTRACT: every field below is derivable from a single shooter's own
+// scorecard plus the stage list. No stage-winner hit factor, no field median,
+// no division distribution, no ranking. That invariant is what lets the server
+// swap from "project the cached whole-field snapshot" to "fetch just these
+// shooters" without the client changing.
+
+/** One shooter's result on one stage. */
+export interface LiveGridCell {
+  hf: number | null;
+  time: number | null;
+  points: number | null;
+  a: number | null;
+  /** B-zone is already folded into C by `parseRawScorecards`. */
+  c: number | null;
+  d: number | null;
+  m: number | null;
+  /** No-shoots. Maps from SSI's `penalty` field (lib/scorecard-data.ts). */
+  ns: number | null;
+  p: number | null;
+  status: "scored" | "dq" | "zeroed" | "not_fired" | "incomplete" | "pending";
+  /** Scorecard creation timestamp; drives live-edge detection. */
+  created: string | null;
+}
+
+export interface LiveGridStage {
+  stage_id: number;
+  stage_num: number;
+  name: string;
+  max_points: number;
+}
+
+export interface LiveGridShooter {
+  id: number;
+  shooterId: number | null;
+  name: string;
+  competitor_number: string;
+  division: string | null;
+  squad: string | null;
+}
+
+export interface LiveGridResponse {
+  match_id: number;
+  stages: LiveGridStage[];
+  shooters: LiveGridShooter[];
+  /** cells[competitorId][stageId] */
+  cells: Record<number, Record<number, LiveGridCell>>;
+  cacheInfo: CacheInfo;
+  /** True when SSI returned no scorecard detail despite non-zero scoring. */
+  scorecardsRestricted?: boolean;
+}

--- a/scripts/spike-competitor-scorecards.ts
+++ b/scripts/spike-competitor-scorecards.ts
@@ -1,0 +1,329 @@
+#!/usr/bin/env tsx
+/**
+ * Spike: does SSI expose a per-competitor scorecard path we can use instead of
+ * the whole-field per-stage fan-out?
+ *
+ * READ ONLY. Introspects and probes:
+ *   - RootQuery.competitor_scorecards(content_type, id, updated_after)
+ *   - RootQuery.competitor_scorecards_count(content_type, id)
+ *   - IpscCompetitorNode.scorecards(updated_after) / scorecards_count /
+ *     latest_scorecard_update
+ *   - whether N competitors can be batched via GraphQL aliases in one request
+ *
+ * Usage: pnpm tsx scripts/spike-competitor-scorecards.ts [ct] [matchId]
+ * Throwaway -- delete once the answer is recorded.
+ */
+
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const ENDPOINT = "https://shootnscoreit.com/graphql/";
+
+function loadEnvFile(filePath: string): void {
+  if (!existsSync(filePath)) return;
+  for (const line of readFileSync(filePath, "utf-8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in process.env)) process.env[key] = value;
+  }
+}
+
+loadEnvFile(join(process.cwd(), ".env.local"));
+
+const API_KEY = process.env.SSI_API_KEY ?? "";
+const EMAIL = process.env.SSI_SERVICE_EMAIL ?? "";
+const PASSWORD = process.env.SSI_SERVICE_PASSWORD ?? "";
+
+if (!API_KEY) {
+  console.error("Missing SSI_API_KEY in .env.local");
+  process.exit(1);
+}
+
+interface GqlResult<T> {
+  data?: T;
+  errors?: { message: string }[];
+}
+
+let jwt: string | null = null;
+
+async function gql<T>(query: string, variables: Record<string, unknown> = {}): Promise<GqlResult<T>> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": API_KEY,
+  };
+  if (jwt) headers["Authorization"] = `JWT ${jwt}`;
+  const r = await fetch(ENDPOINT, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ query, variables }),
+  });
+  const text = await r.text();
+  try {
+    return JSON.parse(text) as GqlResult<T>;
+  } catch {
+    return { errors: [{ message: `HTTP ${r.status}: ${text.slice(0, 300)}` }] };
+  }
+}
+
+async function loginForJwt(): Promise<void> {
+  if (!EMAIL || !PASSWORD) {
+    console.log("No service credentials -- running with api key only");
+    return;
+  }
+  const res = await gql<{ token_auth?: { success?: boolean; token?: { token?: string } | null } }>(
+    "mutation Login($email: String!, $pwd: String!) { token_auth(email: $email, password: $pwd) { success token { token } } }",
+    { email: EMAIL, pwd: PASSWORD },
+  );
+  if (res.errors?.length) {
+    console.log("login errors:", res.errors.map((e) => e.message).join("; "));
+    return;
+  }
+  jwt = res.data?.token_auth?.token?.token ?? null;
+  console.log(jwt ? "Authenticated as service account" : "Login returned no token");
+}
+
+const out: string[] = [];
+function say(s: string) {
+  console.log(s);
+  out.push(s);
+}
+
+async function main() {
+  await loginForJwt();
+
+  const ct = process.argv[2] ?? "22";
+  let matchId = process.argv[3] ?? null;
+
+  // ── 0. Find a match with scorecards if none supplied ──────────────────────
+  if (!matchId) {
+    const res = await gql<{ events: { id: string; name: string; starts: string }[] }>(
+      `query { events(levels: "2,3,4,5", starts_before: "${new Date().toISOString().slice(0, 10)}") { id name starts } }`,
+    );
+    if (res.errors?.length) {
+      say(`## FATAL: events query failed\n\n${res.errors.map((e) => e.message).join("; ")}`);
+      finish();
+      return;
+    }
+    const events = res.data?.events ?? [];
+    const recent = events.sort((a, b) => (a.starts < b.starts ? 1 : -1))[0];
+    matchId = recent?.id ?? null;
+    say(`Auto-picked match ${matchId} (${recent?.name}, ${recent?.starts})`);
+  }
+
+  if (!matchId) {
+    say("## FATAL: no match id available");
+    finish();
+    return;
+  }
+
+  // ── 1. Grab a competitor id + its content type ────────────────────────────
+  const compRes = await gql<{
+    event: {
+      name: string;
+      stages_count: number;
+      competitors_count: number;
+      competitors_approved_w_wo_results_not_dnf: {
+        id: string;
+        get_content_type_key: number;
+        first_name: string;
+        last_name: string;
+      }[];
+    };
+  }>(
+    `query($ct: Int!, $id: String!) {
+      event(content_type: $ct, id: $id) {
+        name
+        ... on IpscMatchNode {
+          stages_count
+          competitors_count
+          competitors_approved_w_wo_results_not_dnf {
+            id
+            get_content_type_key
+            ... on IpscCompetitorNode { first_name last_name }
+          }
+        }
+      }
+    }`,
+    { ct: parseInt(ct, 10), id: matchId },
+  );
+
+  if (compRes.errors?.length) {
+    say(`## FATAL: match query failed\n\n${compRes.errors.map((e) => e.message).join("; ")}`);
+    finish();
+    return;
+  }
+
+  const ev = compRes.data?.event;
+  const comps = ev?.competitors_approved_w_wo_results_not_dnf ?? [];
+  say(`\n## Match: ${ev?.name} (${ev?.competitors_count} competitors, ${ev?.stages_count} stages)`);
+  if (comps.length === 0) {
+    say("No competitors -- pick a different match");
+    finish();
+    return;
+  }
+  const compCt = comps[0].get_content_type_key;
+  say(`Competitor content_type = ${compCt}`);
+
+  const sample = comps.slice(0, 5);
+  say(`Sample competitors: ${sample.map((c) => `${c.id} (${c.first_name} ${c.last_name})`).join(", ")}`);
+
+  // ── 2. RootQuery.competitor_scorecards ────────────────────────────────────
+  say(`\n## Probe A -- RootQuery.competitor_scorecards(content_type, id, updated_after)`);
+  const a = await gql<{ competitor_scorecards: unknown[] }>(
+    `query($ct: Int!, $id: String!, $after: String!) {
+      competitor_scorecards(content_type: $ct, id: $id, updated_after: $after) {
+        ... on IpscScoreCardNode {
+          created
+          points
+          hitfactor
+          time
+          disqualified
+          zeroed
+          stage_not_fired
+          incomplete
+          ascore bscore cscore dscore miss penalty procedural
+          stage { id number name ... on IpscStageNode { max_points } }
+          competitor { id }
+        }
+      }
+    }`,
+    { ct: compCt, id: sample[0].id, after: "1970-01-01T00:00:00Z" },
+  );
+  if (a.errors?.length) {
+    say(`ERRORS: ${a.errors.map((e) => e.message).join("; ")}`);
+  } else {
+    const cards = a.data?.competitor_scorecards ?? [];
+    say(`OK -- ${cards.length} scorecards returned`);
+    say("```json\n" + JSON.stringify(cards.slice(0, 2), null, 2) + "\n```");
+  }
+
+  // ── 3. RootQuery.competitor_scorecards_count ──────────────────────────────
+  say(`\n## Probe B -- RootQuery.competitor_scorecards_count(content_type, id)`);
+  const b = await gql<{ competitor_scorecards_count: number }>(
+    `query($ct: Int!, $id: String!) { competitor_scorecards_count(content_type: $ct, id: $id) }`,
+    { ct: compCt, id: sample[0].id },
+  );
+  say(b.errors?.length
+    ? `ERRORS: ${b.errors.map((e) => e.message).join("; ")}`
+    : `OK -- count = ${b.data?.competitor_scorecards_count}`);
+
+  // ── 4. Nested IpscCompetitorNode.scorecards via event ──────────────────────
+  say(`\n## Probe C -- event { competitors { scorecards, scorecards_count, latest_scorecard_update } }`);
+  const c = await gql<Record<string, unknown>>(
+    `query($ct: Int!, $id: String!, $after: String!) {
+      event(content_type: $ct, id: $id) {
+        ... on IpscMatchNode {
+          competitors_approved_w_wo_results_not_dnf {
+            id
+            ... on IpscCompetitorNode {
+              first_name
+              scorecards_count
+              latest_scorecard_update
+              scorecards(updated_after: $after) {
+                ... on IpscScoreCardNode {
+                  points hitfactor time
+                  stage { id number }
+                }
+              }
+            }
+          }
+        }
+      }
+    }`,
+    { ct: parseInt(ct, 10), id: matchId, after: "1970-01-01T00:00:00Z" },
+  );
+  if (c.errors?.length) {
+    say(`ERRORS: ${c.errors.map((e) => e.message).join("; ")}`);
+  } else {
+    const json = JSON.stringify(c.data);
+    say(`OK -- payload ${json.length} bytes for the whole field`);
+    say("```json\n" + json.slice(0, 1200) + "\n```");
+  }
+
+  // ── 5. Alias batching: N competitors in ONE request ───────────────────────
+  say(`\n## Probe D -- alias batching, ${sample.length} competitors in one request`);
+  const aliases = sample
+    .map(
+      (cp, i) => `c${i}: competitor_scorecards(content_type: $ct, id: "${cp.id}", updated_after: $after) {
+        ... on IpscScoreCardNode { points hitfactor time stage { id number } }
+      }`,
+    )
+    .join("\n");
+  const tD0 = Date.now();
+  const d = await gql<Record<string, unknown[]>>(
+    `query($ct: Int!, $after: String!) {\n${aliases}\n}`,
+    { ct: compCt, after: "1970-01-01T00:00:00Z" },
+  );
+  const tD1 = Date.now();
+  if (d.errors?.length) {
+    say(`ERRORS: ${d.errors.map((e) => e.message).join("; ")}`);
+  } else {
+    const json = JSON.stringify(d.data);
+    const counts = Object.entries(d.data ?? {}).map(([k, v]) => `${k}=${v.length}`).join(" ");
+    say(`OK in ${tD1 - tD0}ms -- ${json.length} bytes, ${counts}`);
+  }
+
+  // ── 6. Cost baseline: what ONE full-stage pull costs today ────────────────
+  say(`\n## Baseline -- one full-stage scorecards pull (what we do today)`);
+  const stagesRes = await gql<{ event: { stages: { id: string; number: number }[] } }>(
+    `query($ct: Int!, $id: String!) {
+      event(content_type: $ct, id: $id) { ... on IpscMatchNode { stages { id number } } }
+    }`,
+    { ct: parseInt(ct, 10), id: matchId },
+  );
+  const stage0 = stagesRes.data?.event?.stages?.[0];
+  if (stage0) {
+    const tS0 = Date.now();
+    const s = await gql<{ stage: { scorecards: unknown[] } }>(
+      `query($ct: Int!, $id: String!) {
+        stage(content_type: $ct, id: $id) {
+          id number name
+          ... on IpscStageNode {
+            max_points
+            scorecards {
+              ... on IpscScoreCardNode {
+                created points hitfactor time disqualified zeroed stage_not_fired incomplete
+                ascore bscore cscore dscore miss penalty procedural
+                competitor { id ... on IpscCompetitorNode { first_name last_name number club get_division_display } }
+              }
+            }
+          }
+        }
+      }`,
+      { ct: 24, id: stage0.id },
+    );
+    const tS1 = Date.now();
+    if (s.errors?.length) {
+      say(`ERRORS: ${s.errors.map((e) => e.message).join("; ")}`);
+    } else {
+      const n = s.data?.stage?.scorecards?.length ?? 0;
+      say(`stage ${stage0.number}: ${n} scorecards, ${JSON.stringify(s.data).length} bytes, ${tS1 - tS0}ms`);
+      say(`-> whole match today = ~${(ev?.stages_count ?? 0)} such pulls per changed cycle`);
+    }
+  }
+
+  finish();
+}
+
+function finish() {
+  const dir = join(homedir(), ".claude-tmp");
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "spike-competitor-scorecards.md");
+  writeFileSync(path, out.join("\n") + "\n");
+  console.log(`\nReport written to ${path}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  finish();
+  process.exit(1);
+});

--- a/tests/components/live-grid-cell.test.tsx
+++ b/tests/components/live-grid-cell.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LiveGridCellView } from "@/components/live-grid-cell";
+import type { LiveGridCell } from "@/lib/types";
+
+function cell(over: Partial<LiveGridCell> = {}): LiveGridCell {
+  return {
+    hf: 5.42,
+    time: 16.42,
+    points: 89,
+    a: 16,
+    c: 0,
+    d: 0,
+    m: 0,
+    ns: 0,
+    p: 0,
+    status: "scored",
+    created: "2026-08-23T09:00:00Z",
+    ...over,
+  };
+}
+
+describe("LiveGridCellView", () => {
+  it("shows hit factor and time for a scored run", () => {
+    render(<LiveGridCellView cell={cell()} />);
+    expect(screen.getByText("5.42")).toBeInTheDocument();
+    expect(screen.getByText("16.42")).toBeInTheDocument();
+  });
+
+  it("marks an all-alpha run with an accessible clean label", () => {
+    render(<LiveGridCellView cell={cell()} />);
+    expect(screen.getByLabelText("All alpha, clean stage")).toBeInTheDocument();
+  });
+
+  it("drops the clean marker as soon as a single charlie appears", () => {
+    render(<LiveGridCellView cell={cell({ c: 1 })} />);
+    expect(
+      screen.queryByLabelText("All alpha, clean stage"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("drops the clean marker for a penalty even with all alphas", () => {
+    render(<LiveGridCellView cell={cell({ ns: 1 })} />);
+    expect(
+      screen.queryByLabelText("All alpha, clean stage"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders DQ instead of a score", () => {
+    render(<LiveGridCellView cell={cell({ status: "dq" })} />);
+    expect(screen.getByText("DQ")).toBeInTheDocument();
+    expect(screen.queryByText("5.42")).not.toBeInTheDocument();
+  });
+
+  it("renders ZERO with the time still visible", () => {
+    render(<LiveGridCellView cell={cell({ status: "zeroed" })} />);
+    expect(screen.getByText("ZERO")).toBeInTheDocument();
+    expect(screen.getByText("16.42")).toBeInTheDocument();
+  });
+
+  it("renders a pending placeholder when the stage is not yet shot", () => {
+    render(
+      <LiveGridCellView cell={cell({ status: "pending", hf: null, time: null })} />,
+    );
+    expect(screen.getByLabelText("Not shot yet")).toBeInTheDocument();
+  });
+
+  it("treats not_fired the same as pending", () => {
+    render(<LiveGridCellView cell={cell({ status: "not_fired" })} />);
+    expect(screen.getByLabelText("Not shot yet")).toBeInTheDocument();
+  });
+
+  it("shows the penalty count next to its pip", () => {
+    render(<LiveGridCellView cell={cell({ c: 2, m: 1, ns: 1 })} />);
+    expect(screen.getByText(/M1/)).toBeInTheDocument();
+    expect(screen.getByText(/N1/)).toBeInTheDocument();
+  });
+
+  it("carries the full breakdown in an accessible label so nothing rests on colour", () => {
+    render(<LiveGridCellView cell={cell({ a: 12, c: 2, d: 1, m: 1 })} />);
+    const label = screen.getByLabelText(/12A/);
+    expect(label).toHaveAccessibleName(expect.stringContaining("2C"));
+    expect(label).toHaveAccessibleName(expect.stringContaining("1D"));
+  });
+});

--- a/tests/components/live-grid-sheet.test.tsx
+++ b/tests/components/live-grid-sheet.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LiveGridSheet } from "@/components/live-grid-sheet";
+import type {
+  LiveGridCell,
+  LiveGridShooter,
+  LiveGridStage,
+} from "@/lib/types";
+
+const SHOOTER: LiveGridShooter = {
+  id: 1,
+  shooterId: 500,
+  name: "Mathias Axell",
+  competitor_number: "118",
+  division: "Production",
+  squad: "4",
+};
+
+const STAGE: LiveGridStage = {
+  stage_id: 10,
+  stage_num: 4,
+  name: "Steel Alley",
+  max_points: 60,
+};
+
+function cell(over: Partial<LiveGridCell> = {}): LiveGridCell {
+  return {
+    hf: 5.42,
+    time: 16.42,
+    points: 48,
+    a: 8,
+    c: 2,
+    d: 1,
+    m: 0,
+    ns: 1,
+    p: 0,
+    status: "scored",
+    created: "2026-08-23T09:00:00Z",
+    ...over,
+  };
+}
+
+function renderSheet(over: Partial<LiveGridCell> = {}) {
+  return render(
+    <LiveGridSheet
+      open
+      cell={cell(over)}
+      shooter={SHOOTER}
+      stage={STAGE}
+      onClose={vi.fn()}
+    />,
+  );
+}
+
+describe("LiveGridSheet", () => {
+  it("names the shooter and the stage", () => {
+    renderSheet();
+    expect(screen.getByText("Mathias Axell")).toBeInTheDocument();
+    expect(screen.getByText(/Steel Alley/)).toBeInTheDocument();
+  });
+
+  it("shows points against the stage max", () => {
+    renderSheet();
+    expect(screen.getByText("48")).toBeInTheDocument();
+    expect(screen.getByText("/60")).toBeInTheDocument();
+  });
+
+  it("lists no-shoots as their own row", () => {
+    renderSheet();
+    expect(screen.getByText("no-shoot")).toBeInTheDocument();
+  });
+
+  it("omits zero-count zones", () => {
+    renderSheet({ p: 0 });
+    expect(screen.queryByText("procedural")).not.toBeInTheDocument();
+  });
+
+  it("labels the points-dropped figure as minor scoring", () => {
+    renderSheet();
+    expect(screen.getByText(/points dropped \(minor\)/i)).toBeInTheDocument();
+  });
+
+  it("celebrates a clean stage instead of showing a drop", () => {
+    renderSheet({ a: 12, c: 0, d: 0, m: 0, ns: 0, p: 0, points: 60 });
+    expect(screen.getByText("Clean stage")).toBeInTheDocument();
+    expect(screen.queryByText(/points dropped/i)).not.toBeInTheDocument();
+  });
+
+  it("is a modal dialog", () => {
+    renderSheet();
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("renders nothing when closed", () => {
+    render(
+      <LiveGridSheet
+        open={false}
+        cell={cell()}
+        shooter={SHOOTER}
+        stage={STAGE}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("reports a DQ instead of a scorecard", () => {
+    renderSheet({ status: "dq" });
+    expect(screen.getByText(/Disqualified/)).toBeInTheDocument();
+  });
+
+  it("states the figures carry no field context", () => {
+    renderSheet();
+    expect(screen.getByText(/no stage winner/i)).toBeInTheDocument();
+  });
+});

--- a/tests/components/live-grid.test.tsx
+++ b/tests/components/live-grid.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { LiveGridResponse } from "@/lib/types";
+
+const FIXTURE: LiveGridResponse = {
+  match_id: 1,
+  stages: [
+    { stage_id: 10, stage_num: 1, name: "Cold Start", max_points: 60 },
+    { stage_id: 11, stage_num: 2, name: "Doubles", max_points: 40 },
+  ],
+  shooters: [
+    {
+      id: 1,
+      shooterId: 500,
+      name: "Mathias Axell",
+      competitor_number: "118",
+      division: "Production",
+      squad: "4",
+    },
+    {
+      id: 2,
+      shooterId: 501,
+      name: "Jonas Berg",
+      competitor_number: "042",
+      division: "Open",
+      squad: "4",
+    },
+  ],
+  cells: {
+    1: {
+      10: {
+        hf: 5.42,
+        time: 16.42,
+        points: 55,
+        a: 11,
+        c: 0,
+        d: 0,
+        m: 0,
+        ns: 0,
+        p: 0,
+        status: "scored",
+        created: "2026-08-23T09:00:00Z",
+      },
+    },
+    2: {},
+  },
+  cacheInfo: { cachedAt: null },
+};
+
+vi.mock("@/lib/queries", () => ({
+  useLiveGridQuery: () => ({
+    data: FIXTURE,
+    isLoading: false,
+    isFetching: false,
+    error: null,
+  }),
+}));
+
+import { LiveGrid } from "@/components/live-grid";
+
+function renderGrid(over: Partial<React.ComponentProps<typeof LiveGrid>> = {}) {
+  return render(
+    <LiveGrid
+      ct="22"
+      id="1"
+      shooters={[1, 2]}
+      matchName="Swedish Handgun Championship"
+      source="squad"
+      onSourceChange={vi.fn()}
+      onExit={vi.fn()}
+      {...over}
+    />,
+  );
+}
+
+describe("LiveGrid", () => {
+  it("renders one row per shooter", () => {
+    renderGrid();
+    expect(screen.getByRole("rowheader", { name: /Mathias/ })).toBeInTheDocument();
+    expect(screen.getByRole("rowheader", { name: /Jonas/ })).toBeInTheDocument();
+  });
+
+  it("renders one column header per stage", () => {
+    renderGrid();
+    expect(screen.getByRole("columnheader", { name: "S1" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "S2" })).toBeInTheDocument();
+  });
+
+  it("gives every stage a labelled rail jump button", () => {
+    renderGrid();
+    expect(
+      screen.getByRole("button", { name: "Jump to stage 1" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Jump to stage 2" }),
+    ).toBeInTheDocument();
+  });
+
+  it("marks the identity shooter with a You badge", () => {
+    renderGrid({ myShooterId: 500 });
+    const row = screen.getByRole("rowheader", { name: /Mathias/ });
+    expect(within(row).getByText(/you/i)).toBeInTheDocument();
+  });
+
+  it("does not mark other shooters with a You badge", () => {
+    renderGrid({ myShooterId: 500 });
+    const row = screen.getByRole("rowheader", { name: /Jonas/ });
+    expect(within(row).queryByText(/you/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the match name", () => {
+    renderGrid();
+    expect(
+      screen.getByText("Swedish Handgun Championship"),
+    ).toBeInTheDocument();
+  });
+
+  it("offers a way back to the full analysis", () => {
+    const onExit = vi.fn();
+    renderGrid({ onExit });
+    screen.getByRole("button", { name: /full analysis/i }).click();
+    expect(onExit).toHaveBeenCalled();
+  });
+
+  it("renders a cell button for every shooter and stage combination", () => {
+    renderGrid();
+    // 2 shooters x 2 stages. The comma anchors this to cell buttons
+    // ("Mathias Axell, stage 1") and excludes the rail's "Jump to stage N".
+    expect(screen.getAllByRole("button", { name: /, stage \d/i })).toHaveLength(4);
+  });
+});

--- a/tests/e2e/live-grid.spec.ts
+++ b/tests/e2e/live-grid.spec.ts
@@ -1,0 +1,226 @@
+import { test, expect, type Page } from "@playwright/test";
+import type { LiveGridResponse, MatchResponse } from "@/lib/types";
+import { LATEST_RELEASE_ID } from "@/lib/releases";
+
+// 390px -- iPhone 14, the primary breakpoint per CLAUDE.md.
+test.use({ viewport: { width: 390, height: 844 } });
+
+const STAGE_COUNT = 12;
+const SHOOTER_COUNT = 8;
+
+const STAGES = Array.from({ length: STAGE_COUNT }, (_, i) => ({
+  id: i + 1,
+  name: `Stage ${i + 1}`,
+  stage_number: i + 1,
+  max_points: 60,
+  min_rounds: 12,
+  paper_targets: 6,
+  steel_targets: 0,
+  ssi_url: null,
+  course_display: "Medium",
+  procedure: null,
+  firearm_condition: null,
+}));
+
+const COMPETITORS = Array.from({ length: SHOOTER_COUNT }, (_, i) => ({
+  id: 100 + i,
+  shooterId: 500 + i,
+  name: `Shooter ${i + 1} Lastname`,
+  competitor_number: String(10 + i),
+  club: "Test Club",
+  division: "Production",
+  region: null,
+  region_display: null,
+  category: null,
+  ics_alias: null,
+  license: null,
+}));
+
+const MOCK_MATCH: MatchResponse = {
+  name: "Live Grid Test Match",
+  cacheInfo: { cachedAt: null },
+  venue: "Test Range",
+  lat: null,
+  lng: null,
+  date: new Date().toISOString(),
+  level: "l2",
+  sub_rule: "nm",
+  discipline: "IPSC Handgun & PCC",
+  region: "SWE",
+  stages_count: STAGE_COUNT,
+  competitors_count: SHOOTER_COUNT,
+  scoring_pct: 50,
+  match_status: "on",
+  results_status: "stg",
+  is_live_scores_accessible: true,
+  registration_status: "cl",
+  registration_starts: null,
+  registration_closes: null,
+  is_registration_possible: false,
+  squadding_starts: null,
+  squadding_closes: null,
+  is_squadding_possible: false,
+  max_competitors: null,
+  ends: null,
+  ssi_url: "https://shootnscoreit.com/event/22/88888888/",
+  visibility: {
+    class: "public",
+    rawCode: "pub",
+    displayName: "Public, searchable and details/names for all",
+  },
+  access_reason: { kind: "public", rawVisibility: "pub", role: null },
+  role_names: [],
+  organizer: null,
+  stages: STAGES,
+  competitors: COMPETITORS,
+  squads: [
+    {
+      id: 1,
+      number: 4,
+      name: "Squad 4",
+      competitorIds: COMPETITORS.map((c) => c.id),
+    },
+  ],
+};
+
+const MOCK_GRID: LiveGridResponse = {
+  match_id: 88888888,
+  stages: STAGES.map((s) => ({
+    stage_id: s.id,
+    stage_num: s.stage_number,
+    name: s.name,
+    max_points: s.max_points,
+  })),
+  shooters: COMPETITORS.map((c) => ({
+    id: c.id,
+    shooterId: c.shooterId,
+    name: c.name,
+    competitor_number: c.competitor_number,
+    division: c.division,
+    squad: "4",
+  })),
+  cells: Object.fromEntries(
+    COMPETITORS.map((c, ci) => [
+      c.id,
+      Object.fromEntries(
+        // Stages 1-6 shot, 7-12 pending.
+        STAGES.slice(0, 6).map((s, si) => [
+          s.id,
+          {
+            hf: 5 + ((ci + si) % 5) * 0.3,
+            time: 14 + ((ci * si) % 7),
+            points: 50 + ((ci + si) % 10),
+            a: 10 - (si % 3),
+            c: si % 3,
+            d: 0,
+            m: si === 4 ? 1 : 0,
+            ns: si === 5 ? 1 : 0,
+            p: 0,
+            status: "scored" as const,
+            created: `2026-08-23T0${si + 3}:00:00Z`,
+          },
+        ]),
+      ),
+    ]),
+  ),
+  cacheInfo: { cachedAt: null },
+};
+
+async function mockApis(page: Page) {
+  await page.route("**/api/match/**", (route) =>
+    route.fulfill({ json: MOCK_MATCH }),
+  );
+  await page.route("**/api/live-grid**", (route) =>
+    route.fulfill({ json: MOCK_GRID }),
+  );
+  // Everything else the page pulls in -- keep it quiet so the test is about
+  // the grid, not the surrounding chrome.
+  await page.route("**/api/upstream-status**", (route) =>
+    route.fulfill({ json: { degraded: false, paused: false } }),
+  );
+  await page.route("**/api/coaching/availability**", (route) =>
+    route.fulfill({ json: { available: false } }),
+  );
+}
+
+async function openGrid(page: Page) {
+  // Suppress the first-visit dialogs -- their overlay intercepts pointer
+  // events and this suite is about the grid, not the release notes.
+  await page.addInitScript((releaseId) => {
+    localStorage.setItem("ssi-cell-help-seen", "1");
+    localStorage.setItem("whats-new-seen-id", releaseId);
+  }, LATEST_RELEASE_ID);
+  await mockApis(page);
+  await page.goto("/match/22/88888888?competitors=100,101,102");
+  // exact: true -- "S1" would otherwise also match S10, S11 and S12.
+  await expect(
+    page.getByRole("columnheader", { name: "S1", exact: true }),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe("live grid", () => {
+  test("does not overflow the page horizontally", async ({ page }) => {
+    await openGrid(page);
+    const overflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth >
+        document.documentElement.clientWidth,
+    );
+    expect(overflow).toBe(false);
+  });
+
+  test("every cell button meets the 44px touch floor", async ({ page }) => {
+    await openGrid(page);
+    const heights = await page
+      .locator("[data-live-grid-scroller] tbody button")
+      .evaluateAll((els) => els.map((e) => e.getBoundingClientRect().height));
+    expect(heights.length).toBeGreaterThan(0);
+    expect(Math.min(...heights)).toBeGreaterThanOrEqual(44);
+  });
+
+  test("opens the detail sheet on cell tap and closes it", async ({ page }) => {
+    await openGrid(page);
+    // The grid opens scrolled to the live edge, so the earliest cells sit
+    // under the sticky shooter column. Click one that is actually in view.
+    await page
+      .locator('[data-live-grid-scroller] tbody button')
+      .filter({ hasText: /\d/ })
+      .last()
+      .click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByRole("button", { name: /close detail/i }).click();
+    await expect(page.getByRole("dialog")).toBeHidden();
+  });
+
+  test("rail jump scrolls the grid", async ({ page }) => {
+    await openGrid(page);
+    const scroller = page.locator("[data-live-grid-scroller]");
+    const before = await scroller.evaluate((e) => e.scrollLeft);
+    await page.getByRole("button", { name: "Jump to stage 12" }).click();
+    await expect
+      .poll(() => scroller.evaluate((e) => e.scrollLeft))
+      .toBeGreaterThan(before);
+  });
+
+  test("never calls /api/compare while the grid is showing", async ({
+    page,
+  }) => {
+    // The whole point of the grid is that it does not pull the whole-field
+    // snapshot. If compare fires alongside it, the upstream saving is gone.
+    const compareCalls: string[] = [];
+    page.on("request", (req) => {
+      if (req.url().includes("/api/compare")) compareCalls.push(req.url());
+    });
+    await openGrid(page);
+    await page.waitForTimeout(1500);
+    expect(compareCalls).toEqual([]);
+  });
+
+  test("switching to full analysis leaves the grid", async ({ page }) => {
+    await openGrid(page);
+    await page.getByRole("button", { name: /full analysis/i }).click();
+    await expect(
+      page.getByRole("columnheader", { name: "S1", exact: true }),
+    ).toBeHidden();
+  });
+});

--- a/tests/unit/live-grid-route.test.ts
+++ b/tests/unit/live-grid-route.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The validation paths below return before any cache or upstream access, but
+// importing the route pulls in the cache/graphql modules -- stub them so the
+// test stays a pure unit test of request validation.
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(async () => ({ allowed: true, retryAfter: 0 })),
+}));
+vi.mock("@/lib/telemetry-context", () => ({ maybeTagAsMcp: vi.fn() }));
+
+import { GET } from "@/app/api/live-grid/route";
+
+async function call(qs: string) {
+  const res = await GET(new Request(`http://localhost/api/live-grid?${qs}`));
+  return { status: res.status, body: await res.json() };
+}
+
+describe("GET /api/live-grid validation", () => {
+  it("400s without ct", async () => {
+    expect((await call("id=1&competitor_ids=1")).status).toBe(400);
+  });
+
+  it("400s without id", async () => {
+    expect((await call("ct=22&competitor_ids=1")).status).toBe(400);
+  });
+
+  it("400s without competitor_ids", async () => {
+    expect((await call("ct=22&id=1")).status).toBe(400);
+  });
+
+  it("400s on a non-numeric ct", async () => {
+    expect((await call("ct=abc&id=1&competitor_ids=1")).status).toBe(400);
+  });
+
+  it("400s when competitor_ids parses to nothing", async () => {
+    expect((await call("ct=22&id=1&competitor_ids=x,y")).status).toBe(400);
+  });
+
+  it("400s past MAX_LIVE_GRID_ROWS", async () => {
+    const ids = Array.from({ length: 21 }, (_, i) => i + 1).join(",");
+    const res = await call(`ct=22&id=1&competitor_ids=${ids}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/20/);
+  });
+
+  it("accepts exactly MAX_LIVE_GRID_ROWS ids without a validation error", async () => {
+    const ids = Array.from({ length: 20 }, (_, i) => i + 1).join(",");
+    const res = await call(`ct=22&id=1&competitor_ids=${ids}`);
+    // Passes validation; whatever happens next is a cache/upstream concern.
+    expect(res.status).not.toBe(400);
+  });
+});

--- a/tests/unit/live-grid-rows.test.ts
+++ b/tests/unit/live-grid-rows.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { resolveGridRows } from "@/lib/live-grid-rows";
+import type { CompetitorInfo, SquadInfo } from "@/lib/types";
+
+const comp = (id: number, shooterId: number | null): CompetitorInfo => ({
+  id,
+  shooterId,
+  name: `C${id}`,
+  competitor_number: String(id),
+  club: null,
+  division: "Production",
+  region: null,
+  region_display: null,
+  category: null,
+  ics_alias: null,
+  license: null,
+});
+
+const COMPETITORS = [comp(1, 500), comp(2, 501), comp(3, 502), comp(4, null)];
+const SQUADS: SquadInfo[] = [
+  { id: 90, number: 4, name: "Squad 4", competitorIds: [1, 2, 3] },
+  { id: 91, number: 5, name: "Squad 5", competitorIds: [4] },
+];
+
+describe("resolveGridRows", () => {
+  it("returns my squad-mates when source is squad", () => {
+    expect(
+      resolveGridRows({
+        source: "squad",
+        competitors: COMPETITORS,
+        squads: SQUADS,
+        myShooterId: 500,
+        trackedShooterIds: new Set(),
+        fallback: [],
+      }),
+    ).toEqual([1, 2, 3]);
+  });
+
+  it("falls back to the existing selection when I am in no squad", () => {
+    expect(
+      resolveGridRows({
+        source: "squad",
+        competitors: COMPETITORS,
+        squads: SQUADS,
+        myShooterId: 999,
+        trackedShooterIds: new Set(),
+        fallback: [2, 3],
+      }),
+    ).toEqual([2, 3]);
+  });
+
+  it("maps tracked shooter IDs to this match's competitor IDs", () => {
+    expect(
+      resolveGridRows({
+        source: "tracked",
+        competitors: COMPETITORS,
+        squads: SQUADS,
+        myShooterId: 500,
+        trackedShooterIds: new Set([502]),
+        fallback: [],
+      }),
+    ).toEqual([1, 3]);
+  });
+
+  it("drops tracked shooters who are not in this match", () => {
+    expect(
+      resolveGridRows({
+        source: "tracked",
+        competitors: COMPETITORS,
+        squads: SQUADS,
+        myShooterId: null,
+        trackedShooterIds: new Set([501, 8888]),
+        fallback: [],
+      }),
+    ).toEqual([2]);
+  });
+
+  it("never exceeds MAX_LIVE_GRID_ROWS", () => {
+    const many = Array.from({ length: 30 }, (_, i) => comp(i + 1, i + 1));
+    const squad: SquadInfo[] = [
+      { id: 1, number: 1, name: "S1", competitorIds: many.map((c) => c.id) },
+    ];
+    expect(
+      resolveGridRows({
+        source: "squad",
+        competitors: many,
+        squads: squad,
+        myShooterId: 1,
+        trackedShooterIds: new Set(),
+        fallback: [],
+      }),
+    ).toHaveLength(20);
+  });
+
+  it("puts me first so my row is the one already on screen", () => {
+    const rows = resolveGridRows({
+      source: "tracked",
+      competitors: COMPETITORS,
+      squads: SQUADS,
+      myShooterId: 502,
+      trackedShooterIds: new Set([500]),
+      fallback: [],
+    });
+    expect(rows[0]).toBe(3);
+  });
+
+  it("ignores competitors with no shooterId when resolving tracked rows", () => {
+    // Competitor 4 has shooterId null -- it must never match a tracked ID.
+    expect(
+      resolveGridRows({
+        source: "tracked",
+        competitors: COMPETITORS,
+        squads: SQUADS,
+        myShooterId: null,
+        trackedShooterIds: new Set([500, 501]),
+        fallback: [],
+      }),
+    ).toEqual([1, 2]);
+  });
+});

--- a/tests/unit/live-grid.test.ts
+++ b/tests/unit/live-grid.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { buildLiveGridCells, computeLiveEdgeStageId } from "@/lib/live-grid";
+import type { RawScorecard } from "@/app/api/compare/logic";
+import type { LiveGridStage } from "@/lib/types";
+
+function card(over: Partial<RawScorecard> = {}): RawScorecard {
+  return {
+    competitor_id: 1,
+    competitor_division: "Production",
+    stage_id: 10,
+    stage_number: 1,
+    stage_name: "Cold Start",
+    max_points: 60,
+    points: 55,
+    hit_factor: 5.5,
+    time: 10,
+    dq: false,
+    zeroed: false,
+    dnf: false,
+    incomplete: false,
+    a_hits: 10,
+    c_hits: 2,
+    d_hits: 0,
+    miss_count: 0,
+    no_shoots: 0,
+    procedurals: 0,
+    scorecard_created: "2026-08-23T09:00:00Z",
+    ...over,
+  };
+}
+
+const STAGES: LiveGridStage[] = [
+  { stage_id: 10, stage_num: 1, name: "Cold Start", max_points: 60 },
+  { stage_id: 11, stage_num: 2, name: "Doubles", max_points: 40 },
+];
+
+describe("buildLiveGridCells", () => {
+  it("keys cells by competitor then stage", () => {
+    const cells = buildLiveGridCells([card()], [1]);
+    expect(cells[1][10].hf).toBe(5.5);
+    expect(cells[1][10].status).toBe("scored");
+  });
+
+  it("ignores competitors that were not requested", () => {
+    const cells = buildLiveGridCells([card(), card({ competitor_id: 99 })], [1]);
+    expect(cells[99]).toBeUndefined();
+  });
+
+  it("maps no_shoots to ns and keeps B+C folded in c", () => {
+    const cells = buildLiveGridCells([card({ no_shoots: 2, c_hits: 3 })], [1]);
+    expect(cells[1][10].ns).toBe(2);
+    expect(cells[1][10].c).toBe(3);
+  });
+
+  it("classifies dq, zeroed, not_fired and incomplete ahead of scored", () => {
+    const s = (o: Partial<RawScorecard>) =>
+      buildLiveGridCells([card(o)], [1])[1][10].status;
+    expect(s({ dq: true })).toBe("dq");
+    expect(s({ zeroed: true })).toBe("zeroed");
+    expect(s({ dnf: true })).toBe("not_fired");
+    expect(s({ incomplete: true })).toBe("incomplete");
+  });
+
+  it("prefers dq over every other flag", () => {
+    const cells = buildLiveGridCells(
+      [card({ dq: true, zeroed: true, dnf: true })],
+      [1],
+    );
+    expect(cells[1][10].status).toBe("dq");
+  });
+
+  it("returns an empty map for a competitor with no cards", () => {
+    expect(buildLiveGridCells([], [1])).toEqual({ 1: {} });
+  });
+});
+
+describe("computeLiveEdgeStageId", () => {
+  it("picks the stage holding the newest scorecard", () => {
+    const cells = buildLiveGridCells(
+      [
+        card({ stage_id: 10, scorecard_created: "2026-08-23T09:00:00Z" }),
+        card({
+          stage_id: 11,
+          stage_number: 2,
+          scorecard_created: "2026-08-23T11:00:00Z",
+        }),
+      ],
+      [1],
+    );
+    expect(computeLiveEdgeStageId(cells, STAGES)).toBe(11);
+  });
+
+  it("returns the first stage when nothing has been scored", () => {
+    expect(computeLiveEdgeStageId({ 1: {} }, STAGES)).toBe(10);
+  });
+
+  it("returns null when there are no stages", () => {
+    expect(computeLiveEdgeStageId({}, [])).toBeNull();
+  });
+});


### PR DESCRIPTION
Rebuilds the live experience as a full-screen grid: **one row per shooter, one column per stage**, designed for a phone held one-handed at 390px. Becomes the default for `effectiveMode === "live"`; the comparison table and coaching analysis stay one tap away behind "Full analysis".

Design: `docs/superpowers/specs/2026-08-23-live-grid-design.md`
Plan: `docs/superpowers/plans/2026-08-23-live-grid-phase-1.md`
Developer notes: `docs/live-grid.md`

## The contract, and why it matters

**Every value the grid renders derives from a single shooter's own scorecard, plus the stage list.** No `group_leader_hf`, no `overall_leader_hf`, no `field_median_hf`, no `divisionDistributions`, no rankings or fingerprints. `app/api/live-grid/route.ts` imports nothing from `compare/logic` beyond the `RawScorecard` type.

That constraint is not minimalism. Today the route projects the whole-field snapshot we already cache, so it costs nothing. Its purpose is Phase 2: SSI exposes an unused per-competitor scorecard path, and the moment one shooter's cell needs another shooter's data, that swap stops being a server-only change.

## Please read this before assuming a load win

**Phase 1 delivers no upstream reduction.** Refreshes are viewer-driven and single-flighted per match, so the snapshot refreshes on the same clock regardless of what the UI draws. What this PR buys is the view, the contract, and something we can test courtside.

The load win is entirely Phase 2, and Phase 2 is gated on a spike that could not run — SSI's API key is enabled weekdays only, so `scripts/spike-competitor-scorecards.ts` returned `Invalid API Key!`. Its three questions, in priority order:

1. Does GraphQL **alias-batching** of N competitors in one request work? This is the load question. 14 competitor requests is *worse* than 12 stage requests on request count, and request count is what caused the 2026-08-15 outage. Payload shrinks either way; request count does not.
2. Does the root `competitor_scorecards` resolver work at all? The sibling root `competitor(content_type, id)` returns 404 in practice.
3. Does it respect `is_live_scores_accessible`?

## A real bug this caught

`autoMode` falls back to `"coaching"` while `matchQuery.data` is undefined, and `compareEnabled` short-circuited on that — so **every match page fired a whole-field `/api/compare` request** in the window before the match response landed. Pre-existing and harmless while live mode used compare anyway; with the grid it is exactly the fetch the view exists to avoid. Fixed in 4a22615, with an e2e assertion guarding it.

## The cell

Hit factor, time, then the zone story — but only when there is one.

- **Points dropped** — A/C/D bar reusing `BAR_SEGMENTS` from `hit-zone-bar.tsx`, plus M/NS/P shape pips with counts.
- **Clean run** — a green circle and `ALL A`. The circle is the one shape neither the bar (rectangle) nor the pips (square, triangle, diamond) use, so it separates under greyscale and CVD. Exact counts also ride in the `aria-label`.
- Tap any cell for the full scorecard: points against stage max, what each zone and penalty cost, and the hit factor a clean run would have produced.

An all-alpha run is the best thing that can appear on the page, so it earns a positive mark — drawing nothing would make "clean" and "no data" identical.

**Zero new design tokens.** Everything resolves to existing tokens plus the four zone literals already in `hit-zone-bar.tsx`.

## Known gaps, deliberately not hidden

- **Major scoring is wrong in the detail sheet.** The points-dropped arithmetic assumes Minor (A5/C3/D1); Major is A5/C4/D2. Labelled `(minor)` with a `TODO(major-scoring)` rather than presented as universal — but for Open and Standard shooters that figure is currently misleading. The label is a mitigation, not a fix.
- **No `live-grid` screenshot scene exists**, so the `RELEASES` entry omits `screenshotScenes` with a TODO. Add the scene to `scripts/screenshot-match.ts` before this ships to users.

## Verification

- `pnpm -w run lint` — zero warnings
- `pnpm -w run typecheck` — zero errors; `cd mcp && pnpm run typecheck` also clean
- `pnpm -w test` — 2002 pass (up from 1960)
- `pnpm test:e2e` — 6 new tests: no horizontal overflow at 390px, the 44px touch floor on every cell button, sheet open/close, rail jump, exit to full analysis, and compare-suppression
- `pnpm build` — clean

Three `scoreboard.spec.ts` e2e tests fail on my machine, identically on `main` — local Redis is down and the SSI key is weekday-invalid. CI is green on `main`, so these should pass here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012x2vS5oBd7QgkeDhnWBVX8