### PR TITLE
fix: power-factor-aware scoring and a live-grid screenshot scene

### DIFF
--- a/components/live-grid-sheet.tsx
+++ b/components/live-grid-sheet.tsx
@@ -2,22 +2,35 @@
 
 import { useEffect, useRef } from "react";
 import { X } from "lucide-react";
-import { PENALTY_DEFS } from "@/components/hit-zone-bar";
-import { BAR_SEGMENTS } from "@/components/hit-zone-bar";
+import { BAR_SEGMENTS, PENALTY_DEFS } from "@/components/hit-zone-bar";
+import { isMajorPowerFactor } from "@/lib/what-if-calc";
 import type {
   LiveGridCell,
   LiveGridShooter,
   LiveGridStage,
 } from "@/lib/types";
 
-// Points a single hit or penalty costs against an all-alpha run.
-//
-// TODO(major-scoring): these are Minor values (A5/C3/D1). Major is A5/C4/D2,
-// which changes charlie from -2 to -1 and delta from -4 to -3. The scorecard
-// response does not currently carry the competitor's power factor into this
-// component, so the section is labelled "minor" rather than silently
-// presenting Minor numbers as universal.
-const COST = { c: 2, d: 4, m: 15, ns: 10, p: 10 } as const;
+/**
+ * What each dropped hit or penalty costs against an all-alpha run, at the
+ * competitor's power factor.
+ *
+ * Minor scores A5/C3/D1, Major A5/C4/D2 -- so a charlie costs 2 at minor but
+ * only 1 at major, and a delta 4 vs 3. A miss is 15 either way (the 5-point
+ * alpha you did not score, plus the 10-point penalty); no-shoots and
+ * procedurals are flat 10s.
+ *
+ * Power factor is read off the formatted division string via
+ * isMajorPowerFactor, the same helper the stage simulator uses -- the suffix
+ * is already baked into LiveGridShooter.division by extractDivision().
+ *
+ * Non-handgun disciplines never carry a Major/Minor suffix
+ * (formatDivisionDisplay only applies one when shoots_handgun_major is set),
+ * so they fall to minor here. That matches the stage simulator's existing
+ * behaviour rather than diverging from it.
+ */
+function costsFor(isMajor: boolean) {
+  return { c: isMajor ? 1 : 2, d: isMajor ? 3 : 4, m: 15, ns: 10, p: 10 };
+}
 
 interface ZoneRow {
   key: string;
@@ -103,7 +116,7 @@ export function LiveGridSheet({
           </button>
         </div>
 
-        <SheetBody cell={cell} stage={stage} />
+        <SheetBody cell={cell} stage={stage} shooter={shooter} />
       </div>
     </div>
   );
@@ -112,9 +125,11 @@ export function LiveGridSheet({
 function SheetBody({
   cell,
   stage,
+  shooter,
 }: {
   cell: LiveGridCell;
   stage: LiveGridStage;
+  shooter: LiveGridShooter;
 }) {
   if (cell.status === "pending" || cell.status === "not_fired") {
     return (
@@ -145,6 +160,8 @@ function SheetBody({
   const ns = cell.ns ?? 0;
   const p = cell.p ?? 0;
 
+  const isMajor = isMajorPowerFactor(shooter.division);
+  const COST = costsFor(isMajor);
   const hitLoss = c * COST.c + d * COST.d + m * 5;
   const penLoss = (m + ns) * 10 + p * COST.p;
   const dropped = hitLoss + penLoss;
@@ -205,7 +222,7 @@ function SheetBody({
         <div className="flex items-center gap-3 rounded-md bg-muted px-3 py-2.5">
           <div className="min-w-0 flex-1">
             <b className="block text-[13px] font-semibold">
-              −{dropped} points dropped (minor)
+              −{dropped} points dropped
             </b>
             <span className="text-[11px] text-muted-foreground">
               {hitLoss} on target

--- a/components/live-grid.tsx
+++ b/components/live-grid.tsx
@@ -208,7 +208,7 @@ export function LiveGrid({
         data-live-grid-scroller
         className="min-h-0 flex-1 overflow-auto bg-muted [scroll-snap-type:x_proximity] [overscroll-behavior-x:contain]"
       >
-        <table className="border-separate border-spacing-0 font-mono tabular-nums">
+        <table className="min-w-full border-separate border-spacing-0 font-mono tabular-nums">
           <thead>
             <tr>
               <th
@@ -296,9 +296,19 @@ export function LiveGrid({
   );
 }
 
-// "Mathias Axell" -> "Mathias A." so a 94px column holds a real name.
+/**
+ * Fit a name into a 94px column: "Mathias Axell" -> "Mathias A."
+ *
+ * When the first token is already an initial -- plenty of competitors
+ * register as "A. Lindstrom" -- abbreviating the surname too would leave
+ * "A. L.", dropping the only part that identifies them. Keep the surname
+ * whole in that case and let CSS truncate if it must.
+ */
 function shortName(full: string): string {
   const parts = full.trim().split(/\s+/);
   if (parts.length < 2) return full;
-  return `${parts[0]} ${parts[parts.length - 1].charAt(0)}.`;
+  const first = parts[0];
+  const last = parts[parts.length - 1];
+  const firstIsInitial = first.replace(".", "").length <= 1;
+  return firstIsInitial ? `${first} ${last}` : `${first} ${last.charAt(0)}.`;
 }

--- a/docs/live-grid.md
+++ b/docs/live-grid.md
@@ -66,11 +66,20 @@ positive mark. Drawing nothing would make "clean" and "no data" identical.
 `ns` maps from SSI's `penalty` field (`lib/scorecard-data.ts`). `c` already
 folds B-zone into C.
 
-### Known gap: Major scoring
+### Power factor
 
-The detail sheet's points-dropped arithmetic assumes **Minor** (A5/C3/D1) and
-is labelled `(minor)` for that reason. Major is A5/C4/D2. See
-`TODO(major-scoring)` in `components/live-grid-sheet.tsx`.
+The detail sheet's points-dropped arithmetic is power-factor aware: Minor
+scores A5/C3/D1, Major A5/C4/D2, so a charlie costs 2 at minor and 1 at
+major. It reads the factor via `isMajorPowerFactor()` from
+`lib/what-if-calc.ts` -- the same helper the stage simulator uses -- off the
+suffix `extractDivision()` already bakes into `LiveGridShooter.division`
+("Open Major", "Production").
+
+Non-handgun disciplines never get a Major/Minor suffix, because
+`formatDivisionDisplay()` only applies one when `shoots_handgun_major` is
+set. They therefore fall to minor here. That matches the stage simulator
+rather than diverging from it; if IPSC Rifle/Shotgun power factor is ever
+modelled, fix both together.
 
 ## Refresh
 

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -18,9 +18,7 @@ export const RELEASES: Release[] = [
     id: LATEST_RELEASE_ID,
     date: "August 23, 2026",
     title: "Courtside grid: the live view, rebuilt for a phone at the range",
-    // TODO: no "live-grid" scene exists in scripts/screenshot-match.ts yet.
-    // Omitted rather than pointed at an unrelated scene; add the scene and
-    // list it here before the release ships.
+    screenshotScenes: ["live-grid", "comparison-table"],
     sections: [
       {
         heading: "A new live view",

--- a/scripts/screenshot-match.ts
+++ b/scripts/screenshot-match.ts
@@ -25,6 +25,7 @@
  *   hf-level-bars         HF Level bars
  *   archetype-chart       Archetype performance breakdown
  *   style-fingerprint     Style fingerprint scatter chart
+ *   live-grid             Courtside grid -- the full-screen live view
  *   shooter-dashboard     Shooter dashboard with match history and trend charts
  *   competitor-identity   Competitor picker open showing identity + tracked star states
  *   tracked-shooters-sheet  My shooters management sheet
@@ -83,6 +84,72 @@ function parseSsiUrl(url: string): { ct: string; id: string } | null {
   const match = url.match(/\/event\/(\d+)\/(\d+)\/?$/);
   if (!match) return null;
   return { ct: match[1], id: match[2] };
+}
+
+/**
+ * Live-grid mock, derived from MOCK_MATCH + MOCK_COMPARE rather than
+ * hand-authored, so it cannot drift from the comparison fixtures. Only the
+ * field-blind subset crosses over -- ranks and percentages are dropped,
+ * which is exactly the contract the real endpoint honours.
+ */
+function buildMockLiveGrid() {
+  const wanted = MOCK_IDS.split(",").map((n) => parseInt(n, 10));
+  const cells: Record<number, Record<number, unknown>> = {};
+  for (const id of wanted) cells[id] = {};
+
+  for (const stage of MOCK_COMPARE.stages) {
+    for (const id of wanted) {
+      const c = stage.competitors?.[id];
+      if (!c) continue;
+      cells[id][stage.stage_id] = {
+        hf: c.hit_factor,
+        time: c.time,
+        points: c.points,
+        a: c.a_hits,
+        c: c.c_hits,
+        d: c.d_hits,
+        m: c.miss_count,
+        ns: c.no_shoots,
+        p: c.procedurals,
+        status: c.dq
+          ? "dq"
+          : c.zeroed
+            ? "zeroed"
+            : c.dnf
+              ? "not_fired"
+              : c.incomplete
+                ? "incomplete"
+                : "scored",
+        // Ascending so the live edge lands on the last stage with data.
+        created: `2026-08-23T${String(8 + stage.stage_num).padStart(2, "0")}:00:00Z`,
+      };
+    }
+  }
+
+  const squadOf = (cid: number) =>
+    MOCK_MATCH.squads.find((sq) => sq.competitorIds.includes(cid))?.name ?? null;
+
+  return {
+    match_id: 88888888,
+    stages: MOCK_COMPARE.stages.map((st) => ({
+      stage_id: st.stage_id,
+      stage_num: st.stage_num,
+      name: st.stage_name,
+      max_points: st.max_points,
+    })),
+    shooters: MOCK_MATCH.competitors
+      .filter((c) => wanted.includes(c.id))
+      .map((c) => ({
+        id: c.id,
+        shooterId: c.shooterId,
+        name: c.name,
+        competitor_number: c.competitor_number,
+        division: c.division,
+        squad: squadOf(c.id),
+      })),
+    cells,
+    cacheInfo: { cachedAt: null },
+  };
 }
 
 // ── Scene catalogue ───────────────────────────────────────────────────────────
@@ -236,6 +303,34 @@ const SCENES: Scene[] = [
       // Wait for the identity card (h1) and at least one match card to render
       await page.waitForSelector("h1", { timeout: 10000 });
       await page.waitForSelector('[aria-labelledby="history-heading"]', { timeout: 8000 }).catch(() => null);
+    },
+  },
+  {
+    name: "live-grid",
+    description: "Courtside grid -- full-screen live view, one row per shooter, one column per stage",
+    suppressWhatsNew: true,
+    setup: async (page, matchPath) => {
+      // The mock match is completed (match_status "cp"), so autoMode resolves
+      // to coaching and the grid never mounts. Force the live view the same
+      // way the ModeToggle does, and pin the live surface to the grid.
+      const parts = matchPath.split("/").filter(Boolean);
+      const ct = parts[parts.length - 2];
+      const id = parts[parts.length - 1];
+      await page.addInitScript(
+        ({ ct, id }: { ct: string; id: string }) => {
+          localStorage.setItem(`ssi_mode_${ct}_${id}`, "live");
+          localStorage.setItem(`ssi_liveview_${ct}_${id}`, "grid");
+        },
+        { ct, id },
+      );
+      await page.goto(`${matchPath}?competitors=${MOCK_IDS}`);
+      // The grid owns the viewport, so wait on its own scroller rather than
+      // the page's usual table.
+      await page.waitForSelector("[data-live-grid-scroller] table", {
+        timeout: 10000,
+      });
+      // Let the live-edge auto-scroll settle before the shot.
+      await page.waitForTimeout(600);
     },
   },
   {
@@ -409,6 +504,9 @@ async function main() {
         );
         await page.route(/\/api\/compare/, (route) =>
           route.fulfill({ json: MOCK_COMPARE })
+        );
+        await page.route(/\/api\/live-grid/, (route) =>
+          route.fulfill({ json: buildMockLiveGrid() })
         );
       }
 

--- a/tests/components/live-grid-sheet.test.tsx
+++ b/tests/components/live-grid-sheet.test.tsx
@@ -75,9 +75,51 @@ describe("LiveGridSheet", () => {
     expect(screen.queryByText("procedural")).not.toBeInTheDocument();
   });
 
-  it("labels the points-dropped figure as minor scoring", () => {
+  it("scores charlie and delta at minor values for a minor division", () => {
+    // Production is always minor: A5/C3/D1. 2C = -4, 1D = -4, 1NS = -10.
+    render(
+      <LiveGridSheet
+        open
+        cell={cell({ a: 8, c: 2, d: 1, m: 0, ns: 1, p: 0 })}
+        shooter={{ ...SHOOTER, division: "Production" }}
+        stage={STAGE}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/−18 points dropped/)).toBeInTheDocument();
+  });
+
+  it("scores charlie and delta at major values for a major division", () => {
+    // Open Major is A5/C4/D2. Same hits: 2C = -2, 1D = -3, 1NS = -10.
+    render(
+      <LiveGridSheet
+        open
+        cell={cell({ a: 8, c: 2, d: 1, m: 0, ns: 1, p: 0 })}
+        shooter={{ ...SHOOTER, division: "Open Major" }}
+        stage={STAGE}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/−15 points dropped/)).toBeInTheDocument();
+  });
+
+  it("shows the per-zone cost at the division's power factor", () => {
+    render(
+      <LiveGridSheet
+        open
+        cell={cell({ a: 8, c: 2, d: 0, m: 0, ns: 0, p: 0 })}
+        shooter={{ ...SHOOTER, division: "Open Major" }}
+        stage={STAGE}
+        onClose={vi.fn()}
+      />,
+    );
+    // 2 charlies at major cost 1 each.
+    expect(screen.getByText("−2")).toBeInTheDocument();
+  });
+
+  it("no longer claims every figure is minor", () => {
     renderSheet();
-    expect(screen.getByText(/points dropped \(minor\)/i)).toBeInTheDocument();
+    expect(screen.queryByText(/\(minor\)/i)).not.toBeInTheDocument();
   });
 
   it("celebrates a clean stage instead of showing a drop", () => {

--- a/tests/components/live-grid.test.tsx
+++ b/tests/components/live-grid.test.tsx
@@ -108,6 +108,16 @@ describe("LiveGrid", () => {
     expect(within(row).queryByText(/you/i)).not.toBeInTheDocument();
   });
 
+  it("keeps the surname when the first name is already an initial", () => {
+    // Some competitors register as "A. Lindstrom". Treating the first token
+    // as a full first name collapses that to "A. L." and loses the surname
+    // entirely -- the one part that identifies them.
+    renderGrid();
+    expect(
+      screen.queryByRole("rowheader", { name: /^M\. A\./ }),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows the match name", () => {
     renderGrid();
     expect(


### PR DESCRIPTION
Both release blockers from #532. Closes #533 and #534.

## #533 — points-dropped was Minor-only

The detail sheet hardcoded Minor (A5/C3/D1), so charlies and deltas read wrong for every Major shooter — Open and Standard included. Labelling it `(minor)` stopped it *claiming* to be universal but left the number wrong for the people it was wrong for.

Now reads power factor via `isMajorPowerFactor()` from `lib/what-if-calc.ts` — the same helper the stage simulator uses, rather than a second scoring table that could drift from it.

**The fix sketch in #533 turned out to be unnecessary.** I proposed threading `shoots_handgun_major` through into a new `LiveGridShooter.major` field. It isn't needed: `extractDivision()` already bakes the suffix into `LiveGridShooter.division` ("Open Major"), which is exactly what `isMajorPowerFactor()` reads. No schema change, no new field.

Non-handgun disciplines still fall to minor, because `formatDivisionDisplay()` only applies a suffix when `shoots_handgun_major` is set. That matches the stage simulator rather than diverging from it, and is now documented rather than left as a silent assumption.

## #534 — no screenshot scene

The mock match is completed, so `autoMode` resolves to coaching and the grid never mounts. The scene forces the live view through the same localStorage keys `ModeToggle` writes. The `/api/live-grid` mock is **derived** from `MOCK_MATCH` + `MOCK_COMPARE` rather than hand-authored, so it can't drift — and only the field-blind subset crosses over, which mirrors the real contract.

## Two defects the screenshots caught that typechecking could not

Running the scene and actually looking at the output found:

- **`shortName("A. Lindström")` produced `"A. L."`** — plenty of competitors register with an initial, and abbreviating the surname too drops the only part that identifies them. Now keeps the surname whole in that case.
- **The table left a large void beside it on wide viewports.** `min-w-full` fills the container.

Neither was reachable from tests alone; both came from looking at the PNG.

## Verification

- `pnpm -w run lint` / `typecheck` — clean
- `pnpm -w test` — 2006 pass
- `pnpm test:e2e tests/e2e/live-grid.spec.ts` — 6 pass
- Scene captured at 390×844 and 1280×900 and visually inspected, before and after the two fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012x2vS5oBd7QgkeDhnWBVX8