### PR TITLE
chore: unpin release-as now that v1.0.0 has shipped

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -41,12 +41,13 @@ carries a releasable type.
 
 ## Two things to know about the setup
 
-**`release-as` is pinned to `1.0.0` and must be removed after the first
-release.** `release-please-config.json` currently forces the next version to
-`1.0.0` so the repo leaves its permanent `0.1.0` behind on a clean number.
-`release-as` is sticky -- it forces that same version on *every* subsequent
-release. Delete the `"release-as": "1.0.0"` line in the PR immediately after
-`v1.0.0` ships.
+**`release-as` was pinned to `1.0.0` for the first release and has since been
+removed** (v1.0.0 shipped 2026-08-23). It forced the version to `1.0.0` so the
+repo left its permanent `0.1.0` behind on a clean number. `release-as` is
+sticky -- it forces the same version on *every* subsequent release -- so it was
+deleted immediately afterwards. If you ever pin it again, delete it in the same
+breath as the release it was pinned for, or version bumps stop working
+silently.
 
 **The deploy is a `workflow_call`, not `on: release: published`.** GitHub will
 not trigger a workflow from an event raised with the default `GITHUB_TOKEN`;

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,6 @@
       "package-name": "ssi-scoreboard",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
-      "release-as": "1.0.0",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
`release-as` is sticky. Left in `release-please-config.json` it forces `1.0.0` on **every** subsequent release, so the next `feat:` would produce another 1.0.0 and version bumps would stop working with no error anywhere.

`docs/releases.md` called this out as one of the two setup caveats and said to delete the line immediately after `v1.0.0` ships. It shipped at 2026-08-23T12:00:45Z, so this is that deletion.

Also updates the doc from an instruction into a record of what happened, with the general warning kept for anyone who pins it again.

Verified `release-please-config.json` is still valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012x2vS5oBd7QgkeDhnWBVX8